### PR TITLE
[author] author-intro 의 line-height 지정 버그를 수정합니다.

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,4 @@
 {
-  "packages": [
-    "docs",
-    "packages/*",
-    "tests"
-  ],
+  "packages": ["docs", "packages/*", "tests"],
   "version": "1.1.4"
 }

--- a/packages/author/src/author-intro.tsx
+++ b/packages/author/src/author-intro.tsx
@@ -22,7 +22,7 @@ export default function AuthorIntro({
     return <Html dangerouslySetInnerHTML={{ __html: rawHTML }} />
   }
   return (
-    <Text alpha={0.5} size={14} line-height={1.43} margin={{ top: 21 }}>
+    <Text alpha={0.5} size={14} lineHeight={1.43} margin={{ top: 21 }}>
       {text}
     </Text>
   )


### PR DESCRIPTION
## 설명
author 의 intro 렌더링시 line-height 가 의도한대로 나오지 않던 문제를 수정합니다.

## 변경 내역 및 배경
> This fixes #308
- `<Text line-height  ...` 가 아니라 `<Text lineHeight ...` 로 지정해야합니다.

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
