### PR TITLE
[BookingCompletion] 제목을 옵셔널하게 받을 수 있도록 설정합니다.

### DIFF
--- a/packages/booking-completion/src/index.tsx
+++ b/packages/booking-completion/src/index.tsx
@@ -31,7 +31,7 @@ function BookingCompletion({
   listButtonLabel,
 }: BookingCompletionProps) {
   return (
-    <Container>
+    <>
       <Container margin={{ bottom: 12 }}>
         <Text size={28} bold>
           {title || `예약이 \n 접수되었습니다.`}
@@ -79,7 +79,7 @@ function BookingCompletion({
           </Button.Group>
         </Container>
       ) : null}
-    </Container>
+    </>
   )
 }
 


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
제목을 옵셔널하게 받을 수 있도록 설정합니다.

## 변경 내역 및 배경
this closes #465

- 제목을 옵셔널하게 받을 수 있도록 설정합니다. (항공의 경우 제목이 다릅니다.)
- 상단 padding을 삭제하여 사용하는 측에서 적절히 처리하도록 합니다. (항공의 경우 해당 컴포넌트를 중앙 정렬해야합니다)

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
