### PR TITLE
PromoLabel 수정

### DIFF
--- a/docs/stories/label.stories.js
+++ b/docs/stories/label.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { storiesOf } from '@storybook/react'
-import { text, select, boolean } from '@storybook/addon-knobs'
+import { text, select, boolean, number } from '@storybook/addon-knobs'
 
 import { Label } from '@titicaca/core-elements'
 
@@ -17,6 +17,7 @@ storiesOf('Label', module)
       size={select('크기', ['small', 'medium', 'big'], 'medium')}
       color={select('색깔', ['purple', 'blue', 'red', 'gray'], 'purple')}
       fontColor={select('글자 색깔', ['white', 'gray'], 'gray')}
+      fontAlpha={number('fontAlpha', 1)}
       emphasized={boolean('강조', true)}
     >
       {text('텍스트', '최대 24%')}

--- a/packages/core-elements/src/elements/label.tsx
+++ b/packages/core-elements/src/elements/label.tsx
@@ -83,6 +83,7 @@ interface PromoLabelProps {
   color?: LabelColor
   margin?: MarginPadding
   fontColor?: GlobalColors
+  fontAlpha?: number
 }
 
 export const PromoLabel = styled.div<PromoLabelProps>`
@@ -99,8 +100,10 @@ export const PromoLabel = styled.div<PromoLabelProps>`
       ? css`
           font-weight: bold;
           background-color: ${({ color }) => rgba({ color, alpha: 1 })};
-          color: ${({ fontColor }) =>
-            fontColor ? `rgba(${GetGlobalColor(fontColor)}, 0.7)` : 'white'};
+          color: ${({ fontColor, fontAlpha }) =>
+            fontColor
+              ? `rgba(${GetGlobalColor(fontColor)}, ${fontAlpha || 1})`
+              : 'white'};
         `
       : css`
           font-weight: normal;
@@ -149,6 +152,7 @@ export default class Label extends React.PureComponent<
         emphasized,
         color,
         fontColor,
+        fontAlpha,
         ...props
       },
     } = this
@@ -168,6 +172,7 @@ export default class Label extends React.PureComponent<
           color={color}
           fontColor={fontColor}
           margin={margin}
+          fontAlpha={fontAlpha}
         >
           {children}
         </PromoLabel>


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
- `PromoLabel`을 매거진 상세 태그로 사용할수 있게 합니다

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
- gray 색상을 배경색으로 추가합니다
- `fontColor`, `fontAlpha`속성을 `PromoLabel`에 추가합니다
-` PROMO_SIZE` large를 추가합니다

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->
- 스토리북 참고

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->
![image](https://user-images.githubusercontent.com/46436155/66795470-ad3dd700-ef3f-11e9-89e4-c384ffa02a62.png)

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
