### PR TITLE
@types/react-dom 개발 디펜던시 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2150,6 +2150,15 @@
         "csstype": "^2.2.0"
       }
     },
+    "@types/react-dom": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-OL2lk7LYGjxn4b0efW3Pvf2KBVP0y1v3wip1Bp7nA79NkOpElH98q3WdCEdDj93b2b0zaeBG9DvriuKjIK5xDA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/runtime": "^7.5.5",
     "@types/node": "^12.7.1",
     "@types/react": "^16.9.1",
+    "@types/react-dom": "^16.9.0",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
     "babel-eslint": "^10.0.2",


### PR DESCRIPTION
react-contexts 빌드 과정에서 react-dom ~패키지~ 타입 정의를 찾을 수 없다는 에러가 있었어요: https://console.cloud.google.com/gcr/builds/62f920cb-8996-480b-a080-131c04345c45?project=854714705856

~이 문제 해결을 위해 react-contexts의 development dependency로 react-dom을 추가했습니다. 프로젝트 루트에 설치가 되어 있긴 한데... `next` 패키지에서 react-dom 패키지를 못 찾는 모양이네요. 로드 순서에 영향이 있는 것 같은데..~

`@types/react-dom`을 추가했습니다! (사실 따로 있는 줄 몰랐던 것 같아요...)