### PR TITLE
[core-elements] Text에 ref를 지정할 수 있도록 합니다.

### DIFF
--- a/packages/core-elements/src/elements/text.tsx
+++ b/packages/core-elements/src/elements/text.tsx
@@ -167,17 +167,7 @@ const TextBase = styled.div<TextBaseProps>`
 `
 
 function Text({ children, ...props }: TextProps) {
-  return (
-    <TextBase {...props}>
-      {React.Children.toArray(children).map((child, i) =>
-        typeof child === 'string' ? (
-          <LineBreak key={i}>{child}</LineBreak>
-        ) : (
-          child
-        ),
-      )}
-    </TextBase>
-  )
+  return <TextBase {...props}>{ChildrenWithLineBreaks(children)}</TextBase>
 }
 
 const Html = styled(TextBase)`
@@ -232,7 +222,24 @@ function TextTitle({
   )
 }
 
+const TextWithRef = React.forwardRef<HTMLDivElement>(
+  ({ children, ...props }: TextProps, ref) => (
+    <TextBase ref={ref} {...props}>
+      {ChildrenWithLineBreaks(children)}
+    </TextBase>
+  ),
+)
+
+function ChildrenWithLineBreaks(children: React.ReactNode) {
+  return React.Children.toArray(children).map((child, i) =>
+    typeof child === 'string' ? <LineBreak key={i}>{child}</LineBreak> : child,
+  )
+}
+
+TextWithRef.displayName = 'TextWithRef'
+
 Text.Html = Html
 Text.Title = TextTitle
+Text.WithRef = TextWithRef
 
 export default Text


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
`<Text>` 엘리먼트에 `ref`를 달 수 있도록 합니다.

## 변경 내역 및 배경

content-web 작업 중에 발견했는데, 현 `LocationSegment` 구현에 title 영역의 너비에 따라 value 영역의 너비를 제어해야 하는 니즈가 있습니다.

<img width="358" alt="Screen Shot 2020-03-09 at 5 02 42 PM" src="https://user-images.githubusercontent.com/712260/77298458-4d3d2f00-6d2e-11ea-9d5a-f24d0aa81197.png">

위에서 '홈페이지' 속성에 해당하는 부분인데, '홈페이지' 속성의 값 부분이 title 길이에 따라 늘어나거나 줄어들어야 합니다.

`Text` 컴포넌트가 렌더하는 `TextBase` 컴포넌트에 ref가 붙어야 하는데, `Text` 컴포넌트에 `ref`만 전달하면 React가 그 ref를 알 수 없기 때문에 `forwardRef`를 사용해야 합니다: https://reactjs.org/docs/forwarding-refs.html

모든 `Text` 엘리먼트에 `forwardRef`를 적용하려니 퍼포먼스 임팩트가 걱정되어서, `Text.WithRef`로 ref를 사용하는 `Text`를 지정할 수 있도록 했습니다.

## 사용 및 테스트 방법
Canary!

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
