### PR TITLE
리뷰 리스트/Thanks 리스트 페이지 전환 시 네이티브 Navbar 감춤

### DIFF
--- a/packages/review/src/review-container.tsx
+++ b/packages/review/src/review-container.tsx
@@ -105,7 +105,7 @@ export default function ReviewContainer({
 
     navigate(
       `${appUrlScheme}:///inlink?path=${encodeURIComponent(
-        `/reviews/list?region_id=${regionId}&resource_id=${resourceId}&resource_type=${resourceType}`,
+        `/reviews/list?_triple_no_navbar&region_id=${regionId}&resource_id=${resourceId}&resource_type=${resourceType}`,
       )}`,
     )
   }

--- a/packages/review/src/reviews-list.tsx
+++ b/packages/review/src/reviews-list.tsx
@@ -73,7 +73,7 @@ export default function ReviewsList({
 
     navigate(
       `${appUrlScheme}:///inlink?path=${encodeURIComponent(
-        `/reviews/thanks?region_id=${regionId}&resource_id=${resourceId}&resource_type=${resourceType}&review_id=${id}`,
+        `/reviews/thanks?_triple_no_navbar&region_id=${regionId}&resource_id=${resourceId}&resource_type=${resourceType}&review_id=${id}`,
       )}`,
     )
   }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
리뷰 리스트와 Thanks 리스트로 `navigate`할 때 `_triple_no_navbar` 파라미터를 추가로 붙여줍니다.

## 변경 내역 및 배경
Navbar에 리뷰 쓰기 버튼이 있어서 웹에서 직접 그려줘야 하는 상황이었어요. triple-reviews-web 쪽은 직접 그리는 걸로 준비해뒀었는데, triple-frontend에 넣어둔 주소가 잘못되었었네요. 미리 발견하지 못해서 반성합니다 ㅠㅠ

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
