### PR TITLE
day-picker에 휴일을 추가합니다.

### DIFF
--- a/docs/stories/date-picker.stories.js
+++ b/docs/stories/date-picker.stories.js
@@ -31,6 +31,16 @@ storiesOf('DatePicker', module)
       height="300px"
     />
   ))
+  .add('DayPicker - 휴일', () => (
+    <DayPicker
+      publicHolidays={publicHolidays}
+      day={today.toString()}
+      beforeBlock={today}
+      afterBlock={afterDate}
+      disabledDays={[specificDate.toString()]}
+      height="300px"
+    />
+  ))
   .add('RangePicker - 일반', () => <RangePicker />)
   .add('RangePicker - 선택됨', () => (
     <RangePicker startDate={today.toString()} endDate={endDate.toString()} />

--- a/packages/date-picker/src/day-picker.tsx
+++ b/packages/date-picker/src/day-picker.tsx
@@ -69,6 +69,7 @@ function DatePicker({
   onDateChange,
   disabledDays = [],
   height,
+  publicHolidays,
 }: {
   day: string
   beforeBlock: Date
@@ -77,6 +78,7 @@ function DatePicker({
   onDateChange: Function
   disabledDays?: string[]
   height?: string
+  publicHolidays?: Date[]
 }) {
   const selectedDay = day && moment(day).toDate()
 
@@ -96,6 +98,7 @@ function DatePicker({
           }}
           numberOfMonths={numberOfMonths}
           modifiers={{
+            publicHolidays,
             sunday: (day) => day.getDay() === 0,
             saturday: (day) => day.getDay() === 6,
           }}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
#226에서는 range-picker에만 추가된 props를 day-picker에도 추가합니다.
related with #218

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
- holiday props를 optional하게 받을수 있게 추가합니다.
- holiday일 경우 빨간색으로, disabled처리된 날짜와 holiday의 날짜가 겹칠 경우의 css 처리를 추가합니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->
docs 

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<img width="345" alt="range-picker-holiday" src="https://user-images.githubusercontent.com/51554632/68733672-cc9d5200-061a-11ea-9e47-8e21b951172d.png">
(현재 month의 1일, 25일, 26일, 27일이 휴일로 처리 되어있습니다.)

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
