### PR TITLE
Feature: 인벤토리 조회 기능을 포함한 BannerCTA 컴포넌트 구현

### DIFF
--- a/docs/stories/app-installation-cta.stories.js
+++ b/docs/stories/app-installation-cta.stories.js
@@ -6,7 +6,7 @@ import { text } from '@storybook/addon-knobs'
 import {
   ImageBanner,
   TextBanner,
-  AppInstallationCTA,
+  BannerCTA,
 } from '@titicaca/app-installation-cta'
 
 storiesOf('AppInstallationCTA', module)
@@ -23,19 +23,16 @@ storiesOf('AppInstallationCTA', module)
       installUrl={text('설치 URL', 'https://triple-dev.titicaca-corp.com')}
     />
   ))
-  .add('통합', () => (
+  .add('배너 CTA', () => (
     <div>
-      <AppInstallationCTA
-        imgUrl={text('이미지 URL', '')}
+      <BannerCTA
+        inventoryId={text(
+          '표시할 배너의 인벤토리 ID',
+          'app-install-cta-poi-v1',
+        )}
         installUrl={text('설치 URL', 'https://triple-dev.titicaca-corp.com')}
-        message={text('표시할 메시지', '앱 다운로드시 가이드북 무료')}
       />
 
-      {new Array(200).fill(
-        <>
-          긴 텍스트입니다!
-          <br />
-        </>,
-      )}
+      <div style={{ height: '2000px' }} />
     </div>
   ))

--- a/packages/app-installation-cta/src/app-installation-cta.tsx
+++ b/packages/app-installation-cta/src/app-installation-cta.tsx
@@ -33,6 +33,9 @@ const BottomFixedContainer = styled.div`
   }
 `
 
+/**
+ * @deprecated 구체적인 형태의 컴포넌트인 BannerCTA를 사용하세요
+ */
 const AppInstallationCTA: FC<AppInstallationCTAProps> = ({
   imgUrl,
   installUrl,

--- a/packages/app-installation-cta/src/banner-cta.tsx
+++ b/packages/app-installation-cta/src/banner-cta.tsx
@@ -1,0 +1,84 @@
+import React, { FC, useState, useEffect } from 'react'
+import styled from 'styled-components'
+
+import ImageBanner from './image-banner'
+import TextBanner from './text-banner'
+
+interface BannerCTAProps {
+  inventoryId: string
+  installUrl: string
+}
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.07);
+  background-color: rgba(58, 58, 58, 0.5);
+  z-index: 10;
+`
+
+const BottomFixedContainer = styled.div`
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  z-index: 11;
+
+  > * {
+    margin: 0 auto;
+  }
+`
+
+/**
+ * 이미지가 포함된 배너를 띄우고 dismiss 시에는 텍스트 배너로 바뀌는 CTA 컴포넌트
+ *
+ * @param inventoryId 표시할 이미지의 인벤토리 ID
+ * @param installUrl 앱 설치 URL
+ */
+const BannerCTA: FC<BannerCTAProps> = ({ inventoryId, installUrl }) => {
+  const [{ image, desc }, setCTAImage] = useState({ image: '', desc: '' })
+  const [isImageBannerOpen, setIsImageBannerOpen] = useState(true)
+
+  useEffect(() => {
+    async function fetchCTAImage() {
+      const response = await fetch(`/api/inventories/v1/${inventoryId}/items`, {
+        credentials: 'same-origin',
+      })
+
+      if (response.ok) {
+        const { items } = await response.json()
+
+        if (items.length > 0) {
+          const item = items[0]
+
+          setCTAImage({
+            image: item.image ? item.image.replace(/\.jpg$/, '.png') : '',
+            desc: item.desc,
+          })
+        }
+      }
+    }
+    fetchCTAImage()
+  }, [inventoryId])
+
+  if (isImageBannerOpen) {
+    return (
+      <Overlay>
+        <BottomFixedContainer>
+          <ImageBanner
+            imgUrl={image}
+            installUrl={installUrl}
+            onDismiss={() => setIsImageBannerOpen(false)}
+          />
+        </BottomFixedContainer>
+      </Overlay>
+    )
+  }
+
+  return <TextBanner message={desc} installUrl={installUrl} />
+}
+
+export default BannerCTA

--- a/packages/app-installation-cta/src/index.tsx
+++ b/packages/app-installation-cta/src/index.tsx
@@ -1,5 +1,6 @@
 import ImageBanner from './image-banner'
 import TextBanner from './text-banner'
 import AppInstallationCTA from './app-installation-cta'
+import BannerCTA from './banner-cta'
 
-export { ImageBanner, TextBanner, AppInstallationCTA }
+export { ImageBanner, TextBanner, AppInstallationCTA, BannerCTA }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
사용처에서 공통적으로 인벤토리를 부르고 있으므로 해당 로직을 모듈 내부로 옮긴 컴포넌트를 새로 만듧니다.
기존에 사용하던 AppInstallationCTA 컴포넌트는 deprecated 처리 했습니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
- hotels-web, content-web에서 이 컴포넌트를 사용하고 있는데, 표시할 배너 이미지를 인벤토리에서 조회하는 로직을 각각 추가해야 했습니다. 인벤토리 ID만 관여하기 때문에 해당 로직을 공통 컴포넌트에 넣어도 무방하다고 판단했습니다.
- app-installation-cta에 속하는 컴포넌트 이름으로 AppInstallationCTA 보다 BannerCTA가 더 적절한 이름이라고 판단하여 이름을 바꿨습니다. "앱 설치 CTA" 중 "배너 형태의 CTA"를 의미하게 됩니다. 만약 다른 종류의 CTA가 있을 때 이름을 짓기 수월해졌습니다. 하위 호환을 유지하기 위해 기존 컴포넌트는 삭제하지 않았습니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->
docs에서 확인할 수 있습니다.

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
