### PR TITLE
basePrice, salePrice 가격이 같을 때 할인 전 가격 노출하지 않도록 수정, 할인 전 가격 단위 prop 추가

### DIFF
--- a/docs/stories/pricing.stories.js
+++ b/docs/stories/pricing.stories.js
@@ -35,6 +35,7 @@ storiesOf('Pricing', module)
     return (
       <Pricing
         basePrice={number('basePrice', 30000)}
+        basePriceUnit={text('basePriceUnit', undefined)}
         pricingNote={text('문구', '1박, 세금포함')}
         salePrice={25000}
         label={useStringLabel ? '트리플가' : <PricingLabel />}

--- a/packages/pricing/src/index.tsx
+++ b/packages/pricing/src/index.tsx
@@ -19,6 +19,7 @@ interface RegularPricingProps {
 
 interface RichPricingProps {
   basePrice?: BasePrice
+  basePriceUnit?: string
   salePrice: number
   label?: React.ReactNode
   pricingNote?: string
@@ -132,6 +133,7 @@ function RichPricing({
   label,
   pricingNote,
   description,
+  basePriceUnit,
 }: RichPricingProps) {
   const pricingDescription = description ? (
     typeof description === 'string' ? (
@@ -161,7 +163,8 @@ function RichPricing({
 
             {hasBasePrice && (
               <Text alpha={0.3} size="mini" strikethrough inline>
-                {formatNumber(basePrice)}원
+                {formatNumber(basePrice)}
+                {basePriceUnit}
               </Text>
             )}
           </Container>
@@ -202,11 +205,12 @@ export default function Pricing(props: PricingProps) {
   const { salePrice } = props
 
   if (props.rich) {
-    const { basePrice, label, pricingNote, description } = props
+    const { basePrice, label, pricingNote, description, basePriceUnit } = props
 
     return (
       <RichPricing
         basePrice={basePrice}
+        basePriceUnit={basePriceUnit}
         salePrice={salePrice}
         label={label}
         pricingNote={pricingNote}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
basePrice를 노출하는 로직을 수정하고, 할인 전 가격에 단위를 붙일 수 있게 합니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
- 할인 전 가격에 단위를 붙여주는 basePriceUnit prop 추가 
- `basePrice`가 `salePrice`보다 클 때만 할인 전 가격 노출하도록 로직 수정

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->
docs에서 basePrice를 salePrice와 같게 설정
docs에서 basePriceUnit을 설정

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
기능 추가

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
