### PR TITLE
[Search] 🗑안드로이드 환경에서, 팝업에 search를 사용할때, 상단 navbar가 고정이 안되는 문제를 수정합니다.

### DIFF
--- a/packages/core-elements/src/elements/search-navbar.tsx
+++ b/packages/core-elements/src/elements/search-navbar.tsx
@@ -19,7 +19,6 @@ const InputText = styled.input`
 const MainNavbarFrame = styled(Navbar.NavbarFrame)`
   height: 58px;
   padding: 12px;
-  position: fixed;
 `
 
 const Back = styled(Navbar.Item)`

--- a/packages/search/src/index.tsx
+++ b/packages/search/src/index.tsx
@@ -115,7 +115,7 @@ export default function FullScreenSearchView({
         }}
         onKeyUp={(e: KeyboardEvent) => handleKeyUp(e.keyCode)}
       />
-      <ContentsContainer margin={{ top: 58 }} isIOS={isIOS} userSelect="none">
+      <ContentsContainer isIOS={isIOS} userSelect="none">
         <div ref={contentsDivRef}>{children}</div>
       </ContentsContainer>
     </>


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
Search navbar와 contents를 감싸는 Container를 삭제합니다.

## 변경 내역 및 배경
this closes [TAQ-114](https://titicaca.atlassian.net/jira/software/projects/TAQ/boards/52?assignee=5cde847a00d9750e45e22d3d&selectedIssue=TAQ-114)
안드로이드 환경에서만 상단 Navbar가 고정이 안되는 문제가 있습니다.
그래서 navbar와 contents를 감싸는 Container를 삭제합니다.
fixed도 삭제합니다.

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

(버그 동작)
![Feb-03-2020 14-34-56](https://user-images.githubusercontent.com/39641309/73628049-67458400-4692-11ea-8b47-eaf32b90da50.gif)


## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
