### PR TITLE
[common] Storybook webpack에 watchOptions를 추가합니다.

### DIFF
--- a/docs/.storybook/main.js
+++ b/docs/.storybook/main.js
@@ -31,6 +31,11 @@ module.exports = {
       },
     })
 
+    config.watchOptions = {
+      ignored: /node_modules\/.+tsx?$/,
+      aggregateTimeout: 1000,
+    }
+
     return config
   },
 }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
Storybook이 사용하는 webpack configuration에 `watchOptions`를 추가하여, 한 변경마다 (되도록이면) 한 번의 webpack build만 일어나도록 합니다.

변경 이전에는 변경 당 2~n번의 webpack-dev-server의 build trigger가 일어날 수 있었습니다.

참고: https://webpack.js.org/configuration/watch/#watchoptions

This is related to #591 

## 변경 내역 및 배경

  - `ignored`: Type declarations나 소스 파일 변경으로 인해 webpack rebuild가 일어나는 것을 방지합니다.
  - `aggregateTimeout`: `babel` output의 js 파일들이 순차적으로 변경되는데, 이들 각각 watch trigger를 일으킵니다. 모든 변경에 대해 watch trigger가 발생하는 것을 방지하기 위해 debouncing과 유사한 방식의 처리를 하고 있습니다. 그런데 일부 모듈은 파일 개수가 많아서 기본값인 200ms로 부족한 경우가 생깁니다. 이 값을 1000으로 늘려 주었습니다.

## 사용 및 테스트 방법
`npm run dev`

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
