### PR TITLE
📏 search-navbar 스타일 변경

### DIFF
--- a/packages/core-elements/src/elements/navbar.tsx
+++ b/packages/core-elements/src/elements/navbar.tsx
@@ -124,5 +124,6 @@ function Navbar({
 
 Navbar.Item = NavbarItem
 Navbar.Secondary = SecondaryNavbar
+Navbar.NavbarFrame = NavbarFrame
 
 export default Navbar

--- a/packages/core-elements/src/elements/search-navbar.tsx
+++ b/packages/core-elements/src/elements/search-navbar.tsx
@@ -1,18 +1,38 @@
 import * as React from 'react'
 import InputMask, { InputState, MaskOptions } from 'react-input-mask'
 import styled from 'styled-components'
+
 import Navbar from './navbar'
 
 const InputText = styled(InputMask)`
-  margin-left: 4px;
-  margin-top: 6px;
-  height: 19px;
-  font-size: 16px;
-  width: calc(100vw - 130px);
   border-style: none;
+  font-size: 17px;
+  height: 19px;
+  margin: 6px 34px 0 34px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: calc(100% - 68px);
+`
+
+const MainNavbarFrame = styled(Navbar.NavbarFrame)`
+  height: 58px;
+  padding: 12px;
+  position: relative;
+`
+
+const Back = styled(Navbar.Item)`
+  float: none;
+  margin-right: 0px;
+  position: absolute;
 `
 
 const DeleteIcon = styled(Navbar.Item)<{ visible: boolean }>`
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  margin-right: 0px;
+  float: none;
   display: ${({ visible }) => (visible ? 'block' : 'none')};
 `
 
@@ -30,19 +50,18 @@ export default function SearchNavbar({
 } & InputState &
   MaskOptions) {
   return (
-    <Navbar>
-      <Navbar.Item floated="left" icon="back" onClick={onBackClick} />
+    <MainNavbarFrame>
+      <Back icon="back" onClick={onBackClick} />
       <InputText
         placeholder={inputPlaceholder}
         onChange={(e) => onInputChange(e, e.target.value)}
         {...props}
       />
       <DeleteIcon
-        floated="right"
         icon="delete"
         onClick={onDeleteClick}
         visible={!!props.value}
       />
-    </Navbar>
+    </MainNavbarFrame>
   )
 }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
input이 있는 navbar의 스타일을 변경합니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
디자이너 분께서 최대한 앱에 있는 검색 navbar(도시 검색 상단에 있는 것) 와 비슷하게 해달라고 요청하셨습니다. (원래 zeplin도 수정되었습니다.)

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->
storybook - navbar - 검색

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
