### PR TITLE
image-carousel 패키지에 strict 옵션 추가

### DIFF
--- a/packages/image-carousel/src/carousel.tsx
+++ b/packages/image-carousel/src/carousel.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react'
 import styled from 'styled-components'
-import { FlickingEvent } from '@egjs/flicking'
+import { FlickingEvent, FlickingOptions } from '@egjs/flicking'
 import Flicking, { FlickingProps } from '@egjs/react-flicking'
 import { Container, MarginPadding } from '@titicaca/core-elements'
 
-export interface CarouselProps extends Partial<FlickingProps> {
-  margin: MarginPadding
-  borderRadius: number
-  pageLabelRenderer: (props: { currentIndex: number }) => JSX.Element
-  children: React.ReactNode
+export interface CarouselProps
+  extends Partial<FlickingProps & FlickingOptions> {
+  margin?: MarginPadding
+  borderRadius?: number
+  pageLabelRenderer: (params: { currentIndex: number }) => React.ReactNode
 }
 
 const CarouselContainer = styled(Container)`
@@ -26,9 +26,10 @@ const TopRightControl = styled.div`
 `
 
 export default class Carousel extends React.PureComponent<
-  Partial<CarouselProps>
+  React.PropsWithChildren<CarouselProps>,
+  { currentIndex: number }
 > {
-  static defaultProps: Partial<CarouselProps> = {
+  static defaultProps: Partial<Carousel['props']> = {
     zIndex: 1,
     defaultIndex: 0,
     autoResize: true,
@@ -67,7 +68,7 @@ export default class Carousel extends React.PureComponent<
     onMoveEnd && onMoveEnd(e)
   }
 
-  get flickingProps() {
+  get flickingProps(): Partial<FlickingProps & FlickingOptions> {
     const {
       zIndex,
       defaultIndex,
@@ -93,7 +94,9 @@ export default class Carousel extends React.PureComponent<
 
   render() {
     const { margin, borderRadius, pageLabelRenderer, children } = this.props
-    const PageLabel = ({ currentIndex }) => {
+    const PageLabel: React.ComponentType<{ currentIndex: number }> = ({
+      currentIndex,
+    }) => {
       const Label = pageLabelRenderer({ currentIndex })
 
       return Label ? <TopRightControl>{Label}</TopRightControl> : null

--- a/packages/image-carousel/src/index.tsx
+++ b/packages/image-carousel/src/index.tsx
@@ -3,6 +3,17 @@ import styled from 'styled-components'
 import Carousel, { CarouselProps } from './carousel'
 import { Image, GlobalSizes } from '@titicaca/core-elements'
 
+interface ImageEntity {
+  frame: GlobalSizes
+  size: GlobalSizes
+  sizes: {
+    large: { url: string }
+  }
+  sourceUrl?: string
+  title?: string
+  description?: string
+}
+
 const PageLabelText = styled.div`
   font-size: 12px;
   font-weight: bold;
@@ -21,25 +32,25 @@ export interface RendererProps {
   totalCount: number
 }
 
-interface ImageCarouselProps extends Partial<CarouselProps> {
-  size: GlobalSizes
-  frame: GlobalSizes
-  images: any[]
-  ImageSource: string
-  onImageClick: (e?: React.SyntheticEvent, image?: any) => void
-  showMoreRenderer: (props: RendererProps) => JSX.Element
-  pageLabelRenderer: (props: RendererProps) => JSX.Element
+interface ImageCarouselProps extends Omit<CarouselProps, 'pageLabelRenderer'> {
+  images: ImageEntity[]
+  size?: GlobalSizes
+  frame?: GlobalSizes
+  ImageSource?: string
+  onImageClick?: (e?: React.SyntheticEvent, image?: ImageEntity) => void
+  showMoreRenderer?: (params: RendererProps) => React.ReactNode
+  pageLabelRenderer?: (params: RendererProps) => React.ReactNode
   displayedTotalCount?: number
 }
 
 export default class ImageCarousel extends React.PureComponent<
-  Partial<ImageCarouselProps>
+  ImageCarouselProps
 > {
-  static defaultProps = {
+  static defaultProps: Partial<ImageCarousel['props']> = {
     pageLabelRenderer: (props) => PageLabel(props),
   }
 
-  get carouselProps() {
+  get carouselProps(): CarouselProps {
     const {
       margin,
       borderRadius,
@@ -64,7 +75,9 @@ export default class ImageCarousel extends React.PureComponent<
       onMove,
       onMoveEnd,
       pageLabelRenderer: ({ currentIndex }) =>
-        pageLabelRenderer({
+        // HACK: defaultProps로 지정해주었기 때문에 존재가 보장됨
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        pageLabelRenderer!({
           currentIndex,
           totalCount,
         }) || null,

--- a/packages/image-carousel/tsconfig.json
+++ b/packages/image-carousel/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "./lib",
     "baseUrl": ".",
     "rootDir": "src",
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "strict": true
   },
   "include": ["./src"],
   "exclude": ["node_modules", "lib"]


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
> Related to #352

image-carousel 패키지에 strict 옵션을 추가하고 뒤따르는 컴파일 에러를 제거합니다.
타입 정의가 모호한 부분도 구체적으로 작성했습니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
### 주요 변경 사항

- Flicking 컴포넌트에 들어가는 prop 형식을 FlickingProps + Flicking 옵션으로 설정했습니다.
- Carousel의 state 형식을 지정했습니다.
- ImageEntity(이미지 데이터) 형식을 정의했습니다.
- defaultProp을 정의한 prop의 null checking을 건너뜁니다.

### 기타

- `totalCount` 변수 위치 변경 6be7bf0
