### PR TITLE
[core-elements] Navbar의 배경색 스타일에서 alpha가 없는 rgba를 사용하는 것을 수정합니다.

### DIFF
--- a/packages/core-elements/src/elements/navbar.tsx
+++ b/packages/core-elements/src/elements/navbar.tsx
@@ -8,7 +8,7 @@ const NavbarFrame = styled.div<{
   backgroundColor?: string | GlobalColors
 }>`
   background-color: ${({ backgroundColor = 'white' }) =>
-    `rgba(${GetGlobalColor(backgroundColor)})`};
+    `rgb(${GetGlobalColor(backgroundColor)})`};
   position: sticky;
   top: 0;
   left: 0;


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`rgba()`인데 alpha 값이 없던 스타일을 수정합니다.

## 변경 내역 및 배경

iOS 11에서 `Navbar` 스타일이 깨지고 있었습니다.

## 사용 및 테스트 방법
N/A

## 스크린샷

AS-IS 붙여둡니다.

![IMG_1215B6F545B0-1](https://user-images.githubusercontent.com/712260/74416018-cc198f00-4e87-11ea-9f37-2352a21415cf.jpeg)



## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
