### PR TITLE
pricing fixed label 의 기본 색상을 변경합니다

### DIFF
--- a/packages/pricing/src/index.tsx
+++ b/packages/pricing/src/index.tsx
@@ -245,7 +245,7 @@ function FixedPricing({
 }: FixedPricingProps) {
   const pricingLabel = label ? (
     typeof label === 'string' ? (
-      <Text color="blue" size="mini">
+      <Text color="gray" alpha={0.5} size="mini">
         {label}
       </Text>
     ) : (


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

pricing 의 구조는 tna, hotel 이 같습니다.
하지만 최종금액 블라블라 부분은 tna 는 blue, hotel은  gray 을 사용하고있는데 
tna 의 변화를 주고싶지 않아 호텔에서는 커스텀하게 사용하고자하였으나 ..

https://titicaca.slack.com/archives/C7XGZTMFX/p1579503150014500

이런 문제가 있어 .. tna 는 깨질 여지가 없기 때문에 호텔을 default 로 두고 tna 를 고쳐쓰는 방향을 선택해야 될 것 같습니다 ..

아마 tna 도 후에는 호텔같은 스타일로 변할 것이라 .. 그렇게 믿고 일단은 커스텀 태그를 받는 것으로 ..

![image](https://user-images.githubusercontent.com/27910236/72707076-f0dd5800-3ba2-11ea-856d-631b3e226ddd.png)

## 변경 내역 및 배경
- fixed label 의 기본 스타일을 호텔로 맞춥니다

## 사용 및 테스트 방법
- DOCS

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [x] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
