### PR TITLE
[nearby-pois] 맛집 hasMore 정보가 제대로 반영되지 않던 문제를 수정합니다.

### DIFF
--- a/packages/nearby-pois/src/nearby-pois.tsx
+++ b/packages/nearby-pois/src/nearby-pois.tsx
@@ -94,7 +94,7 @@ export default function NearbyPois({
         appendPois({
           type: 'restaurant',
           pois: restaurants,
-          hasMore: attractions.length === DEFAULT_PAGE_SIZE,
+          hasMore: restaurants.length === DEFAULT_PAGE_SIZE,
         }),
       )
     }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
이근처장소 첫 로딩 시 맛집의 `hasMore` 정보가 attraction의 것으로 들어가고 있었습니다.

## 변경 내역 및 배경
오타... 정신차리겠습니다.

## 사용 및 테스트 방법
Canary

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
