### PR TITLE
[core-element] `Drawer` 컴포넌트에서 z-index prop을 추가로 받습니다

### DIFF
--- a/packages/core-elements/src/elements/drawer.tsx
+++ b/packages/core-elements/src/elements/drawer.tsx
@@ -6,7 +6,7 @@ const DrawerContainer = styled.div<{
   overflow?: string
   zIndex?: number
 }>`
-  z-index: ${({ zIndex }) => zIndex || 20};
+  z-index: ${({ zIndex }) => (Number.isInteger(zIndex) ? zIndex : 20)};
   position: fixed;
   bottom: 0;
   left: 0;
@@ -23,7 +23,17 @@ const DrawerContainer = styled.div<{
     `};
 `
 
-export default function Drawer({ active, overflow, children, zIndex }) {
+export default function Drawer({
+  active,
+  overflow,
+  zIndex,
+  children,
+}: {
+  active?: boolean
+  overflow?: string
+  zIndex?: number
+  children?: React.ReactNode
+}) {
   return (
     <DrawerContainer active={active} overflow={overflow} zIndex={zIndex}>
       {children}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
Drawer의 기본 z-index는 20이지만 prop으로 값을 받아 다른 값을 할당할 수 있게 합니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
modal보다 z-index가 높아 컴포넌트가 dimmed 되지 않는 현상이 있었습니다. 추후에 modal 또한 z-index prop을 열어 받게 하려고 합니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
