### PR TITLE
:bug::package: docs 프로젝트에서 image-carousel dependency 누락부분 추가

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "@titicaca/author": "^1.0.0-alpha.8",
     "@titicaca/floating-install-button": "^1.0.0-alpha.8",
     "@titicaca/footer": "^1.0.0-alpha.8",
+    "@titicaca/image-carousel": "^1.0.0-alpha.8",
     "@titicaca/listing-filter": "^1.0.0-alpha.8",
     "@titicaca/modals": "^1.0.0-alpha.8",
     "@titicaca/poi-list-elements": "^1.0.0-alpha.8",


### PR DESCRIPTION
docs 프로젝트내 package.json 에 해당 dependency 가 누락되어 추가합니다.
