### PR TITLE
리스팅하는 리뷰의 최대 갯수 지정

### DIFF
--- a/packages/review/src/review-container.tsx
+++ b/packages/review/src/review-container.tsx
@@ -173,6 +173,7 @@ export default function ReviewContainer({
           </Container>
 
           <ReviewsList
+            maxLength={shortened ? 3 : null}
             myReview={myReview}
             reviews={reviews}
             resourceType={resourceType}

--- a/packages/review/src/reviews-list.tsx
+++ b/packages/review/src/reviews-list.tsx
@@ -27,6 +27,7 @@ export default function ReviewsList({
   resourceType,
   resourceId,
   regionId,
+  maxLength,
   notifyReviewDeleted,
   showToast,
 }: {
@@ -38,6 +39,7 @@ export default function ReviewsList({
   resourceType: string
   resourceId: string
   regionId: string
+  maxLength?: number
   notifyReviewDeleted: Function
   showToast: Function
   perPage?: number
@@ -125,31 +127,31 @@ export default function ReviewsList({
     ? (index) => index > reviews.length - 3 && fetchNext()
     : null
 
+  const allReviews = myReview
+    ? [myReview, ...(reviews || []).filter(({ id }) => id !== myReview.id)]
+    : reviews
+
   return (
     <>
       <List margin={margin} divided verticalGap={60}>
-        {(myReview
-          ? [
-              myReview,
-              ...(reviews || []).filter(({ id }) => id !== myReview.id),
-            ]
-          : reviews
-        ).map((review, i) => (
-          <ReviewElement
-            key={review.id}
-            index={i}
-            review={review}
-            onUserClick={handleUserClick}
-            onLikeButtonClick={handleLikeButtonClick}
-            onLikesCountClick={handleLikesCountClick}
-            onMenuClick={handleMenuClick}
-            onImageClick={handleImageClick}
-            likeVisible={!isPublic}
-            menuVisible={!isPublic}
-            DateFormatter={ReviewTimestamp}
-            onShow={handleShow}
-          />
-        ))}
+        {(maxLength ? allReviews.slice(0, maxLength) : allReviews).map(
+          (review, i) => (
+            <ReviewElement
+              key={review.id}
+              index={i}
+              review={review}
+              onUserClick={handleUserClick}
+              onLikeButtonClick={handleLikeButtonClick}
+              onLikesCountClick={handleLikesCountClick}
+              onMenuClick={handleMenuClick}
+              onImageClick={handleImageClick}
+              likeVisible={!isPublic}
+              menuVisible={!isPublic}
+              DateFormatter={ReviewTimestamp}
+              onShow={handleShow}
+            />
+          ),
+        )}
       </List>
 
       <MyReviewActionSheet


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
리스트에 보일 리뷰의 최대 갯수를 지정합니다.

## 변경 내역 및 배경
내 리뷰가 추천/최신 리스트에 포함되지 않는 경우 3+1개까지 디스플레이될 수 있었어요. 리뷰 상태 관리를 `ReviewContainer`로 끌어올리면서 발생한 문제랄까..

## 사용 및 테스트 방법
위와 같은 조건을 만족하는 리소스를 찾고, docs에 해당 리소스 타입/ID를 설정해서 보실 수 있습니다.

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
