### PR TITLE
ImagesContext에 type-definitions 적용

### DIFF
--- a/packages/react-contexts/package.json
+++ b/packages/react-contexts/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@titicaca/triple-web-to-native-interfaces": "^1.0.0",
+    "@titicaca/type-definitions": "^1.13.1",
     "@titicaca/view-utilities": "^1.13.1",
     "humps": "^2.0.1",
     "qs": "^6.7.0",

--- a/packages/react-contexts/src/images-context/index.tsx
+++ b/packages/react-contexts/src/images-context/index.tsx
@@ -5,8 +5,8 @@ import React, {
   ComponentType,
   useReducer,
 } from 'react'
+import { ImageMeta } from '@titicaca/type-definitions'
 
-import { Image } from './model'
 import reducer, {
   loadImagesRequest,
   loadImagesSuccess,
@@ -14,7 +14,7 @@ import reducer, {
 } from './reducer'
 
 interface ImagesContext {
-  images: Image[]
+  images: ImageMeta[]
   total: number
   actions: {
     fetch: (cb?: () => void) => Promise<void>
@@ -31,7 +31,7 @@ interface ImagesProviderProps {
     id: string
     type: 'attraction' | 'restaurant' | 'hotel'
   }
-  images?: Image[]
+  images?: ImageMeta[]
 }
 
 const Context = React.createContext<ImagesContext>({

--- a/packages/react-contexts/src/images-context/model.ts
+++ b/packages/react-contexts/src/images-context/model.ts
@@ -1,8 +1,0 @@
-export interface Image {
-  id: string
-  sizes: {
-    [key: string]: {
-      url: string
-    }
-  }
-}

--- a/packages/react-contexts/src/images-context/reducer.ts
+++ b/packages/react-contexts/src/images-context/reducer.ts
@@ -1,8 +1,8 @@
-import { Image } from './model'
+import { ImageMeta } from '@titicaca/type-definitions'
 
 interface ImagesState {
   loading: boolean
-  images: Image[]
+  images: ImageMeta[]
   total: number
   hasMore: boolean
 }
@@ -17,7 +17,10 @@ export function loadImagesRequest() {
   } as const
 }
 
-export function loadImagesSuccess(payload: { images: Image[]; total: number }) {
+export function loadImagesSuccess(payload: {
+  images: ImageMeta[]
+  total: number
+}) {
   return {
     type: LOAD_IMAGES_SUCCESS,
     payload,


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
ImagesContext에 공통 타입 정의를 적용합니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
공통 타입 ImageMeta가 imagesContext랑 호환이 안되는 문제가 있었습니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
