### PR TITLE
[react-contexts] device context에 state 추가

### DIFF
--- a/packages/react-contexts/src/device-context.tsx
+++ b/packages/react-contexts/src/device-context.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, ComponentType, useContext } from 'react'
+import React, {
+  createContext,
+  ComponentType,
+  useContext,
+  PropsWithChildren,
+  useState,
+} from 'react'
 import { DeepPartial } from 'utility-types'
 
 interface DeviceContextValue {
@@ -13,7 +19,15 @@ const Context = createContext<DeviceContextValue>({
   longitude: null,
 })
 
-export const DeviceProvider = Context.Provider
+export function DeviceProvider({
+  value: initialValue,
+  children,
+}: PropsWithChildren<{
+  value: DeviceContextValue
+}>) {
+  const [deviceContext] = useState(initialValue)
+  return <Context.Provider value={deviceContext}>{children}</Context.Provider>
+}
 
 export interface WithDeviceContextBaseProps {
   deviceContext: DeviceContextValue


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
device context provider를 마운트 할 때 넣어준 값을 계속 보존하도록 state를 사용합니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
titicacadev/triple-hotels-web#1459 PR에서 device context의 상태를 보존할 필요가 생겼습니다.
앱에서 웹뷰로 새 창을 열 때 url path에 있는 regionId로 사용자가 현재 region에 있는지 여부를 판단하여 `inRegion`, `latitude`, `longitude` query를 넣어줍니다. 세션이 유지되는 동안 값이 변하지 않는다고 가정하고 있습니다.
그런데 기존 구현은 값을 보존해주지 않습니다. value로 주어진 값을 그대로 context로 투사하기 때문에 세션 안에서 페이지 푸시가 일어난 경우 query string이 날아가서 context 값이 없어지게 됩니다.
query와 context 중간에 state를 두어 provider가 unmount되기 전까진 mount 당시의 값을 유지하도록 구현을 수정했습니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->
canary

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
<!-- - [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.) -->
<!-- - [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.) -->
