### PR TITLE
[core-elements] List divider의 default style을 수정합니다.

### DIFF
--- a/packages/core-elements/src/elements/list.tsx
+++ b/packages/core-elements/src/elements/list.tsx
@@ -29,8 +29,8 @@ const ListBase = styled.ul<ListBaseProp & DividerOptions>`
   ${marginMixin}
 
   li:not(:first-child) {
-    ${({ verticalGap = 0 }) => css`
-      margin-top: ${verticalGap}px;
+    ${({ divided, verticalGap = 0 }) => css`
+      margin-top: ${divided ? verticalGap / 2 : verticalGap}px;
     `};
   }
 


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
List divider의 default style을 수정합니다.

Related to #514 #518 
See also: https://github.com/titicacadev/triple-hotels-web/issues/1212

## 변경 내역 및 배경

  - Divider 1개당 1개의 `verticalGap`이 적용되어야 하는데, 2개가 적용되고 있었습니다.
  - Divider의 기본 컬러를 `#efefef`로 수정합니다. 기존에 이용하던 HR1/HR3의 기본 컬러와 같은 값입니다.

## 사용 및 테스트 방법

docs, canary

## 스크린샷

AS-IS
<img width="729" alt="Screen Shot 2020-04-17 at 9 09 52 AM" src="https://user-images.githubusercontent.com/712260/79518213-76ca4b80-808b-11ea-9b22-305eccf664d8.png">

TO-BE
<img width="711" alt="Screen Shot 2020-04-17 at 9 14 11 AM" src="https://user-images.githubusercontent.com/712260/79518448-112a8f00-808c-11ea-8274-9d00d9572c53.png">


## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
