### PR TITLE
[common] Declarations 빌드 시 incremental flag 사용

### DIFF
--- a/build-watch.js
+++ b/build-watch.js
@@ -4,7 +4,7 @@ const debounce = require('lodash.debounce')
 
 const BUILD_RESOURCES =
   'BABEL_ENV=build babel --root-mode upward src --out-dir lib --source-maps --extensions .ts,.tsx,.js --no-comments'
-const BUILD_DECLARATIONS = 'tsc'
+const BUILD_DECLARATIONS = 'tsc --incremental'
 
 const watcher = chokidar.watch('packages/', {
   ignored: /(node_modules|lib|(^|[/\\])\..)/,
@@ -32,7 +32,7 @@ function createBuilder(packageName) {
           name: 'resources',
         },
         {
-          command: `lerna exec --scope=@titicaca/${packageName} ${BUILD_DECLARATIONS}`,
+          command: `lerna exec --scope=@titicaca/${packageName} '${BUILD_DECLARATIONS}'`,
           name: 'declarations',
         },
       ],

--- a/package.json
+++ b/package.json
@@ -4,12 +4,10 @@
   "scripts": {
     "bootstrap": "lerna bootstrap --no-ci && npm run clean-lock",
     "dev": "npm run build && concurrently --names watch,docs --kill-others 'node build-watch' 'npm run dev-docs'",
-    "watch-build-resources": "lerna exec --ignore @titicaca/triple-frontend-docs --ignore @titicaca/triple-frontend-tests --parallel 'babel --root-mode upward src --out-dir lib --source-maps --extensions .ts,.tsx,.js --no-comments --watch'",
-    "watch-build-declarations": "lerna exec --ignore @titicaca/triple-frontend-docs --ignore @titicaca/triple-frontend-tests --parallel 'tsc --watch --preserveWatchOutput'",
     "version": "lerna version --no-push --force-publish",
     "build": "npm run build-resources && npm run build-declarations",
     "build-resources": "lerna exec --ignore @titicaca/triple-frontend-docs --ignore @titicaca/triple-frontend-tests 'BABEL_ENV=build babel --root-mode upward src --out-dir lib --source-maps --extensions .ts,.tsx,.js --delete-dir-on-start --no-comments'",
-    "build-declarations": "lerna exec --ignore @titicaca/triple-frontend-docs --ignore @titicaca/triple-frontend-tests tsc",
+    "build-declarations": "lerna exec --ignore @titicaca/triple-frontend-docs --ignore @titicaca/triple-frontend-tests tsc -- --incremental",
     "dev-docs": "lerna exec --scope @titicaca/triple-frontend-docs npm run dev",
     "lint-json": "prettier --check '**/*.json'",
     "lint-es": "eslint '{docs,packages,tests/src}/**/*.{ts,tsx,js}'",


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
tsc 빌드 시 `--incremental` 플래그를 사용합니다.

This closes #687 

## 변경 내역 및 배경

  - `npm run dev` 1단계로 수행하는 bulid-declarations 스크립트에 `--incremental` 옵션을 더합니다.
  - `watch-build.js`에서 수행하는 declarations 빌드에 `--incremental` 옵션을 더합니다.

Note: `--incremental` 옵션 사용 시 tsconfig.json과 같은 단계에 `tsconfig.tsbuildinfo` 파일이 생성됩니다. 이미 `.gitignore`로 무시되고 있었네요 ㅎㅎ

## 사용 및 테스트 방법

`npm run dev`

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
