### PR TITLE
[env] Canary Version 을 추론하여 notifier 에 알려줍니다.

### DIFF
--- a/.github/workflows/canary-on-review.yaml
+++ b/.github/workflows/canary-on-review.yaml
@@ -73,17 +73,16 @@ jobs:
             ${{ runner.OS }}-build-${{ env.cache-name }}-
             ${{ runner.OS }}-build-
 
-      # - name: Build and Test
-      #   run: |
-      #     npm ci
-      #     npm run lint
-      #     npm run bootstrap
-      #     npm run build
-      #     npm test
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Build
+        run: |
+          npm ci
+          npm run lint
+          npm run bootstrap
+          npm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Notify build and test success to slack
+      - name: Notify build success to slack
         if: success()
         env:
           SLACK_TITLE: ":tada: Build Succeed"
@@ -92,7 +91,7 @@ jobs:
         run: |
           node ./.github/workflows/notifier.js
 
-      - name: Notify build and test fail to slack
+      - name: Notify build fail to slack
         if: failure()
         env:
           SLACK_TITLE: ":pleading: Build Failed"

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -63,13 +63,6 @@ jobs:
         with:
           ref: ${{ env.PR_SHA }}
 
-      - name: Recognize next canary version
-        run: |
-          NEXT_VERSION=$(node -e "const [major, minor, patch] = require('./lerna.json').version.split('.');console.log(['v'+major, minor, parseInt(patch, 10) + 1].join('.'))")
-          REF_COUNT=$(node -p -e "Math.max(0, parseInt((\"$(git describe --always --long --dirty --match "v*.*.*")\".match(/^(?:.*@)?.*-(\d+)-.*?$/) || ['0', '0'])[1], 10) - 1)")
-          echo ::set-env name=CANARY_VERSION::$NEXT_VERSION-pr-${{ env.PR_NUMBER }}.$REF_COUNT
-          echo ${{ env.CANARY_VERSION }}
-
       - name: Notify build start to slack
         env:
           SLACK_TITLE: ":rocket: Build Started"
@@ -92,17 +85,16 @@ jobs:
             ${{ runner.OS }}-build-${{ env.cache-name }}-
             ${{ runner.OS }}-build-
 
-      - name: Build and Test
+      - name: Build
         run: |
           npm ci
           npm run lint
           npm run bootstrap
           npm run build
-          npm test
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Notify build and test success to slack
+      - name: Notify build success to slack
         if: success()
         env:
           SLACK_TITLE: ":tada: Build Succeed"
@@ -111,7 +103,7 @@ jobs:
         run: |
           node ./.github/workflows/notifier.js
 
-      - name: Notify build and test fail to slack
+      - name: Notify build fail to slack
         if: failure()
         env:
           SLACK_TITLE: ":pleading: Build Failed"
@@ -119,6 +111,17 @@ jobs:
           SLACK_COLOR: fail
         run: |
           node ./.github/workflows/notifier.js
+
+      - name: Preparing canary publish
+        run: |
+          git stash
+          git fetch --unshallow
+          git checkout ${{ env.PR_SHORT_SHA }}
+
+          NEXT_VERSION=$(node -e "const [major, minor, patch] = require('./lerna.json').version.split('.');console.log(['v'+major, minor, parseInt(patch, 10) + 1].join('.'))")
+          REF_COUNT=$(node -p -e "Math.max(0, parseInt((\"$(git describe --always --long --dirty --match "v*.*.*")\".match(/^(?:.*@)?.*-(\d+)-.*?$/) || ['0', '0'])[1], 10) - 1)")
+          echo ::set-env name=CANARY_VERSION::$NEXT_VERSION-pr-${{ env.PR_NUMBER }}.$REF_COUNT
+          echo ${{ env.CANARY_VERSION }}
 
       - name: Notify canary publish start to slack
         env:
@@ -129,10 +132,6 @@ jobs:
 
       - name: Canary Release
         run: |
-          git stash
-          git fetch --unshallow
-          git checkout ${{ env.PR_SHORT_SHA }}
-
           npx lerna publish --canary --force-publish --yes --preid "pr-${{ env.PR_NUMBER }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
Canary Version 을 추론하여 notifier 에 알려줍니다.

## 변경 내역 및 배경
- notifier 에서 publish 된 canary version 을 표시하기 위한 스크립트를 추가합니다.
- pr review event 를 사용하는 canary-on-review workflow를 추가하여 master 에 머지되기 전 canary trigger 를 테스트할 수 있게합니다.

## 사용 및 테스트 방법
pr review comment 로 `canary publish` 입력

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
