### PR TITLE
[poi-list-element] notes prop 을 추가하여 note 값을 제어합니다

### DIFF
--- a/docs/stories/poi-list-elements/poi.stories.tsx
+++ b/docs/stories/poi-list-elements/poi.stories.tsx
@@ -69,6 +69,7 @@ storiesOf('poi-list-elements | POI', module)
           hideDiscountRate={boolean('hideDiscountRate', false)}
           hideScrapButton={boolean('hideScrapButton', false)}
           onScrapedChange={action('scrap change')}
+          notes={boolean('custom note') && ['3성급', '판교 백현동']}
           {...(boolean('distance 표시', false)
             ? {
                 distance: text('distance', '300m'),

--- a/packages/poi-list-elements/src/index.tsx
+++ b/packages/poi-list-elements/src/index.tsx
@@ -311,14 +311,14 @@ class ExtendedPoiListElement<T extends ListingPOI> extends React.PureComponent<
       currentState: (resourceScraps || {})[id],
     })
     const reviewsCount = Number(rawReviewsCount || 0)
-    const note =
-      notes ||
-      [
+    const note = (
+      notes || [
         starRating ? `${starRating}성급` : category ? category.name : null,
         area ? area.name : null,
       ]
-        .filter((v) => v)
-        .join(' · ')
+    )
+      .filter((v) => v)
+      .join(' · ')
 
     /**
      * Deprecation: priceInfo 배포 후 prices 제거 예정


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
> closes #738 

notes prop 을 추가하여 note 값을 제어합니다

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

호텔쪽에서 areas 의 name 대신 districtName 을 사용해야합니다.
하지만 공통 컴포넌트인지라 ... 확장가능한 prop 을 추가하여 값을 제어합니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
