### PR TITLE
💫 플로팅 설치 버튼 추가

### DIFF
--- a/packages/triple-design-system/src/elements/floating-install-button.tsx
+++ b/packages/triple-design-system/src/elements/floating-install-button.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react'
+import styled from 'styled-components'
+import { GetGlobalColor } from '../commons'
+import Text from './text'
+import Container from './container'
+
+const MIN_DESKTOP_WIDTH = 1142
+
+const FloatingButton = styled.div`
+  position: fixed;
+  height: 84px;
+  border-radius: 42px;
+  box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.07);
+  background-color: rgba(${GetGlobalColor('blue')}, 0.98);
+  bottom: 0;
+  left: 10px;
+  right: 10px;
+  margin-bottom: 30px;
+  overflow: hidden;
+
+  @media (min-width: ${MIN_DESKTOP_WIDTH}px) {
+    display: none;
+  }
+`
+
+const InstallDescription = styled(Text)`
+  height: 21px;
+  font-size: 18px;
+  font-weight: bold;
+  margin: 23px 0px 0px 32px;
+  color: rgb(${GetGlobalColor('white')});
+`
+
+const InstallAnchor = styled.a`
+  &,
+  &:visited,
+  &:hover,
+  &:active {
+    color: inherit;
+  }
+`
+
+const Description = styled(Text)`
+  width: 200px;
+  height: 15px;
+  font-size: 12px;
+  font-weight: 500;
+  color: rgba(${GetGlobalColor('white')}, 0.6);
+  margin: 3px 0px 22px 32px;
+`
+
+const GoAppButton = styled.img`
+  width: 20px;
+  height: 20px;
+`
+
+const CloseButton = styled.img`
+  width: 30px;
+  height: 30px;
+  margin: 27px 16px 27px 0;
+`
+
+class FloatingInstallButton extends React.PureComponent<{
+  appInstallLink?: string
+  onClose?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
+}> {
+  render() {
+    const {
+      props: { appInstallLink, onClose },
+    } = this
+
+    return (
+      <FloatingButton>
+        <Container floated="left">
+          <InstallDescription>
+            <InstallAnchor href={appInstallLink}>
+              <Container floated="left">트리플 앱 설치하기</Container>
+              <GoAppButton src="https://assets.triple.guide/images/ico-arrow@4x.png" />
+            </InstallAnchor>
+          </InstallDescription>
+          <Description>가이드북, 일정짜기, 길찾기, 맛집</Description>
+        </Container>
+        <Container floated="right" onClick={onClose}>
+          <CloseButton src="https://assets.triple.guide/images/btn-closebanner@3x.png" />
+        </Container>
+      </FloatingButton>
+    )
+  }
+}
+
+export default FloatingInstallButton

--- a/packages/triple-design-system/src/index.ts
+++ b/packages/triple-design-system/src/index.ts
@@ -35,6 +35,9 @@ export { default as Textarea } from './elements/textarea'
 export { default as Select } from './elements/select'
 export { default as NumericSpinner } from './elements/numeric-spinner'
 export { default as Drawer } from './elements/drawer'
+export {
+  default as FloatingInstallButton,
+} from './elements/floating-install-button'
 
 export * from './views/modal'
 export * from './views/listing-filter'


### PR DESCRIPTION
https://github.com/titicacadev/triple-content-web/blob/5b1ff6d9da6203f1b2ed17abc0eb05c48b467da4/src/common/floating-install-button.js
여기에서 이벤트 빼고, 타입스크립트 버전으로 가져왔습니다.