### PR TITLE
[core-elements > accordion] 🐛🏷 Content 와 Folded 의 리턴 방식을 변경합니다.

### DIFF
--- a/packages/core-elements/src/elements/accordion.tsx
+++ b/packages/core-elements/src/elements/accordion.tsx
@@ -36,14 +36,14 @@ function Content({
   active,
   children,
 }: React.PropsWithChildren<{ active: boolean }>) {
-  return active && <Container margin={{ top: 5 }}>{children}</Container>
+  return active ? <Container margin={{ top: 5 }}>{children}</Container> : null
 }
 
 function Folded({
   active,
   children,
 }: React.PropsWithChildren<{ active: boolean }>) {
-  return !active && <Container margin={{ top: 5 }}>{children}</Container>
+  return !active ? <Container margin={{ top: 5 }}>{children}</Container> : null
 }
 
 export default class Accordion extends React.PureComponent<


### PR DESCRIPTION

## 설명
> This fix #431 

## 변경 내역 및 배경
타입스크립트를 strict 모드로 컴파일하게되면서 발생한 Accordion.Content 와 Accordion.Folded 의 declaration 오류를 수정합니다.

## 사용 및 테스트 방법
- https://console.cloud.google.com/cloud-build/builds/361c7150-311b-4489-b7c1-88d19c3000b1?project=titicaca-ci 이 빌드 오류의 원인 참조
   - `Accordion.Folded` 의 타입이 `boolean | JSX.Element` 여서 오류가 발생합니다.

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [x] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
