### PR TITLE
PromoLabel에서 emphasized를 받지 않습니다

### DIFF
--- a/packages/core-elements/src/elements/label.tsx
+++ b/packages/core-elements/src/elements/label.tsx
@@ -79,7 +79,7 @@ const PROMO_SIZES: Partial<
 
 interface PromoLabelProps {
   size?: GlobalSizes
-  emphasized?: boolean
+  bold?: boolean
   color?: LabelColor
   margin?: MarginPadding
   fontColor?: GlobalColors
@@ -95,21 +95,12 @@ export const PromoLabel = styled.div<PromoLabelProps>`
   height: ${({ size }) => PROMO_SIZES[size || 'small'].height}px;
   font-size: ${({ size }) => PROMO_SIZES[size || 'small'].fontSize}px;
 
-  ${({ emphasized }) =>
-    emphasized
-      ? css`
-          font-weight: bold;
-          background-color: ${({ color }) => rgba({ color, alpha: 1 })};
-          color: ${({ fontColor, fontAlpha }) =>
-            fontColor
-              ? `rgba(${GetGlobalColor(fontColor)}, ${fontAlpha || 1})`
-              : 'white'};
-        `
-      : css`
-          font-weight: normal;
-          background-color: ${({ color }) => rgba({ color, alpha: 0.1 })};
-          color: ${({ color }) => rgba({ color, alpha: 1 })};
-        `};
+  background-color: ${({ color }) => rgba({ color, alpha: 1 })}
+  color: ${({ color, fontColor, fontAlpha }) =>
+    `rgba(${
+      fontColor ? GetGlobalColor(fontColor) : GetLabelColors[color]
+    }, ${fontAlpha || 1})`};
+  font-weight: ${({ bold }) => (bold ? 'bold' : 'normal')};
 
   ${({ margin }) =>
     margin &&
@@ -149,7 +140,7 @@ export default class Label extends React.PureComponent<
         children,
         promo,
         size,
-        emphasized,
+        bold,
         color,
         fontColor,
         fontAlpha,
@@ -168,7 +159,7 @@ export default class Label extends React.PureComponent<
         <PromoLabel
           {...props}
           size={size}
-          emphasized={emphasized}
+          bold={bold}
           color={color}
           fontColor={fontColor}
           margin={margin}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
- `PromoLabel` 스타일을 자유롭게 지정하도록 합니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
- `PromoLabel` 의 emphasized 를 deprecate 합니다
  - https://github.com/titicacadev/triple-articles-web/pull/114 와 같이 emphasized로 표현 못하는 케이스가 있습니다.
  - `bold` 값을 대신 받습니다

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
