### PR TITLE
잘못된 input type 을 재정의합니다

### DIFF
--- a/packages/core-elements/src/elements/input.tsx
+++ b/packages/core-elements/src/elements/input.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import InputMask from 'react-input-mask'
+import InputMask, { MaskOptions } from 'react-input-mask'
 import styled, { css } from 'styled-components'
 import { withField } from '../utils/form-field'
 import { GetGlobalColor } from '../commons'
@@ -43,13 +43,12 @@ const BaseInput = styled(InputMask)<{ focused?: string; error?: string }>`
     `};
 `
 
-type HTMLInputElementProps = React.InputHTMLAttributes<HTMLInputElement>
+type HTMLInputElementProps = React.InputHTMLAttributes<HTMLInputElement> &
+  MaskOptions
 
 interface InputProps extends Omit<HTMLInputElementProps, 'onChange'> {
   id?: string
   error?: string
-  mask?: string
-  maskChar?: string | null
   focused?: string
   onChange?: (e: React.SyntheticEvent, value: string) => any
   onBlur?: (e: React.FocusEvent<any>) => any
@@ -74,7 +73,7 @@ function Input({
       value={value}
       error={error}
       placeholder={placeholder}
-      mask={mask || '*'}
+      mask={mask}
       maskChar={maskChar}
       focused={focused}
       onBlur={onBlur}


### PR DESCRIPTION
## 설명

잘못된 input type 을 재정의합니다

## 변경 내역 및 배경
mask 에 대한 타입과 default value 가 올바르지 않아 input 의 값이 제대로 입력되지 않는 문제가
있었습니다. 

## 사용 및 테스트 방법
DOCS

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
