### PR TITLE
[core-elements] `<SearchNavBar />` 컴포넌트에서 누락된 `onKeyUp` props를 추가합니다.

### DIFF
--- a/docs/stories/navbar.stories.js
+++ b/docs/stories/navbar.stories.js
@@ -118,6 +118,7 @@ storiesOf('Navbar', module)
       onBackClick={action('onBackClick')}
       onDeleteClick={action('onDeleteClick')}
       onInputChange={action('onInputChange')}
+      onKeyUp={action('onKeyUp')}
       onBlur={action('onBlur')}
       onFocus={action('onFocus')}
     />

--- a/packages/core-elements/src/elements/search-navbar.tsx
+++ b/packages/core-elements/src/elements/search-navbar.tsx
@@ -47,7 +47,7 @@ interface InputProps {
 
 const Input = React.forwardRef(
   (
-    { placeholder, onInputChange, onBlur, onFocus, value }: InputProps,
+    { placeholder, onInputChange, onBlur, onFocus, onKeyUp, value }: InputProps,
     ref?: React.Ref<HTMLInputElement>,
   ) => (
     <InputText
@@ -55,6 +55,7 @@ const Input = React.forwardRef(
       onChange={(e) => onInputChange && onInputChange(e, e.target.value)}
       onBlur={(e) => onBlur && onBlur(e)}
       onFocus={(e) => onFocus && onFocus(e)}
+      onKeyUp={(e) => onKeyUp && onKeyUp(e)}
       value={value}
       ref={ref}
     />
@@ -68,6 +69,7 @@ export default function SearchNavbar({
   onBackClick,
   onDeleteClick,
   onInputChange,
+  onKeyUp,
   onBlur,
   onFocus,
   value,
@@ -84,6 +86,7 @@ export default function SearchNavbar({
         placeholder={placeholder}
         onInputChange={onInputChange}
         onBlur={onBlur}
+        onKeyUp={onKeyUp}
         onFocus={onFocus}
         value={value}
         ref={inputRef}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
`<SearchNavBar />` 컴포넌트에서 인터페이스로만 onKeyUp 이 추가 되어있고 실제로는 prop으로 선언 되어있지 않은 버그를 발견하고, 수정했습니다. 
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경
`<Search />` 컴포넌트에서 `onEnter` 커스텀이벤트가 fire되지 않길래 뭐지 하고 찾다가 발견했어요 ^^;;;
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
