### PR TITLE
[triple-document] image 컴포넌트를 다양한 비율로 사용할 수 있도록 개선합니다.

### DIFF
--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -235,7 +235,7 @@ function EmbeddedImage({
   value: {
     images: [image],
   },
-  size,
+  frame,
   onImageClick,
   onLinkClick,
   ImageSource,
@@ -247,7 +247,7 @@ function EmbeddedImage({
 
     return (
       <Image
-        size={size || 'medium'}
+        frame={frame || 'medium'}
         src={sizes.large.url}
         sourceUrl={sourceUrl}
         onClick={(e) => handleClick(e, image)}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
기존의 triple-document에서 embedded 된 image가 `medium` frame으로 항상 고정되었는데 이번 개선으로 운영툴을 통해 사이즈를 조절 할 수 있게 개선합니다.

## 설명
기존에는 `<Image />` 컴포넌트 내 size props를 고정으로 medium으로 넘기고 width, height를 넘기지 않아 컴포넌트 내부에서 GlobalSize 인터페이스에 맞는 사이즈를 계산했는데 이 부분을 frame props로 바꾸고 이 props를 triple document내에서 받아 넘길 수 있게 개선했습니다.

## 변경 내역 및 배경
#201 이슈를 해결합니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
