### PR TITLE
[core-elements] Text.WithRef의 타이핑 오류를 수정합니다.

### DIFF
--- a/packages/core-elements/src/elements/text.tsx
+++ b/packages/core-elements/src/elements/text.tsx
@@ -222,8 +222,8 @@ function TextTitle({
   )
 }
 
-const TextWithRef = React.forwardRef<HTMLDivElement>(
-  ({ children, ...props }: TextProps, ref) => (
+const TextWithRef = React.forwardRef<HTMLDivElement, TextProps>(
+  ({ children, ...props }, ref) => (
     <TextBase ref={ref} {...props}>
       {ChildrenWithLineBreaks(children)}
     </TextBase>


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
`Text.WithRef`를 사용하는 쪽에서 타입 오류가 발생하고 있었습니다.

Related to #593 

## 변경 내역 및 배경
props를 추가하게 되면 발생하는 타입 오류들이었는데, `React.forwardRef`의 두 번째 Generic 타입 인자가 누락된 것이 원인이었습니다.

## 사용 및 테스트 방법
Canary. 요번 건 확실하게 확인할게요 ㅠㅠ ref만 확인하고 머지했네요.

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
