### PR TITLE
docs: NPM 그룹계정 초대 및 디펜던시 설치 전 필요사항 설명추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Slack `@frontend` 그룹, `#triple-web-dev` 채널 및 GitHub `@frontend` 팀
 $ git clone git@github.com:titicacadev/triple-frontend.git && cd triple-frontend
 ```
 
+NPM 그룹의 본인 계정으로 로그인 합니다:
+
+```sh
+$ npm login
+Username: dev-fe
+Password: ********
+```
+
 디펜던시를 설치합니다:
 
 ```sh


### PR DESCRIPTION
triple-frontend 프로젝트 로컬 개발 환경 셋팅 시 @titicaca npm 계정 필요사항 설명 추가

## 설명
triple-frontend 프로젝트 로컬 개발 환경 셋팅 시 @titicaca npm 계정이 기본적으로 필요해서 관련한 부연 설명을 추가하였습니다.

## 변경 내역 및 배경

보통 npm 그룹 초대를 받겠지만 혹시 이 부분이 누락될 경우 문서를 통에 인지할 수 있으면 좋을것 같습니다.

## 사용 및 테스트 방법

## 스크린샷

## 이 PR의 유형
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
