### PR TITLE
esModuleInterop 옵션 전역 활성화

### DIFF
--- a/packages/react-contexts/tsconfig.json
+++ b/packages/react-contexts/tsconfig.json
@@ -5,7 +5,6 @@
     "baseUrl": ".",
     "rootDir": "src",
     "emitDeclarationOnly": true,
-    "esModuleInterop": true,
   },
   "include": ["./src"],
   "exclude": ["node_modules", "lib"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,6 +7,7 @@
     "jsx": "react",
     "moduleResolution": "node",
     "declaration": true,
-    "alwaysStrict": true
+    "alwaysStrict": true,
+    "esModuleInterop": true
   },
 }


### PR DESCRIPTION
## Purpose

triple-frontend 소스 트리에 Next.js가 디펜던시로 추가되면서 `esModuleInterop` 옵션이 필수로 되었습니다. `react-contexts`에만 선언되었던 걸 전역 설정으로 변경합니다.

## Change List

  - `esModuleInterop` 옵션 활성화

## Discussion

`import * as`를 `import`로 다 바꾸려고 했었는데 당장 동작에 문제는 없고 변경해야 할 코드 양이 상당히 많네요. 다른 작업에 지장을 주지 않으려면 최소한의 변경만 우선 머지하는 게 좋을 것 같습니다.