### PR TITLE
pricing component 스타일을 수정합니다

### DIFF
--- a/docs/stories/pricing.stories.js
+++ b/docs/stories/pricing.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { withKnobs, boolean } from '@storybook/addon-knobs'
+import { withKnobs, boolean, text } from '@storybook/addon-knobs'
 import Pricing from '@titicaca/pricing'
 
 storiesOf('Pricing', module)
@@ -15,30 +15,10 @@ storiesOf('Pricing', module)
       active={boolean('열림', true)}
       basePrice={30000}
       salePrice={25000}
-      label="트리플 클럽가"
+      label={text('라벨')}
       buttonText="객실예약"
-      description="10,000원 쿠폰 할인 가능"
-    />
-  ))
-  .add('Fixed (Custom Label) ', () => (
-    <Pricing
-      fixed
-      active={boolean('열림', true)}
-      basePrice={30000}
-      salePrice={25000}
-      buttonText="객실예약"
-      description="10,000원 쿠폰 할인 가능"
-    />
-  ))
-  .add('Fixed (Tooltip) ', () => (
-    <Pricing
-      fixed
-      active={boolean('열림', true)}
-      basePrice={30000}
-      salePrice={25000}
-      buttonText="객실예약"
-      description="10,000원 쿠폰 할인 가능"
-      tooltipLabel="쿠폰사용시 -15,000원 더 할인!"
+      description={text('설명')}
+      tooltipLabel={text('툴팁 라벨', '쿠폰사용시 -15,000원 더 할인!')}
       onTooltipClick={boolean('툴팁액션', true)}
     />
   ))

--- a/packages/pricing/src/index.tsx
+++ b/packages/pricing/src/index.tsx
@@ -161,7 +161,7 @@ const FloatedFrame = styled(Container)`
   border-top: 1px solid #efefef;
 
   @supports (padding: max(0px)) and (padding: env(safe-area-inset-bottom)) {
-    padding-bottom: max(10px, env(safe-area-inset-bottom, 10px));
+    padding-bottom: max(20px, env(safe-area-inset-bottom, 20px));
   }
 `
 
@@ -206,7 +206,7 @@ function FixedPricing({
 }) {
   const pricingLabel = label ? (
     typeof label === 'string' ? (
-      <Text color="blue" size="mini">
+      <Text color="blue" size="mini" margin={{ bottom: 2 }}>
         {label}
       </Text>
     ) : (
@@ -219,9 +219,9 @@ function FixedPricing({
       <FloatedFrame
         clearing
         padding={{
-          top: label ? 12 : 24,
+          top: 20,
           right: 20,
-          bottom: label ? 12 : 15,
+          bottom: 20,
           left: 20,
         }}
       >
@@ -235,12 +235,12 @@ function FixedPricing({
         )}
 
         <FloatedPricingContainer floated="left">
-          {pricingLabel}
+          {!description && pricingLabel}
           <Text size="huge" bold>
             {formatNumber(salePrice)}원
           </Text>
           {description ? (
-            <Text size="mini" alpha={0.5} margin={{ top: label ? 0 : 4 }}>
+            <Text size="mini" alpha={0.5} margin={{ top: 2 }}>
               {description}
             </Text>
           ) : null}


### PR DESCRIPTION
## 설명

pricing component 스타일을 수정합니다
3줄짜리 옵션떄문에 컴포넌트가 조금 더러웠었는데 앞으로는 2 줄짜리만 필요하여 3줄 옵션을 제거합니다.

라벨과 설명글이 동시에 노출 될 수 없습니다. 

## 변경 내역 및 배경

- 스토리북을 수정합니다
- 라벨 또는 설명글 중 하나만 노출되도록 변경

## 사용 및 테스트 방법
똑스

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
