### PR TITLE
popup 에서 lock 에 관련된 부분을 제거합니다

### DIFF
--- a/docs/stories/popup.stories.js
+++ b/docs/stories/popup.stories.js
@@ -14,12 +14,7 @@ const EmptyScroll = styled.div`
 
 storiesOf('Popup', module).add('일반', () => (
   <>
-    <Popup
-      title="테스트"
-      borderless
-      open={boolean('팝업 열기', false)}
-      isIOS={false}
-    >
+    <Popup title="테스트" borderless open={boolean('팝업 열기', false)}>
       <EmptyScroll>Scroll........</EmptyScroll>
     </Popup>
     <ActionSheet open={boolean('액션시트 열림', false)} title="메뉴 액션시트">

--- a/packages/popup/README.md
+++ b/packages/popup/README.md
@@ -21,4 +21,7 @@ return (
 - onClose: 닫기 버튼을 눌렀을 때의 이벤트 입니다. (required)
 - children: 팝업에서 그릴 `ReactNode`입니다. (required)
 - title: Navbar의 제목입니다. (optional, default: undefined)
-- isIOS: `userAgentContext`에서 가져온 osName이 `iOS` 인지 여부를 넘겨주면 됩니다. (required)
+
+## History
+
+- 2019.11.07: 팝업이 닫히자마자 push or replace 하는 케이스에서 타이밍 이슈가 생겨 lock 을 풀지못하는 케이스가 있었습니다. 일단 lock 의 구현 동작이 완벽하지 않기 떄문에 스펙에서 빼고 다시 고민해보기로 했습니다.

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -22,7 +22,6 @@
   "homepage": "https://github.com/titicacadev/triple-frontend#readme",
   "dependencies": {
     "@titicaca/core-elements": "^1.0.0-alpha.54",
-    "body-scroll-lock": "^2.6.4",
     "react-transition-group": "^4.3.0"
   }
 }

--- a/packages/popup/src/index.tsx
+++ b/packages/popup/src/index.tsx
@@ -1,5 +1,4 @@
-import { clearAllBodyScrollLocks, disableBodyScroll } from 'body-scroll-lock'
-import React, { createRef, ReactNode, SyntheticEvent, useEffect } from 'react'
+import React, { ReactNode, SyntheticEvent } from 'react'
 import { CSSTransition } from 'react-transition-group'
 import styled from 'styled-components'
 
@@ -37,29 +36,17 @@ export default function Popup({
   onClose,
   children,
   title,
-  isIOS,
 }: {
   open: boolean
   borderless?: boolean
   onClose: (e: SyntheticEvent) => void
   children: ReactNode
   title?: string
-  isIOS: boolean
 }) {
-  const lockedContainer = createRef()
-
-  useEffect(() => {
-    if (open && lockedContainer.current && !isIOS) {
-      setTimeout(() => disableBodyScroll(lockedContainer.current), 0)
-    } else if (!open && !isIOS) {
-      clearAllBodyScrollLocks()
-    }
-  }, [isIOS, open, lockedContainer])
-
   return (
     <CSSTransition timeout={0} in={open} classNames="fade" appear>
       {/* https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451 */}
-      <PopupContainer ref={lockedContainer as any}>
+      <PopupContainer>
         <Navbar borderless={borderless} title={title}>
           <Navbar.Item floated="left" icon="close" onClick={onClose} />
         </Navbar>


### PR DESCRIPTION
## 설명
popup 에서 lock 에 관련된 부분을 제거합니다

- 2019.11.07: 팝업이 닫히자마자 push or replace 하는 케이스에서 타이밍 이슈가 생겨 lock 을 풀지못하는 케이스가 있었습니다. 일단 lock 의 구현 동작이 완벽하지 않기 떄문에 스펙에서 빼고 다시 고민해보기로 했습니다.

## 변경 내역 및 배경
- popup 에서 lock 에 관련된 부분을 제거합니다

## 사용 및 테스트 방법
DOCS

## 스크린샷

## 이 PR의 유형

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
