### PR TITLE
PoiCarouselElement 에서 부가정보를 노출 할 수 있도록 additionalInfo prop 을 추가합니다

### DIFF
--- a/docs/stories/poi-list-elements/poi.stories.js
+++ b/docs/stories/poi-list-elements/poi.stories.js
@@ -66,6 +66,9 @@ storiesOf('poi-list-elements | POI', module)
       resourceScraps={{
         [POI.id]: boolean('저장', false),
       }}
+      additionalInfo={
+        boolean('부가 정보 노출', false) ? <PricingDescription /> : null
+      }
     />
   ))
   .add('TripleDocument 리스트', () => (

--- a/packages/poi-list-elements/src/index.tsx
+++ b/packages/poi-list-elements/src/index.tsx
@@ -51,6 +51,7 @@ interface PoiCarouselElementProps {
   onScrapedChange?: ScrapChangeHandler
   resourceScraps?: ResourceScrapSet
   description?: React.ReactNode
+  additionalInfo?: React.ReactNode
 }
 
 interface CompactPoiListElementProps {
@@ -109,6 +110,7 @@ export function PoiCarouselElement({
   onScrapedChange,
   resourceScraps,
   description,
+  additionalInfo = null,
 }: PoiCarouselElementProps) {
   if (poi) {
     const {
@@ -150,6 +152,8 @@ export function PoiCarouselElement({
               onScrapedChange={onScrapedChange}
             />
           ) : null)}
+
+        {additionalInfo}
       </Carousel.Item>
     )
   }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

PoiCarouselElement 에서 부가정보를 노출 할 수 있도록 additionalInfo prop 을 추가합니다

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->


PoiCarouselElement 하단에 무언가가 들어갈 공간이 필요합니다.
(호텔은 price + @ 의 정보지만) 후에 어떤 값이 들어가게 될지 몰라
공간만 뚫어주었습니다 :) 

![image](https://user-images.githubusercontent.com/27910236/75136849-4a4c2000-5729-11ea-8fa8-14fc644e89e3.png)


## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
