### PR TITLE
[social-reviews] Divider를 바로잡습니다.

### DIFF
--- a/packages/social-reviews/src/index.tsx
+++ b/packages/social-reviews/src/index.tsx
@@ -36,7 +36,7 @@ export default function SocialReviews({
   return (
     <Section anchor="external-links" {...props}>
       <H1>{t('common:externalLinks', '소셜 리뷰')}</H1>
-      <List divided margin={{ top: 10 }}>
+      <List divided clearing margin={{ top: 10 }}>
         {socialReviews.map(
           ({ imageUrl, publisher, title, url }: SocialReview, i) => (
             <SocialReviewEntry
@@ -51,7 +51,7 @@ export default function SocialReviews({
                 floated="right"
                 width={60}
                 margin={{ left: 20 }}
-                padding={{ top: 20 }}
+                padding={{ top: 20, bottom: 20 }}
               >
                 <Image src={imageUrl} frame="big" borderRadius={4} />
               </Container>


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

#662 에서 divider의 기본 색을 되찾아(?) 주면서, 그동안 숨겨져있던 문제가 발견되었습니다.

## 변경 내역 및 배경
Divider 처리를 위해 social-reviews 컴포넌트 스타일을 일부 수정합니다.

## 사용 및 테스트 방법
Docs/Canary

## 스크린샷
<img width="410" alt="Screen Shot 2020-04-17 at 3 45 20 PM" src="https://user-images.githubusercontent.com/712260/79540058-7600dc00-80c2-11ea-9256-d1bd54bc7695.png">

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
