### PR TITLE
[core-elements] list item 에 구분선 생략 prop 을 추가합니다

### DIFF
--- a/docs/stories/poi.stories.js
+++ b/docs/stories/poi.stories.js
@@ -28,7 +28,7 @@ storiesOf('POI', module)
             [hotel.id]: boolean('저장', false),
           }}
           pricingNote="1박, 세금포함"
-          skipDivided={boolean('라인 생략', false) && idx % 2 === 0}
+          noDivider={boolean('라인 생략', false) && idx % 2 === 0}
         />
       ))}
     </List>

--- a/packages/core-elements/src/elements/list.tsx
+++ b/packages/core-elements/src/elements/list.tsx
@@ -73,13 +73,13 @@ export default class List extends React.PureComponent<
           {React.Children.toArray(children)
             .reduce((array, child) => {
               const {
-                props: { skipDivided },
+                props: { noDivider },
               } = child
 
               return [
                 ...array,
                 child,
-                !skipDivided && (
+                !noDivider && (
                   <HR1
                     key={array.length + 1}
                     margin={{ top: verticalGap / 2, bottom: verticalGap / 2 }}


### PR DESCRIPTION
## 설명

list item 에 구분선 생략 prop 을 추가합니다

## 변경 내역 및 배경
아래와 같이 List 사이에 끼어 들어가는 디자인이 생기기 시작했습니다.
나중에는 배너가 될 수도 있구요 

처음에는 List 를 사용하는 쪽에서 리스트를 쪼개서 List 를 2 번그리도록 처리해주도록 했었는데
이렇게되면 페이징 값이라던지 쪼갠 리스트만큼 빼주고 그런 작업들이 필요해져서요 

나중에 혼란스럽지 않을까해서 List Item 에서 divided 이지만 구분선을 생략 할 수 있는 조건을 추가해주고자했어요

## 사용 및 테스트 방법
DOCS

## 스크린샷
![image](https://user-images.githubusercontent.com/27910236/70101041-12c45f00-1677-11ea-9d1c-13d6ef21ed12.png)


## 이 PR의 유형
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
