### PR TITLE
Use parseUrl instead of URL constructor

### DIFF
--- a/packages/react-contexts/src/history-context.tsx
+++ b/packages/react-contexts/src/history-context.tsx
@@ -48,7 +48,7 @@ export function HistoryProvider({
   const [uriHash, setUriHash] = React.useState(null)
 
   const onHashChange = React.useCallback((url) => {
-    const hash = new URL(url, 'https://triple.guide').hash.replace(/^#/, '')
+    const { hash } = parseUrl(url)
 
     // We only need to check if onHashChange is triggered by native action.
     const { hash: previousHash } = HASH_HISTORIES[


### PR DESCRIPTION
`new URL`의 사용을 제거합니다

## 설명
기존에 view-utilities에 만들어 둔 `parseUrl`로 `new URL` 사용을 대체합니다.

## 변경 내역 및 배경
https://developer.mozilla.org/en-US/docs/Web/API/URL/URL 에 의하면 `new URL`은 IE에서 일체 사용이 불가합니다.

## 사용 및 테스트 방법
백버튼과 같은 네이티브 동작으로 브라우저의 히스토리의 back을 호출하게 될 때, 기대한 대로 팝업/액션시트 등이 잘 동작하는 지를 확인해야 합니다.

## 스크린샷
생략

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
