### PR TITLE
[dev] Canary release의 preid로 PR 번호 사용

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
         SLACK_ICON_EMOJI: ':gear:'
         SLACK_COLOR: good
         SLACK_TITLE: Build WORKING
+        SLACK_MESSAGE: ${{ github.event.pull_request.title }}
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
@@ -56,6 +57,7 @@ jobs:
         SLACK_ICON_EMOJI: ':gear:'
         SLACK_COLOR: good
         SLACK_TITLE: ${{ ':tada:' }} Build SUCCESS
+        SLACK_MESSAGE: ${{ github.event.pull_request.title }}
 
     - name: Notify build and test fail to slack
       if: failure()
@@ -67,6 +69,7 @@ jobs:
         SLACK_ICON_EMOJI: ':gear:'
         SLACK_COLOR: warning
         SLACK_TITLE: ${{ ':x:' }} Build FAIL
+        SLACK_MESSAGE: ${{ github.event.pull_request.title }}
     - name: Canary Release
       run: |
         cat $GITHUB_EVENT_PATH > event.json


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
Canary release의 preid로 PR 번호를 사용하고, CI를 PR 이벤트 발생 시에만 수행합니다.

This fixes #322 

## 변경 내역 및 배경
preid 충돌이 빈번하게 발생중이고, #619 정책을 적용하면 빈도가 더 늘어날 것이 예상됩니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
