### PR TITLE
fix: getColor 의 alpha 소수점을 2 자리까지 허용합니다

### DIFF
--- a/packages/color-palette/package.json
+++ b/packages/color-palette/package.json
@@ -7,11 +7,19 @@
   "files": [
     "lib"
   ],
+  "scripts": {
+    "test": "mocha --require ts-node/register ./src/**/*.spec.ts"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
+  },
+  "devDependencies": {
+    "mocha": "^6.2.2",
+    "@types/mocha": "^5.2.7",
+    "ts-node": "^8.4.1"
   }
 }

--- a/packages/color-palette/src/get-color.spec.ts
+++ b/packages/color-palette/src/get-color.spec.ts
@@ -1,0 +1,19 @@
+import assert from 'assert'
+
+import { describe, it } from 'mocha'
+
+import { getColor } from './get-color'
+
+describe('getColor remove to rgba', () => {
+  it('getColor(gray20) => 58, 58, 58, 0.02', () => {
+    assert.strictEqual(getColor('gray20'), '58, 58, 58, 0.02')
+  })
+
+  it('getColor(gray50) => 58, 58, 58, 0.05', () => {
+    assert.strictEqual(getColor('gray50'), '58, 58, 58, 0.05')
+  })
+
+  it('getColor(emerald) => 11, 208, 153, 1', () => {
+    assert.strictEqual(getColor('emerald'), '11, 208, 153, 1')
+  })
+})

--- a/packages/color-palette/src/get-color.ts
+++ b/packages/color-palette/src/get-color.ts
@@ -4,7 +4,7 @@ export type Color = keyof typeof ColorSet
 
 export function getColor(color: Color | string): string {
   return (ColorSet[color as Color] ?? color).replace(
-    /^rgba\(((,?\s*\d+){3}(,?\s*\d.?\d?){1}).+$/,
+    /^rgba\(((,?\s*\d+){3}(,?\s*\d.?\d?){2}).+$/,
     '$1',
   )
 }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

fix: getColor 의 alpha 소수점을 2 자리까지 허용합니다



## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
0.05, 0.01 과 같은 알파값이 의도와 다르게 짤리는 문제가 있었습니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
