### PR TITLE
💫 Image에 overlayType 추가

### DIFF
--- a/packages/triple-design-system/src/elements/image.tsx
+++ b/packages/triple-design-system/src/elements/image.tsx
@@ -1,10 +1,23 @@
 import * as React from 'react'
-import styled, { css } from 'styled-components'
+import styled, { css, InterpolationValue } from 'styled-components'
 import Icon from './icon'
 import { MarginPadding, GlobalSizes } from '../commons'
 import * as CSS from 'csstype'
 
 type OverlayType = 'gradient' | 'dark'
+
+const OverlayStyle: { [key in OverlayType]: InterpolationValue[] } = {
+  gradient: css`
+    background-color: rgba(0, 0, 0, 0.8);
+  `,
+  dark: css`
+    background-image: linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.6),
+      rgba(0, 0, 0, 0)
+    );
+  `,
+}
 
 const IMAGE_HEIGHT_OPTIONS: Partial<Record<GlobalSizes, string>> = {
   mini: '80px',
@@ -65,6 +78,8 @@ const ImageOverlay = styled.div<{
   border-radius: ${({ borderRadius }) =>
     borderRadius === 0 ? 0 : borderRadius || 6}px;
 
+  ${({ overlayType = 'gradient' }) => OverlayStyle[overlayType]}
+
   ${({ overlayPadding }) =>
     overlayPadding &&
     css`
@@ -72,23 +87,6 @@ const ImageOverlay = styled.div<{
       padding-bottom: ${overlayPadding.bottom || 0}px;
       padding-left: ${overlayPadding.left || 0}px;
       padding-right: ${overlayPadding.right || 0}px;
-    `};
-
-  ${({ overlayType = 'gradient' }) =>
-    overlayType === 'gradient' &&
-    css`
-      background-image: linear-gradient(
-        to bottom,
-        rgba(0, 0, 0, 0.6),
-        rgba(0, 0, 0, 0)
-      );
-    `};
-
-  ${({ overlayType }) =>
-    overlayType &&
-    overlayType === 'dark' &&
-    css`
-      background-color: rgba(0, 0, 0, 0.8);
     `};
 `
 


### PR DESCRIPTION
기존에 있던 Image 엘리먼트에 overlayType를 추가했습니다.

```typescript
type OverlayType = 'gradient' | 'dark'
```

기본값은 gradient입니다. (기존 overlay에 대응하기 위함)
```css
background-image: linear-gradient(
        to bottom,
        rgba(0, 0, 0, 0.6),
        rgba(0, 0, 0, 0)
      );
```


dark 속성을 추가했으며 
```css
background-color: rgba(0, 0, 0, 0.8);
```

가 적용됩니다.
