### PR TITLE
[history-context] 'initialHashStrategy' 에 따라 초기 uriHash 를 사용 방법을 결정합니다.

### DIFF
--- a/packages/react-contexts/src/history-context.tsx
+++ b/packages/react-contexts/src/history-context.tsx
@@ -37,15 +37,29 @@ interface HashHistory {
 
 const HASH_HISTORIES: HashHistory[] = []
 
+export enum HashStrategy {
+  NONE,
+  NO_PUSH,
+  PUSH,
+}
+export interface HistoryProviderProps {
+  appUrlScheme: string
+  webUrlBase: string
+  transitionModalHash?: string
+  isAndroid?: boolean
+  isPublic?: boolean
+  initialHashStrategy?: HashStrategy
+  children?: React.ReactElement
+}
 export function HistoryProvider({
   appUrlScheme,
   webUrlBase,
-  transitionModalHash,
-  isAndroid,
-  isPublic,
-  initialHash = false,
+  transitionModalHash = '',
+  isAndroid = false,
+  isPublic = false,
+  initialHashStrategy = HashStrategy.NONE,
   children,
-}) {
+}: HistoryProviderProps) {
   const [uriHash, setUriHash] = React.useState(null)
 
   const onHashChange = React.useCallback((url) => {
@@ -67,10 +81,15 @@ export function HistoryProvider({
     Router.events.on('routeChangeStart', onHashChange)
     Router.events.on('hashChangeStart', onHashChange)
 
-    if (initialHash && uriHash === null) {
-      setUriHash(
-        window && window.location ? window.location.hash.substr(1) || '' : '',
-      )
+    if (initialHashStrategy !== HashStrategy.NONE && uriHash === null) {
+      const initialHash =
+        window && window.location ? window.location.hash.substr(1) || '' : ''
+
+      if (initialHashStrategy === HashStrategy.PUSH) {
+        HASH_HISTORIES.push({ hash: initialHash, useRouter: isAndroid })
+      }
+
+      setUriHash(initialHash)
     }
 
     return () => {

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/triple-frontend-tests",
-  "version": "1.0.0-alpha.51",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## 설명
> This resolves #257
초기 uriHash 값을 사용할 수 있는 옵션을 만듭니다.

## 변경 내역 및 배경
- 초기 uriHash 값을 사용하고 싶은 경우 옵션을 설정할 수 있도록 합니다.

초기 hash 값은 고스트 back 이슈로, `HASH_HISTORIES`에 저장하지 않고 있습니다.  
이 부분도 옵션 처리가 필요할지 의견 부탁드립니다. @titicacadev/frontend 

## 사용 및 테스트 방법
- HistoryProvider 의 `initialHash` 를 true 로 놓고, 해시가 달려 있는 url을 새로고침하여 `uriHash` 값을 확인합니다.

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.

----

## HistoryProvider 의 탄생 배경 설명
**iOS 에는 swipe back시 바탕이 보이는 효과가 존재한다!!**
1. Modal Hash 가 변경될 때 마다 history 에 쌓으면, swipe back 시 
   - Modal 을 닫는 동작을 수행합니다.
   - iOS 에서는 swipe back 으로 페이지가 전환되는것 같은데, 실제로는 Modal 만 닫힙니다.
   - Android 에도 swipe back 이 있지만 페이지 전환 효과가 없어 Modal 을 닫는것으로 동작하더라도 자연스럽습니다.

따라서, Android 에서는, 이동시 `useRouter` 옵션이 기본 **true** 로 설정되며, iOS 에서는 **false** 로 설정됩니다. 

2. history 를 이용하지 않으면, iOS 에서는 어떻게 하죠?
   - 그래서, HistoryProvider 가  router 의 push, replace, back 을 래핑합니다.
   - 내부에서 `HASH_HISTORIES` 라는 가상의 해시 히스토리를 관리합니다.
   - 따라서, url 상에는 해시가 보이지 않지만, 가상의 `HASH_HISTORIES` 에서 하나씩 뽑아 쓰며 이동가능합니다.

3. uriHash 의 초기값은 왜 null 이었나요?
   -  해시가 붙어있는 url로 바로 진입하고, 초기 hash 를 `HASH_HISTORIES` 에 넣어서 관리를 시작할경우, iOS 에서는 이전 히스토리가 있는것으로 판단될 우려가 있습니다. 따라서, `back` 호출시 실제로 뒤로 가기가 동작해버립니다.
   - 이것을 Ghost back 이라는 현상으로 지칭했는데, 여러 복잡도를 고려하여, 초기 hash 를 인정하지 않는 방향으로 의사 결정 되었던것 같습니다.

4. 그러면, 이제와서 이것을 다시 허용하는 것인가요?
   - 서비스마다 선택할 수있는 방법을 마련하는것입니다.
   - modal 이나 action-sheet 가 이미 떠있는 상태로 진입하는 화면이 필수 불가결하게 디자인되는 경우가 생기고 있습니다.
   - 따라서, `initialHashStrategy` 라는 이름으로 `NONE`(기본), `NO_PUSH`, `PUSH` 와 같은 형태의 값을 지정하여 선택할 수 있게 ~할 예정입니다.~ 했습니다.