### PR TITLE
[nearby-pois] button을 list 밖으로 뺍니다

### DIFF
--- a/packages/nearby-pois/src/nearby-pois.tsx
+++ b/packages/nearby-pois/src/nearby-pois.tsx
@@ -164,18 +164,19 @@ export default function NearbyPois({
           {t('common:noNearbyPlaces', '장소가 없습니다.')}
         </Paragraph>
       ) : (
-        <List divided margin={{ top: 10 }}>
-          {pois.map((poi, i) => (
-            <PoiEntry
-              key={poi.id}
-              index={i}
-              poi={poi}
-              scraps={scraps}
-              onScrapedChange={onScrapedChange}
-              eventLabel={EVENT_LABELS[currentTab]}
-            />
-          ))}
-
+        <>
+          <List divided margin={{ top: 10 }}>
+            {pois.map((poi, i) => (
+              <PoiEntry
+                key={poi.id}
+                index={i}
+                poi={poi}
+                scraps={scraps}
+                onScrapedChange={onScrapedChange}
+                eventLabel={EVENT_LABELS[currentTab]}
+              />
+            ))}
+          </List>
           {hasMore && (
             <Button
               basic
@@ -190,7 +191,7 @@ export default function NearbyPois({
               {t('common:moreNearbyplaces', '더 많은 장소 보기')}
             </Button>
           )}
-        </List>
+        </>
       )}
     </Section>
   )


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
관련이슈 #714
## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
- 마지막 poi의 하단 구분선을 표시하지 않도록 합니다
## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
- 더보기 Button을 List의 자식으로 두고있었습니다.
  - last-child selector로 마지막 poi를 식별했지만 button이 last-child가 되버렸습니다

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->
![image](https://user-images.githubusercontent.com/46436155/81153437-e2824300-8fbd-11ea-9cf5-45635952600f.png)

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)
