### PR TITLE
Public 페이지에서 리뷰 이미지 섬네일 클릭 시 TransitionModal 노출

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,5 @@ node_modules
 lib
 examples
 package-lock.json
-lerna.json
 
 test/dist/*

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "lint-staged": {
     "**/*.{js,ts,tsx}": [
-      "eslint '{docs,packages,tests/src}/**/*.{ts,tsx,js}' --fix",
+      "eslint '{docs,packages,tests/src}/**/*.{ts,tsx,js}'",
       "prettier --write \"**/*.{ts,tsx,js,json}\"",
       "git add"
     ]


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
리뷰 이미지 섬네일 클릭 핸들러의 `isPublic` 분기 `TransitionModal` 디스플레이를 추가합니다. 

## 변경 내역 및 배경

  - 이미지 클릭 시 `TransitionModal`을 보여줍니다.
  - lint-staged 커맨드의 eslint에서 `--fix` 옵션을 제거합니다.

## 사용 및 테스트 방법
docs에서 볼 수 있습니다.

## 스크린샷

<img width="453" alt="Screen Shot 2019-10-25 at 7 05 26 PM" src="https://user-images.githubusercontent.com/712260/67562836-76936800-f75a-11e9-9f1a-39a57d94d85b.png">

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.