### PR TITLE
Annotated tag 대신 lightweight tag를 생성하던 문제 해결

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -46,6 +46,13 @@ jobs:
     - name: Tag with annotation
       run: |
         VERSION="v$(node -p -e 'require(`./lerna.json`).version')"
+        curl -f --request POST --url https://api.github.com/repos/${{ github.repository }}/git/tags \
+          -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+          -H 'Content-Type: application/json' \
+          -d "{\"tag\":\"${VERSION}\",\"message\":\"${VERSION}\",\"object\":\"${GITHUB_SHA}\",\"type\":\"commit\"}" > tag.json
+
+        TAG_SHA="$(node -p -e 'require(`./tag.json`).sha')"
+
         curl -s -o /dev/null -I -w "%{http_code}" \
           --url https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${VERSION} \
           -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' > status
@@ -54,15 +61,10 @@ jobs:
           curl -f --request PATCH --url https://api.github.com/repos/${{ github.repository }}/git/refs/tags/${VERSION} \
             -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
             -H 'Content-Type: application/json' \
-            -d "{\"force\":true,\"sha\":\"${GITHUB_SHA}\"}"
+            -d "{\"force\":true,\"sha\":\"${TAG_SHA}\"}"
         else
           curl -f --request POST --url https://api.github.com/repos/${{ github.repository }}/git/refs \
             -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
             -H 'Content-Type: application/json' \
-            -d "{\"ref\":\"refs/tags/${VERSION}\",\"sha\":\"${GITHUB_SHA}\"}"
+            -d "{\"ref\":\"refs/tags/${VERSION}\",\"sha\":\"${TAG_SHA}\"}"
         fi
-
-        curl -f --request POST --url https://api.github.com/repos/${{ github.repository }}/git/tags \
-          -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
-          -H 'Content-Type: application/json' \
-          -d "{\"tag\":\"${VERSION}\",\"message\":\"${VERSION}\",\"object\":\"${GITHUB_SHA}\",\"type\":\"commit\"}"


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
Git ref를 생성할 때 잘못된 SHA 시그니쳐를 사용하고 있었어요. Annotated tag 대신 lightweight tag를 만들어내는 문제가 있었습니다.

## 변경 내역 및 배경
  - Tag creation API의 응답으로 나오는 SHA를 파싱해서 ref 생성에 사용했어야 하는데, commit SHA로 ref를 생성해오고 있었어요. 이 때문에 항상 lightweight tag를 만들어내고 있었네요.

## 사용 및 테스트 방법
다음 배포부터 보실 수 있을 겝니다..

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.