### PR TITLE
리뷰 쓰기 동작 오버라이딩 지원

### DIFF
--- a/packages/review/src/review-container.tsx
+++ b/packages/review/src/review-container.tsx
@@ -41,6 +41,7 @@ export default function ReviewContainer({
   },
   shortened,
   sortingOption: initialSortingOption = DEFAULT_SORTING_OPTION,
+  onReviewWrite,
 }: ReviewProps) {
   const [sortingOption, setSortingOption] = useState(initialSortingOption)
   const { isPublic } = useUserAgentContext()
@@ -136,7 +137,7 @@ export default function ReviewContainer({
         {shortened ? (
           <WriteIcon
             src="https://assets.triple.guide/images/btn-com-write@2x.png"
-            onClick={handleWriteButtonClick}
+            onClick={onReviewWrite || handleWriteButtonClick}
           />
         ) : null}
 
@@ -163,7 +164,7 @@ export default function ReviewContainer({
         )}
       </Container>
 
-      {(reviewsCount || 0) > 0 ? (
+      {(reviewsCount || 0) > 0 || myReview ? (
         <>
           <Container margin={{ top: 23 }} clearing>
             <SortingOptions
@@ -192,7 +193,7 @@ export default function ReviewContainer({
       ) : (
         <ReviewsPlaceholder
           resourceType={resourceType}
-          onClick={handleWriteButtonClick}
+          onClick={onReviewWrite || handleWriteButtonClick}
         />
       )}
 

--- a/packages/review/src/types.tsx
+++ b/packages/review/src/types.tsx
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export interface ReviewProps {
   resourceId: string
   resourceType: string
@@ -9,6 +11,7 @@ export interface ReviewProps {
   deepLink?: string
   appNativeActions: AppNativeActionProps
   sortingOption?: string
+  onReviewWrite?: (e: React.SyntheticEvent, rating?: number) => any
 }
 
 export interface AppNativeActionProps {


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
사용자가 UI에서 리뷰 쓰기를 요청했을 때 해당 액션을 override할 수 있도록 합니다.

## 변경 내역 및 배경

  - T&A 페이지에 구 버전 앱으로 접근하는 사용자들이 리뷰 쓰기를 요청할 때 이 요청을 alert 모달과 함께 막아야 하는 요구사항이 있습니다.
  - POI 상세/호텔 상세 페이지에서 리뷰 쓰기를 요청하는 경우 레거시(soto) 리뷰 쓰기 UI를 사용해야 합니다. `resourceType`에 따른 분기가 필요한데, 마이그레이션 상황에 따라 애플리케이션 단계에서 상세한 제어가 필요할 수 있습니다.

위 두 케이스를 triple-frontend 패키지에서 일관적으로 처리하는 것이 효율적인 해결방법은 아닌 것으로 보여서, 리뷰 쓰기 액션 핸들러를 override 가능하도록 했습니다. `onReviewWrite`라는 인터페이스를 추가로 노출하려 해요.

## 사용 및 테스트 방법

아래와 같이 핸들러를 컴포넌트에 전달합니다.

```jsx
<Reviews
  onReviewWrite={(e: React.SyntheticEvent, rating?: number) => {
    /* ... */
  }}
/>
```

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
