### PR TITLE
[image-carousel][ad-banners] @egjs/flicking 의 버전을 3.4.0 으로 고정합니다.

### DIFF
--- a/packages/ad-banners/package.json
+++ b/packages/ad-banners/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@egjs/flicking": "3.4.0",
-    "@egjs/react-flicking": "^3.1.1",
+    "@egjs/react-flicking": "3.1.0",
     "@titicaca/core-elements": "^1.2.0",
     "@titicaca/intersection-observer": "^1.2.0",
     "@titicaca/react-contexts": "^1.2.0",

--- a/packages/image-carousel/package.json
+++ b/packages/image-carousel/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://github.com/titicacadev/triple-frontend#readme",
   "dependencies": {
     "@egjs/flicking": "3.4.0",
-    "@egjs/react-flicking": "^3.0.0",
+    "@egjs/react-flicking": "3.1.0",
     "@titicaca/core-elements": "^1.2.0"
   }
 }


### PR DESCRIPTION
## 설명
`image-carousel` 과 `ad-banners` 의 deps 인 `@egjs/react-flicking` 의 버전을 고정합니다.

## 변경 내역 및 배경
> This closes issue #315 
- 최근 업데이트된 버전의 `@egjs/flicking` 에 문제가 발견되어서 구버전을 사용하고자 합니다.
- 본래 의존하고 있던 `@egjs/react-flicking` 은 항상 최신 `3.x.x` 버전의 `@egjs/flicking` 을 의존하고 있으므로, `@egjs/flicking@3.1.0`, `@egjs/flicking@3.4.0` 으로 사용 버전을 고정합니다.

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [x] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
