### PR TITLE
할인률이 0 보다 아래인 경우 할인률을 노출하지 않습니다

### DIFF
--- a/docs/stories/hotels.sample.json
+++ b/docs/stories/hotels.sample.json
@@ -53,11 +53,11 @@
     },
     "type": "hotel",
     "prices": {
-      "nightlyBasePrice": 427432,
+      "nightlyBasePrice": 355695,
       "nightlyPrice": 355695,
       "promoText": "최대 16%",
-      "nightlyPriceHotelPromotionApplied": 359691,
-      "clubPromotionRate": 1,
+      "nightlyPriceHotelPromotionApplied": 0,
+      "clubPromotionRate": 0,
       "clubPromotionType": "STATIC",
       "clubMemberOnly": false,
       "clubPromotionTarget": true

--- a/docs/stories/poi.stories.js
+++ b/docs/stories/poi.stories.js
@@ -8,7 +8,6 @@ import POIS from './pois.sample.json'
 import HOTELS from './hotels.sample.json'
 
 const [POI] = POIS
-const [HOTEL] = HOTELS
 
 storiesOf('POI', module)
   .add('POI 리스트', () => (
@@ -19,15 +18,18 @@ storiesOf('POI', module)
       }}
     />
   ))
-  .add('호텔 리스트', () => (
-    <PoiListElement
-      poi={HOTEL}
-      resourceScraps={{
-        [HOTEL.id]: boolean('저장', false),
-      }}
-      pricingNote="1박, 세금포함"
-    />
-  ))
+  .add('호텔 리스트', () =>
+    HOTELS.map((hotel, idx) => (
+      <PoiListElement
+        key={idx}
+        poi={hotel}
+        resourceScraps={{
+          [hotel.id]: boolean('저장', false),
+        }}
+        pricingNote="1박, 세금포함"
+      />
+    )),
+  )
   .add('TripleDocument', () => (
     <PoiCarouselElement
       poi={POI}

--- a/packages/pricing/src/index.tsx
+++ b/packages/pricing/src/index.tsx
@@ -99,8 +99,20 @@ const PriceNoteContainer = styled.div`
   right: 0;
 `
 
-function discountRate(basePrice: number, salePrice: number) {
-  return `${Math.floor(((basePrice - salePrice) / basePrice) * 100)}%`
+function DiscountRate({
+  basePrice,
+  salePrice,
+}: {
+  basePrice: number
+  salePrice: number
+}) {
+  const rate = Math.floor(((basePrice - salePrice) / basePrice) * 100)
+
+  return rate > 0 ? (
+    <Price color="pink" size="big" margin={{ right: 5 }} bold>
+      {rate}%
+    </Price>
+  ) : null
 }
 
 function RichPricing({
@@ -135,9 +147,7 @@ function RichPricing({
           {formatNumber(basePrice)}
         </Text>
       </PriceNoteContainer>
-      <Price color="pink" size="big" margin={{ right: 5 }} bold>
-        {discountRate(basePrice, salePrice)}
-      </Price>
+      <DiscountRate basePrice={basePrice} salePrice={salePrice} />
       <Price size="big" bold>
         {formatNumber(salePrice)}원
       </Price>


### PR DESCRIPTION
## 설명
호텔의 할인률이 0 보다 아래인 경우 할인률을 노출하지 않습니다

## 변경 내역 및 배경
호텔 리스트 디자인이 변경되면서 할인률이 들어가게되었는데 basePrice 랑 salePrice 가 같은경우를 고려하지 못했네요 ;; 

## 사용 및 테스트 방법
DOCS

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
