### PR TITLE
[location-properties] copy action 핸들러를 추가합니다.

### DIFF
--- a/packages/location-properties/src/location-properties.tsx
+++ b/packages/location-properties/src/location-properties.tsx
@@ -102,7 +102,7 @@ export default function LocationProperties({
   const value =
     isActionSheetOpen &&
     properties.get(uriHash.replace(`${ACTION_SHEET_PREFIX}.`, ''))?.value
-  const handleClick = useCallback(() => onCopy(value), [onCopy, value])
+  const handleClick = useCallback(() => value && onCopy(value), [onCopy, value])
 
   return (
     <>

--- a/packages/location-properties/src/property-item.tsx
+++ b/packages/location-properties/src/property-item.tsx
@@ -10,7 +10,7 @@ export const ACTION_SHEET_PREFIX = 'location-properties.copy-action-sheet'
 
 export interface PropertyItemProps {
   title: string
-  value?: string | React.ReactNode
+  value?: string
   singleLine?: boolean
   identifier: string
   eventActionFragment?: string


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`LocationProperties` 컴포넌트에 표시되는 속성을 롱탭하면 값을 복사할 수 있는 액션시트를 보여줍니다. 이 액션시트의 복사 액션을 선택했을 때 copy 동작을 처리하는 핸들러를 노출합니다.

## 변경 내역 및 배경
공통 컴포넌트 작업할 때 빼먹었네요. 액션시트가 보이는 것 까지만 확인하고 실제 액션은 생각도 못했습니다 ㅠㅠ

## 사용 및 테스트 방법
Canary+Dev 배포로 해볼게요.

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
