### PR TITLE
리뷰 Placeholder의 여행자 클럽 혜택 보기 링크를 클릭했을 때 리뷰 쓰기 창이 열리는 것을 방지합니다.

### DIFF
--- a/packages/review/src/review-placeholder-with-rating.tsx
+++ b/packages/review/src/review-placeholder-with-rating.tsx
@@ -52,7 +52,12 @@ export default function ReviewsPlaceholder({
       <Text size="tiny" style={{ opacity: '0.5' }}>
         리뷰를 남겨주시면, 여행자 클럽 포인트를 드려요!
       </Text>
-      <Link href={appUrlScheme + `:///my/mileage`}>여행자 클럽 혜텍보기</Link>
+      <Link
+        onClick={(e) => e.stopPropagation()}
+        href={appUrlScheme + `:///my/mileage`}
+      >
+        여행자 클럽 혜텍보기
+      </Link>
     </PlaceholderContainer>
   )
 }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

Placeholder 컴포넌트의 여행자클럽 혜택 보기 링크의 click event propagation을 막습니다.

## 변경 내역 및 배경

리뷰 Placeholder 컴포넌트 전체에 대한 onClick 이벤트 핸들러로 리뷰 쓰기 뷰를 여는 함수가 등록되어 있었는데, placeholder 내의 `<a>` 태그 클릭 시에 이벤트 propagation이 되어서 2개의 링크 이동이 동시에 일어나는 문제가 있었습니다.

## 사용 및 테스트 방법
docs로 보았어요.

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
