### PR TITLE
현재/지나간 내 리뷰를 잘 필터해줍니다.

### DIFF
--- a/packages/review/src/review-container.tsx
+++ b/packages/review/src/review-container.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import styled from 'styled-components'
 import { Section, Container, Text, Button } from '@titicaca/core-elements'
 import { formatNumber } from '@titicaca/view-utilities'
@@ -48,10 +48,21 @@ export default function ReviewContainer({
 }: ReviewProps) {
   const [sortingOption, setSortingOption] = useState(initialSortingOption)
   const { isPublic } = useUserAgentContext()
-  const [myReview, setMyReview] = useState(undefined)
+  const [[myReview, myReviewIds], setMyReviewStatus] = useState<
+    [any, Set<string>]
+  >([undefined, new Set([])])
   const [reviewsCount, setReviewsCount] = useState(initialReviewsCount)
   const { navigate } = useHistoryContext()
   const { show } = useTransitionModal()
+
+  const setMyReview = useCallback(
+    (review) =>
+      setMyReviewStatus(([, ids]) => [
+        review,
+        review ? new Set<string>([String(review.id), ...ids]) : ids,
+      ]),
+    [setMyReviewStatus],
+  )
 
   useEffect(() => {
     const refreshMyReview = async (params?: { id: string }) => {
@@ -131,7 +142,7 @@ export default function ReviewContainer({
     sortingOption,
     resourceId,
     resourceType,
-    perPage: shortened ? 3 : 20,
+    perPage: shortened ? 4 : 20,
   })
 
   return (
@@ -179,7 +190,7 @@ export default function ReviewContainer({
           <ReviewsList
             maxLength={shortened ? 3 : null}
             myReview={myReview}
-            reviews={reviews}
+            reviews={reviews.filter((review) => !myReviewIds.has(review.id))}
             resourceType={resourceType}
             regionId={regionId}
             appUrlScheme={appUrlScheme}

--- a/packages/review/src/reviews-list.tsx
+++ b/packages/review/src/reviews-list.tsx
@@ -123,9 +123,7 @@ export default function ReviewsList({
     ? (index) => index > reviews.length - 3 && fetchNext()
     : null
 
-  const allReviews = myReview
-    ? [myReview, ...(reviews || []).filter(({ id }) => id !== myReview.id)]
-    : reviews
+  const allReviews = myReview ? [myReview, ...(reviews || [])] : reviews
 
   return (
     <>


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
삭제한 내 리뷰를 목록에 계속 노출할 수 있던 문제를 해결합니다.

## 변경 내역 및 배경

현재 리뷰를 보여주는 로직은 이러해요:

  - 내 리뷰와 리뷰 전체 목록 조회 API를 동시에 병렬 요청
  - 내 리뷰가 있으면 내 리뷰는 1번째 고정
  - 리뷰 전체 목록을 내 리뷰 이후로 노출
    - 단, 내 리뷰 ID와 같은 ID를 가진 리뷰는 제외

여기서 내 리뷰가 삭제되었을 때 내 리뷰의 상태를 `null`로 만들어주는데, 내 리뷰가 `null`이면 리뷰 전체 목록에서 내 리뷰를 필터할 수가 없게 되네요.

전체 목록 응답에서 내 리뷰를 구분할 수는 없어서, 1번째 노출되던 내 리뷰는 제거되지만 n번째 노출을 숨겼던 전체 리뷰 안의 내 리뷰가 다시 나타날 수 있는 가능성이 있었습니다.

그래서 내 리뷰 상태 관리를 `[현재 내 리뷰, 지나간 내 리뷰 ID들]` 형식으로 하도록 로직을 수정해보았어요. 

## 사용 및 테스트 방법

docs로 가능합니다.

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
