### PR TITLE
Feature: 리뷰 이미지에 ReviewThumbnail TransitionType 사용

### DIFF
--- a/packages/modals/src/transition-modal.tsx
+++ b/packages/modals/src/transition-modal.tsx
@@ -22,6 +22,7 @@ export enum TransitionType {
   Scrap = 'scrap',
   Review = 'review',
   ReviewWrite = 'reviewWrite',
+  ReviewThumbnail = 'reviewThumbnail',
   Article = 'article',
   Tna = 'tna',
   Hotel = 'hotel',
@@ -59,6 +60,11 @@ const MODAL_CONTENT: {
     icon: 'https://assets.triple.guide/images/ico-popup-review@4x.png',
     description: '리뷰는 앱에서 작성할 수 있어요.',
     eventLabel: '리뷰_리뷰쓰기',
+  },
+  [TransitionType.ReviewThumbnail]: {
+    icon: 'https://assets.triple.guide/images/ico-popup-gallery@4x.png',
+    description: '사진은 앱에서 더 편리하게\n확인할 수 있어요.',
+    eventLabel: '리뷰_리뷰사진썸네일',
   },
   [TransitionType.Article]: {
     icon: 'https://assets.triple.guide/images/ico-popup-guidebook@4x.png',

--- a/packages/review/src/reviews-list.tsx
+++ b/packages/review/src/reviews-list.tsx
@@ -95,7 +95,7 @@ export default function ReviewsList({
     image,
   ) => {
     if (isPublic) {
-      return show(TransitionType.Gallery)
+      return show(TransitionType.ReviewThumbnail)
     }
 
     const convertImage = (convertingImage) => ({


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
공개 환경에서 리뷰 이미지를 눌렀을 때 ReviewThumbnail 타입의 TransitionModal을 띄웁니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
content-web에 TF TransitionModal을 적용하던 중에 리뷰 썸네일 이미지를 눌러서 뜨는 TransitionModal의 [이벤트 라벨이 Gallary 타입과 다른](https://github.com/titicacadev/triple-content-web/blob/816773ca4193d70ac943ee6b94aadaa8ef3d0514/src/common/transition-modals.js#L86) 걸 발견했습니다.
그래서 새로운 타입을 추가하고 review 패키지에서 해당 타입을 사용하도록 수정합니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
