### PR TITLE
[view-utilties] type-definition 의존성을 devDep 에서 dep 으로 변경합니다.

### DIFF
--- a/packages/view-utilities/package.json
+++ b/packages/view-utilities/package.json
@@ -18,13 +18,13 @@
     "test": "mocha --require ts-node/register ./src/*.spec.ts ./src/**/*.spec.ts"
   },
   "devDependencies": {
-    "@titicaca/type-definitions": "^1.19.0",
     "@types/haversine": "^1.1.4",
     "@types/mocha": "^5.2.7",
     "mocha": "^6.2.2",
     "ts-node": "^8.4.1"
   },
   "dependencies": {
+    "@titicaca/type-definitions": "^1.19.0",
     "@types/qs": "^6.9.0",
     "haversine": "^1.1.1",
     "qs": "^6.9.0"


### PR DESCRIPTION
## 설명
view-utilities 에 추가된 @titicaca/type-definition 모듈 의존성을 devDep -> dep 로 변경합니다.

* https://titicaca.slack.com/archives/CEEPB4TDY/p1589160986009500

## 변경 내역 및 배경

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
