### PR TITLE
[type-definitions] ListingHotel.source.priceInfo optional 처리

### DIFF
--- a/packages/type-definitions/src/listing-poi.ts
+++ b/packages/type-definitions/src/listing-poi.ts
@@ -74,9 +74,6 @@ export interface ListingHotel extends ListingPOIBase {
     clubPromotionTarget: boolean
   }
 
-  /**
-   * 판매완료 호텔은 priceInfo가 없습니다`.
-   */
   priceInfo?: {
     nightlyBasePrice: number
     nightlyPrice: number


### PR DESCRIPTION
## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
ListingHotel.source.priceInfo 속성을 optional 처리합니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
> Closes #723 

판매 완료 호텔을 강제로 표시할 때 (ex. landingHotel) priceInfo가 없습니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->
canary

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
