### PR TITLE
[history-context] push, replace, back 메서드 호출시 Promise 를 반환합니다.

### DIFF
--- a/packages/react-contexts/src/history-context.tsx
+++ b/packages/react-contexts/src/history-context.tsx
@@ -106,7 +106,9 @@ export function HistoryProvider({
       setUriHash(hash)
 
       if (useRouter) {
-        Router.replace(generateUrl({ hash }, Router.asPath))
+        return Router.replace(generateUrl({ hash }, Router.asPath))
+      } else {
+        return new Promise((resolve) => resolve(true))
       }
     },
     [isAndroid],
@@ -119,7 +121,9 @@ export function HistoryProvider({
       setUriHash(hash)
 
       if (useRouter) {
-        Router.push(generateUrl({ hash }, Router.asPath))
+        return Router.push(generateUrl({ hash }, Router.asPath))
+      } else {
+        return new Promise((resolve) => resolve(true))
       }
     },
     [isAndroid],
@@ -131,7 +135,9 @@ export function HistoryProvider({
     setUriHash((HASH_HISTORIES[HASH_HISTORIES.length - 1] || {}).hash)
 
     if (useRouter) {
-      Router.back()
+      return Router.back()
+    } else {
+      return new Promise((resolve) => resolve(true))
     }
   }, [])
 


### PR DESCRIPTION
## 설명
push, replace, back 메서드 호출시 Promise 를 반환합니다.

## 변경 내역 및 배경
- This closes #279 
- `useRouter: true` 이면, push, replace, back 시 next/router 메서드를 사용하는데, next 에서 반환하는것과 같은 Promise 를 history-context 에서도 반환하게 합니다.
- `useRouter: false` 이면, `new Promise((resolve) => resolve(true))` 를 반환합니다. (`Promise<boolean>`) 타입

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
