### PR TITLE
별점과 텍스트의 라인을 맞춥니다

### DIFF
--- a/packages/resource-list-element/src/index.tsx
+++ b/packages/resource-list-element/src/index.tsx
@@ -83,9 +83,16 @@ export default function ExtendedResourceListElement({
       </Text>
 
       {reviewsCount || scrapsCount ? (
-        <Container margin={{ top: 4 }}>
+        <Container margin={{ top: 5 }}>
           <>
-            {reviewsCount ? <Rating size="tiny" score={reviewsRating} /> : null}
+            {reviewsCount ? (
+              <Rating
+                verticalAlign="middle"
+                size="tiny"
+                score={reviewsRating}
+              />
+            ) : null}
+
             <Text inline size="tiny" alpha={0.4}>
               {[
                 reviewsCount ? ` (${formatNumber(reviewsCount)})` : null,


### PR DESCRIPTION

## 설명

별점과 텍스트의 라인을 맞춥니다

## 변경 내역 및 배경

tna, hotel 등의 list 에서 별점과 텍스트의 라인이 안맞는 현상이 있어 스타일을 조절합니다

## 사용 및 테스트 방법

독스...

## 스크린샷

![image](https://user-images.githubusercontent.com/27910236/67555001-7344b000-f74b-11e9-9043-5677dfa5a52e.png)


## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
