### PR TITLE
[core-elements] Video 컴포넌트에 poster prop을 추가하고, playsInline 속성을 지정합니다.

### DIFF
--- a/packages/core-elements/src/elements/video/index.tsx
+++ b/packages/core-elements/src/elements/video/index.tsx
@@ -109,6 +109,7 @@ export default function Video({
       <VideoFrame
         autoPlay={autoPlay}
         loop
+        playsInline
         muted={autoPlay}
         ref={videoRef}
         poster={fallbackImageUrl}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
poster 이미지 추가 및 playsInline 설정입니다.

## 변경 내역 및 배경
  - `poster`: Preview가 첫 프레임으로 안 보이는 케이스가 있어서 필요해지네요. `<video>` 로드 전에는 background-image로 깔아둔 이미지가 보이는데, `<video>` 로드 후에는 그게 가려지게 되어요.
  - `playsInline`: iOS에서 멋대로 풀스크린에서 재생하는 케이스가 있다고 합니다.

## 사용 및 테스트 방법
Storybook/Canary

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
