### PR TITLE
search 패키지에 strict 옵션 추가

### DIFF
--- a/packages/search/src/index.tsx
+++ b/packages/search/src/index.tsx
@@ -64,7 +64,10 @@ export default function FullScreenSearchView({
   const contentsDivRef = useRef<HTMLDivElement>(null)
 
   const isControlledInput = typeof controlledKeyword !== 'undefined'
-  const keyword = isControlledInput ? controlledKeyword : uncontrolledKeyword
+  const keyword =
+    typeof controlledKeyword !== 'undefined'
+      ? controlledKeyword
+      : uncontrolledKeyword
   const setKeyword = isControlledInput
     ? onInputChange
     : onUncontrolledKeywordChange

--- a/packages/search/tsconfig.json
+++ b/packages/search/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "./lib",
     "baseUrl": ".",
     "rootDir": "src",
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "strict": true
   },
   "include": ["./src"],
   "exclude": ["node_modules", "lib"]


### PR DESCRIPTION


<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
> Related to #352 

search 패키지에 strict 옵션을 추가하고 이에 따른 컴파일 에러를 제거합니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
컴파일러가 const 로 타입 여부를 narrowing down 할 수 없기 때문에 undefined 검사를 두번 했습니다. microsoft/TypeScript#12184
