### PR TITLE
[triple-document] 이미지와 부제가 있는 `links` element

### DIFF
--- a/docs/stories/triple-document.links.stories.js
+++ b/docs/stories/triple-document.links.stories.js
@@ -59,3 +59,52 @@ storiesOf('TripleDocument.링크', module)
       }}
     />
   ))
+  .add('이미지', () => (
+    <Links
+      value={{
+        links: [
+          {
+            label: '메가 돈키호테 시부야 본점',
+            image: {
+              sizes: {
+                full: {
+                  url:
+                    'https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/1c22ae37-108f-44a7-b96b-1d70179b0b3f.jpeg',
+                },
+                large: {
+                  url:
+                    'https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/1c22ae37-108f-44a7-b96b-1d70179b0b3f.jpeg',
+                },
+                small_square: {
+                  url:
+                    'https://media.triple.guide/triple-cms/c_fill,f_auto,h_256,w_256/1c22ae37-108f-44a7-b96b-1d70179b0b3f.jpeg',
+                },
+              },
+            },
+            description: '관광명소',
+          },
+          {
+            label: '도쿄의 이색 체험',
+            image: {
+              sizes: {
+                full: {
+                  url:
+                    'https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/fc59cda3-056b-41ca-9c87-242d6f15074d.jpeg',
+                },
+                large: {
+                  url:
+                    'https://media.triple.guide/triple-dev/c_limit,f_auto,h_1024,w_1024/fc59cda3-056b-41ca-9c87-242d6f15074d.jpeg',
+                },
+                small_square: {
+                  url:
+                    'https://media.triple.guide/triple-dev/c_fill,f_auto,h_256,w_256/fc59cda3-056b-41ca-9c87-242d6f15074d.jpeg',
+                },
+              },
+            },
+            description: '가이드',
+          },
+        ],
+        display: 'image',
+      }}
+    />
+  ))

--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -21,6 +21,8 @@ import {
   Carousel,
   Container,
   GetGlobalColor,
+  ResourceListItem,
+  SquareImage,
 } from '@titicaca/core-elements'
 import { PoiListElement, PoiCarouselElement } from '@titicaca/poi-list-elements'
 
@@ -394,6 +396,7 @@ const LINK_CONTAINERS = {
   block: BlockContainer,
   list: ListLinkContainer,
   default: LinksContainer,
+  image: ResourceList,
 }
 
 function ButtonLink({ children, ...props }) {
@@ -412,11 +415,35 @@ function BlockLink({ children, ...props }) {
   )
 }
 
+const IMAGE_PLACEHOLDER =
+  'https://assets.triple.guide/images/ico-blank-see@2x.png'
+
+function ImageLink({ href, label, description, image, onClick }) {
+  return (
+    <ResourceListItem onClick={onClick}>
+      <a href={href}>
+        <SquareImage
+          floated="left"
+          size="small"
+          src={(image && image.sizes.small_square.url) || IMAGE_PLACEHOLDER}
+        />
+        <Text bold ellipsis alpha={1} margin={{ left: 50 }}>
+          {label}
+        </Text>
+        <Text size="tiny" alpha={0.7} margin={{ top: 4, left: 50 }}>
+          {description}
+        </Text>
+      </a>
+    </ResourceListItem>
+  )
+}
+
 const LINK_ELEMENTS = {
   button: ButtonLink,
   block: BlockLink,
   list: ListLink,
   default: SimpleLink,
+  image: ImageLink,
 }
 
 function Links({ value: { display, links }, onLinkClick, ...props }) {
@@ -428,8 +455,8 @@ function Links({ value: { display, links }, onLinkClick, ...props }) {
       {links.map((link, i) => (
         <Element
           key={i}
-          href={link.href}
           onClick={onLinkClick && ((e) => onLinkClick(e, link))}
+          {...link}
         >
           {link.label}
         </Element>


### PR DESCRIPTION
## 설명
기존의 `{ label, href }`에 이미지와 부제가 추가된 `{ label, href, image, description }` 형태의 link를 지원합니다.

## 변경 내역 및 배경
* https://github.com/titicacadev/triple-frontend/issues/237

## 사용 및 테스트 방법
* `links`의 `display`가 `image`로 설정되어있으면 이미지와 부제가 추가된 link 형태로 보여줍니다.

## 스크린샷
<img width="309" alt="스크린샷 2019-11-18 오후 6 12 56" src="https://user-images.githubusercontent.com/722173/69039487-59874780-0a2f-11ea-9413-c1551137feb2.png">


## 이 PR의 유형
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
