### PR TITLE
액션시트 초기 상태가 잘못 반영되는 문제를 수정합니다.

### DIFF
--- a/packages/action-sheet/src/index.tsx
+++ b/packages/action-sheet/src/index.tsx
@@ -13,13 +13,10 @@ const Overlay = styled.div`
   right: 0;
   z-index: 10;
   background-color: rgba(58, 58, 58, 0.7);
+  opacity: 0;
 
-  &.fade-enter {
-    opacity: 0;
-
-    & > div {
-      margin-bottom: -120px;
-    }
+  & > div {
+    margin-bottom: -120px;
   }
 
   &.fade-enter-active {
@@ -28,6 +25,15 @@ const Overlay = styled.div`
 
     & > div {
       transition: margin-bottom 120ms ease-in;
+      margin-bottom: 0;
+    }
+  }
+
+  &.fade-appear,
+  &.fade-enter-done {
+    opacity: 1;
+
+    & > div {
       margin-bottom: 0;
     }
   }
@@ -251,7 +257,7 @@ export default function ActionSheet({
   ) : null
 
   return (
-    <CSSTransition in={open} classNames="fade" timeout={500}>
+    <CSSTransition in={open} appear classNames="fade" timeout={500}>
       <Overlay onClick={onClose}>
         <Sheet onClick={silenceEvent}>
           {actionSheetTitle}


### PR DESCRIPTION
#26 에서 react-transition-group의 `CSSTransition` 컴포넌트를 사용해서 액션시트 구현을 변경했었는데, 첫 로드 시 `open` props의 값이 `false`이면 의도와 다른 동작을 하는 버그가 있었습니다.

기본 CSS를 오버레이와 액션시트를 렌더링되는 상태로 두고 애니메이션 스타일을 적용해서 발생하는 문제였어요. 그렇지 않으면 최초 `open` 값이 `true`일 때 렌더링이 안 되는 현상이 있었거든요.

이 버그를 해결하기 위해, 최초 로드 시 상태를 클래스에 반영해주는 `appear`(@appear ??) 옵션을 활성화했고, (http://reactcommunity.org/react-transition-group/transition#Transition-prop-appear) 오버레이 및 액션 시트의 기본 스타일도 렌더링이 안 되는 상태로 변경했습니다.