### PR TITLE
option 추가시 무한루프 도는 것을 수정합니다

### DIFF
--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
   "dependencies": {
-    "deep-equal": "^1.1.0",
-    "isomorphic-fetch": "^2.2.1"
+    "isomorphic-fetch": "^2.2.1",
+    "react-fast-compare": "^2.0.4"
   }
 }

--- a/packages/react-hooks/src/use-fetch.ts
+++ b/packages/react-hooks/src/use-fetch.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import fetch from 'isomorphic-fetch'
-import deepEqual from 'deep-equal'
+import isEqual from 'react-fast-compare'
 
 interface FetchStatus {
   data: any
@@ -20,7 +20,7 @@ export function useFetch(url: string, options?: any): FetchStatus {
   const [fetchOptions, setFetchOptions] = useState(options)
 
   useEffect(() => {
-    if (!deepEqual(fetchOptions, options)) {
+    if (!isEqual(fetchOptions, options)) {
       setFetchOptions(options)
     }
   }, [options, fetchOptions])


### PR DESCRIPTION
## 설명

useFetch 에 option 추가시 무한루프 도는 것을 수정합니다.

## 변경 내역 및 배경

- 외부에서 받은 object 를 바로 useEffect 의 dependency 로 추가하고 내부의 state 를 변경한다면 외부에서 받은 object 를 매번 새로운 값으로 판단하기 때문에 무한루프가 돕니다.
=> 최초 외부에서 받은 값을 useState 로 설정하고 그 값을 dependency 로 사용하도록 변경합니다.
=> useState 의 최초 값은 고정됩니다 => 후 바뀐 option 을 setState 를 해주며 dependency 를 업데이트합니다

## 사용 및 테스트 방법

## 스크린샷

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
