### PR TITLE
[triple-document] 이미지 타입 links의 텍스트의 underline을 제거합니다.

### DIFF
--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -458,6 +458,7 @@ function Links({ value: { display, links }, onLinkClick, ...props }) {
           key={i}
           onClick={onLinkClick && ((e) => onLinkClick(e, link))}
           {...link}
+          href={link.href || '#'}
         >
           {link.label}
         </Element>


### PR DESCRIPTION
## 설명
이미지 타입 links의 텍스트에 뜨는 underline을 제거합니다.

## 변경 내역 및 배경
아래 스크린샷에 첨부된 것과 같이 텍스트에 underline이 뜨는 이슈가 있어 수정합니다.

## 사용 및 테스트 방법
links의 display가 image로 설정되어있으면 이미지와 부제가 추가된 link 형태로 보여줍니다 

## 스크린샷
<img width="341" alt="스크린샷 2019-11-20 오후 2 10 39" src="https://user-images.githubusercontent.com/54011591/69211355-2d8bd380-0ba1-11ea-87f3-c1c05471ac33.png">

## 이 PR의 유형
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
