### PR TITLE
[core-elements] List 하위 li에 적용되는 스타일은 direct children에만 영향이 있도록 합니다.

### DIFF
--- a/packages/core-elements/src/elements/list.tsx
+++ b/packages/core-elements/src/elements/list.tsx
@@ -28,7 +28,7 @@ const ListBase = styled.ul<ListBaseProp & DividerOptions>`
 
   ${marginMixin}
 
-  li:not(:first-child) {
+  > li:not(:first-child) {
     ${({ divided, verticalGap = 0 }) => css`
       margin-top: ${divided ? verticalGap / 2 : verticalGap}px;
     `};
@@ -45,7 +45,7 @@ const ListBase = styled.ul<ListBaseProp & DividerOptions>`
     css`
       ${clearing &&
         css`
-          li:after {
+          > li:after {
             content: '';
             display: block;
             clear: both;
@@ -53,7 +53,7 @@ const ListBase = styled.ul<ListBaseProp & DividerOptions>`
         `}
       ${divided
         ? css`
-            li:not(:last-child):after {
+            > li:not(:last-child):after {
               content: '';
               display: block;
               height: 0;
@@ -64,7 +64,7 @@ const ListBase = styled.ul<ListBaseProp & DividerOptions>`
           `
         : !clearing &&
           css`
-            li:not(:last-child):after {
+            > li:not(:last-child):after {
               display: none;
             }
           `}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
`List` 바로 하위에 위치하는 `List.Item`/`li` 컴포넌트에만 스타일을 적용합니다.

## 변경 내역 및 배경
호텔에 포함되는 일부 `TripleDocument` 내용에 `li` 태그가 올 수 있습니다. 해당 팝업 바깥쪽에 위치한 `<List>` 컴포넌트의 스타일시트에 영향을 받아 이 태그들 사이에도 divider가 생기게 됩니다.


## 사용 및 테스트 방법
Canary

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
