### PR TITLE
[DatePicker] RangePicker에 sameFromTo 옵션을 추가합니다

### DIFF
--- a/docs/stories/date-picker/date-picker.stories.js
+++ b/docs/stories/date-picker/date-picker.stories.js
@@ -180,7 +180,7 @@ storiesOf('date-picker | DatePicker', module)
           .map((date) => new Date(date))}
         numberOfMonths={number('표시할 개월 수', 3)}
         height={text('높이', '300px')}
-        enableOneDay={boolean('enableOneDay 활성화')}
+        enableSameDay={boolean('enableSameDay 활성화')}
       />
     )
   })

--- a/packages/date-picker/src/range-picker.tsx
+++ b/packages/date-picker/src/range-picker.tsx
@@ -16,7 +16,7 @@ import PickerFrame from './picker-frame'
 const RangeContainer = styled.div<{
   height?: string
   selectedAll: boolean
-  enableOneDay?: boolean
+  enableSameDay?: boolean
 }>`
   .DayPicker {
     height: ${({ height }) => height || '395px'};
@@ -90,7 +90,7 @@ const RangeContainer = styled.div<{
     transform: translate(calc(-50% - 3px), -50%);
   }
 
-  ${({ selectedAll, enableOneDay }) =>
+  ${({ selectedAll, enableSameDay }) =>
     selectedAll &&
     css`
       .DayPicker-Day--from:before,
@@ -106,7 +106,7 @@ const RangeContainer = styled.div<{
         right: auto;
         left: 0;
       }
-      ${enableOneDay &&
+      ${enableSameDay &&
         css`
           .DayPicker-Day--from.DayPicker-Day--to:before {
             content: none;
@@ -128,7 +128,7 @@ function RangePicker({
   afterBlock,
   height,
   publicHolidays,
-  enableOneDay,
+  enableSameDay,
 }: {
   startDate: string | null
   endDate: string | null
@@ -143,7 +143,7 @@ function RangePicker({
   disabledDays?: string[]
   height?: string
   publicHolidays?: Date[]
-  enableOneDay?: boolean
+  enableSameDay?: boolean
 }) {
   const from = startDate ? moment(startDate).toDate() : null
   const to = endDate ? moment(endDate).toDate() : null
@@ -160,7 +160,7 @@ function RangePicker({
       <RangeContainer
         selectedAll={!!(startDate && endDate)}
         height={height}
-        enableOneDay={enableOneDay}
+        enableSameDay={enableSameDay}
       >
         <DayPicker
           locale="ko"
@@ -183,7 +183,7 @@ function RangePicker({
             })
 
             if (
-              !enableOneDay &&
+              !enableSameDay &&
               !isValidDate(to) &&
               moment(day)
                 .startOf('day')


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
- From과 To가 같아야할 상황이 생겼습니다

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
- https://github.com/titicacadev/triple-air-web/issues/703
- sameFromTo prop을 추가하여 같은날의 from to 선택이 가능하도록 합니다