### PR TITLE
[triple-document]frame 엔터티 할당 오류 수정

### DIFF
--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -237,13 +237,12 @@ function EmbeddedImage({
   value: {
     images: [image],
   },
-  frame,
   onImageClick,
   onLinkClick,
   ImageSource,
 }) {
   if (image) {
-    const { sizes, sourceUrl } = image
+    const { sizes, sourceUrl, frame } = image
 
     const handleClick = generateClickHandler(onLinkClick, onImageClick)
 


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
`frame` props를 추가하는데 엔터티 위치를 실수로 잘못 할당했어요.
## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
@polysiya 가 merge 후 코멘트로 리뷰해주셨습니다. https://github.com/titicacadev/triple-frontend/pull/240/files#r348301776

solves #201 
## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.