### PR TITLE
categories 가 없을 경우 방어코드를 추가합니다

### DIFF
--- a/packages/poi-list-elements/src/index.tsx
+++ b/packages/poi-list-elements/src/index.tsx
@@ -29,7 +29,7 @@ interface POI {
       local: Name
     }
     areas: { name: string }[]
-    categories: { name: string }[] | null
+    categories?: { name: string }[]
     comment?: string
     reviewsCount?: number
     scrapsCount?: number
@@ -242,7 +242,7 @@ class ExtendedPoiListElement extends React.PureComponent<
             names,
             image,
             areas,
-            categories,
+            categories = [],
             comment,
             reviewsCount: rawReviewsCount,
             scrapsCount: initialScrapsCount,
@@ -262,7 +262,8 @@ class ExtendedPoiListElement extends React.PureComponent<
     } = this
 
     const [area] = areas
-    const [category = ''] = categories || []
+    const [category] = categories
+
     const { state: scraped, count: scrapsCount } = deriveCurrentStateAndCount({
       initialState: initialScraped,
       initialCount: initialScrapsCount,


### PR DESCRIPTION
## 설명

categories 가 없을 경우 방어코드를 추가합니다

## 변경 내역 및 배경
호텔의 경우 categories가 null 로 내려오게되는데 이에 따른 방어로직이 없어서 터지고있었습니당

## 사용 및 테스트 방법
DOCS

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
