### PR TITLE
UserAgentContext에서 클라이언트 앱 정보 제공

### DIFF
--- a/packages/react-contexts/package.json
+++ b/packages/react-contexts/package.json
@@ -8,6 +8,9 @@
   ],
   "author": "",
   "license": "ISC",
+  "scripts": {
+    "test": "mocha --require ts-node/register ./src/**/*.spec.ts"
+  },
   "dependencies": {
     "@titicaca/view-utilities": "^1.0.0-alpha.44",
     "humps": "^2.0.1",
@@ -19,6 +22,9 @@
     "react": ">=16.8.0"
   },
   "devDependencies": {
-    "next": "^9.0.5"
+    "@types/mocha": "^5.2.7",
+    "mocha": "^6.2.2",
+    "next": "^9.0.5",
+    "ts-node": "^8.4.1"
   }
 }

--- a/packages/react-contexts/src/user-agent-context.spec.ts
+++ b/packages/react-contexts/src/user-agent-context.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it } from 'mocha'
+import assert from 'assert'
+
+import { generateUserAgentValues } from './user-agent-context'
+
+describe('generateUserAgentValues', () => {
+  it('should parse Chrome on Windows as public', () => {
+    assert.ok(
+      generateUserAgentValues(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36',
+      ).isPublic,
+    )
+  })
+
+  it('should parse Triple native client as not public', () => {
+    assert.ok(
+      !generateUserAgentValues(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148;Triple-iOS/3.0.0',
+      ).isPublic,
+    )
+  })
+
+  it('should parse Chrome on Windows as an Windows device', () => {
+    assert.strict.deepEqual(
+      generateUserAgentValues(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36',
+      ).os,
+      {
+        name: 'Windows',
+        version: '10',
+      },
+    )
+  })
+
+  it('should parse iOS Triple native client as an iOS device', () => {
+    assert.strict.deepEqual(
+      generateUserAgentValues(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148;Triple-iOS/3.0.0',
+      ).os,
+      {
+        name: 'iOS',
+        version: '12.3.1',
+      },
+    )
+  })
+
+  it('should parse Chrome on Windows as an external app', () => {
+    assert.strict.deepEqual(
+      generateUserAgentValues(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36',
+      ).app,
+      null,
+    )
+  })
+
+  it('should parse iOS Triple native client properly', () => {
+    assert.strict.deepEqual(
+      generateUserAgentValues(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148;Triple-iOS/3.0.0',
+      ).app,
+      {
+        name: 'Triple-iOS',
+        version: '3.0.0',
+      },
+    )
+  })
+})

--- a/packages/react-contexts/src/user-agent-context.tsx
+++ b/packages/react-contexts/src/user-agent-context.tsx
@@ -7,17 +7,18 @@ interface UserAgentProps {
     name: string
     version: string
   }
+  app: {
+    name: string
+    version: string
+  } | null
 }
 
 const Context = createContext({
   isPublic: false,
   os: { name: '', version: '' },
+  app: { name: '', version: '' },
 })
 const { Provider, Consumer } = Context
-
-function isPublic(userAgent: string): boolean {
-  return !userAgent || !userAgent.match(/Triple-(iOS|Android)/i)
-}
 
 export function withUserAgent(Component: React.ElementType) {
   return function UserAgentComponent(props: any) {
@@ -38,8 +39,28 @@ export function useUserAgentContext() {
 }
 
 export function generateUserAgentValues(userAgent: string) {
+  const app = parseApp(userAgent)
   return {
-    isPublic: isPublic(userAgent),
+    isPublic: !app,
     os: new UAParser(userAgent).getOS(),
+    app,
   }
+}
+
+function parseApp(
+  userAgent: string,
+): {
+  name: 'Triple-iOS' | 'Triple-Android'
+  version: string
+} | null {
+  const matchData = userAgent.match(/Triple-(iOS|Android)\/([^ ]+)/i)
+
+  if (matchData) {
+    return {
+      name: `Triple-${matchData[1]}` as any,
+      version: matchData[2] || 'unknown',
+    }
+  }
+
+  return null
 }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
UserAgentContext에서 클라이언트 앱의 종류와 버전 정보를 제공합니다.

## 변경 내역 및 배경

`isPublic` 여부만으로 앱 내부/외부를 구분하고 있었는데, 앱 버전을 이용해서 분기 처리가 필요한 로직들이 생겼어요. 클라이언트 브라우저와 관련한 정보이니 `UserAgentContext`에 담는 게 적합한 것 같습니다.

## 사용 및 테스트 방법

트렌드(?)에 따라 Mocha 테스트를 작성했어요.

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.