### PR TITLE
📏 search-navbar 1px 확장

### DIFF
--- a/packages/core-elements/src/elements/search-navbar.tsx
+++ b/packages/core-elements/src/elements/search-navbar.tsx
@@ -8,8 +8,8 @@ const InputText = styled(InputMask)`
   border-style: none;
   font-size: 17px;
   height: 21px;
+  line-height: 21px;
   margin: 6px 34px 0 40px;
-  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   width: calc(100% - 80px);


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
아이폰 모바일에서 y,j,g가 미세하게 잘리는 문제 때문에 search-navbar의 input을 1px 더 키웁니다.

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

### before
<img width="490" alt="Screen Shot 2019-11-08 at 8 57 39 AM" src="https://user-images.githubusercontent.com/39641309/68437916-d2073080-0205-11ea-883e-66d4ff9c06f0.png">

### after
<img width="490" alt="Screen Shot 2019-11-08 at 8 57 57 AM" src="https://user-images.githubusercontent.com/39641309/68437938-dcc1c580-0205-11ea-9ea3-6261b926bca5.png">

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
