### PR TITLE
label 에 green color 를 추가합니다

### DIFF
--- a/docs/stories/label.stories.js
+++ b/docs/stories/label.stories.js
@@ -15,7 +15,11 @@ storiesOf('Label', module)
     <Label
       promo
       size={select('크기', ['small', 'medium', 'large'], 'medium')}
-      color={select('색깔', ['purple', 'blue', 'red', 'gray'], 'purple')}
+      color={select(
+        '색깔',
+        ['purple', 'blue', 'red', 'gray', 'green'],
+        'purple',
+      )}
       emphasized={boolean('강조', true)}
     >
       {text('텍스트', '최대 24%')}

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,4 @@
 {
-  "packages": [
-    "docs",
-    "packages/*",
-    "tests"
-  ],
+  "packages": ["docs", "packages/*", "tests"],
   "version": "1.0.0-alpha.57"
 }

--- a/packages/core-elements/src/elements/label.tsx
+++ b/packages/core-elements/src/elements/label.tsx
@@ -8,7 +8,7 @@ import {
   GlobalSizes,
 } from '../commons'
 
-export type LabelColor = GlobalColors | 'purple'
+export type LabelColor = GlobalColors | 'purple' | 'green'
 
 type Color = number[] | string[]
 
@@ -34,6 +34,10 @@ const LABEL_COLORS: Partial<
   gray: {
     background: [58, 58, 58, 0.05],
     text: [58, 58, 58, 0.7],
+  },
+  green: {
+    background: [13, 208, 175, 0.1],
+    text: [13, 208, 175, 1],
   },
 }
 


### PR DESCRIPTION
## 설명
label 에 귀여운 green color 를 추가합니다

## 변경 내역 및 배경
쿠폰 라벨 색상이 변경되면서 새로운 색상이 추가되었습니다

## 사용 및 테스트 방법
똑스

## 스크린샷
![image](https://user-images.githubusercontent.com/27910236/68528628-928d3100-0338-11ea-97eb-9588e7b6a2d6.png)


## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
