### PR TITLE
[review] regionId를 옵셔널하게 변경

### DIFF
--- a/packages/review/src/my-review-action-sheet.tsx
+++ b/packages/review/src/my-review-action-sheet.tsx
@@ -1,4 +1,5 @@
 import React, { SyntheticEvent } from 'react'
+import qs from 'qs'
 import ActionSheet from '@titicaca/action-sheet'
 import { Confirm } from '@titicaca/modals'
 import {
@@ -12,7 +13,7 @@ import { ResourceType, ReviewData, ReviewProps } from './types'
 interface MyReviewActionSheetProps {
   myReview: ReviewData
   appUrlScheme: string
-  regionId: string
+  regionId?: string
   resourceType: ResourceType
   resourceId: string
   notifyReviewDeleted: (resourceId: string, reviewId: string) => void
@@ -41,7 +42,14 @@ export default function MyReviewActionSheet({
   } = useMyReviewsContext()
 
   const handleEditMenuClick = () => {
-    window.location.href = `${appUrlScheme}:///reviews/edit?region_id=${regionId}&resource_type=${resourceType}&resource_id=${resourceId}`
+    const params = qs.stringify({
+      /* eslint-disable @typescript-eslint/camelcase */
+      region_id: regionId,
+      resource_type: resourceType,
+      resource_id: resourceId,
+      /* eslint-enable @typescript-eslint/camelcase */
+    })
+    window.location.href = `${appUrlScheme}:///reviews/edit?${params}`
   }
 
   const handleDeleteMenuClick = () => {

--- a/packages/review/src/review-container.tsx
+++ b/packages/review/src/review-container.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import styled from 'styled-components'
+import qs from 'qs'
 import { Section, Container, Text, Button } from '@titicaca/core-elements'
 import { formatNumber } from '@titicaca/view-utilities'
 import {
@@ -187,6 +188,14 @@ export default function ReviewContainer({
   }
 
   const handleFullListButtonClick = (e: React.SyntheticEvent) => {
+    const params = qs.stringify({
+      /* eslint-disable @typescript-eslint/camelcase */
+      region_id: regionId,
+      resource_id: resourceId,
+      resource_type: resourceType,
+      sorting_option: sortingOption,
+      /* eslint-disable @typescript-eslint/camelcase */
+    })
     trackEvent({
       ga: ['리뷰_전체보기'],
       fa: {
@@ -203,7 +212,7 @@ export default function ReviewContainer({
 
     navigate(
       `${appUrlScheme}:///inlink?path=${encodeURIComponent(
-        `/reviews/list?_triple_no_navbar&region_id=${regionId}&resource_id=${resourceId}&resource_type=${resourceType}&sorting_option=${sortingOption}`,
+        `/reviews/list?_triple_no_navbar&${params}`,
       )}`,
     )
   }

--- a/packages/review/src/review-element/index.tsx
+++ b/packages/review/src/review-element/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState, PropsWithChildren, ComponentType } from 'react'
 import styled, { css } from 'styled-components'
+import qs from 'qs'
 import * as CSS from 'csstype'
 import semver from 'semver'
 import IntersectionObserver from '@titicaca/intersection-observer'
@@ -24,7 +25,7 @@ export interface ReviewElementProps {
   review: ReviewData
   isMyReview: boolean
   index: number
-  regionId: string
+  regionId?: string
   appUrlScheme: string
   onUserClick: ReviewEventHandler
   onUnfoldButtonClick?: ReviewEventHandler
@@ -141,6 +142,12 @@ export default function ReviewElement({
     likesCount: review.likesCount,
   })
   const handleSelectReview = (e: React.SyntheticEvent) => {
+    const params = qs.stringify({
+      /* eslint-disable @typescript-eslint/camelcase */
+      region_id: regionId,
+      resource_id: resourceId,
+      /* eslint-disable @typescript-eslint/camelcase */
+    })
     if (appVersion && semver.gte(appVersion, LOUNGE_APP_VERSION)) {
       e.preventDefault()
       e.stopPropagation()
@@ -153,7 +160,7 @@ export default function ReviewElement({
         },
       })
 
-      window.location.href = `${appUrlScheme}:///reviews/${review.id}/detail?region_id=${regionId}&resource_id=${resourceId}`
+      window.location.href = `${appUrlScheme}:///reviews/${review.id}/detail?${params}`
     }
   }
   return (

--- a/packages/review/src/reviews-list.tsx
+++ b/packages/review/src/reviews-list.tsx
@@ -33,7 +33,7 @@ export default function ReviewsList({
   myReview?: ReviewData
   reviews: ReviewData[]
   fetchNext?: () => void
-  regionId: string
+  regionId?: string
   appUrlScheme: string
   resourceId: string
   maxLength?: number

--- a/packages/review/src/types.tsx
+++ b/packages/review/src/types.tsx
@@ -47,7 +47,7 @@ export interface ReviewData {
 export interface ReviewProps {
   resourceId: string
   resourceType: ResourceType
-  regionId: string
+  regionId?: string
   reviewsCount: number
   shortened?: boolean
   reviewed?: boolean


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
리뷰 컴포넌트 내 regionId의 의존성을 제거하고 사용하는 모든 곳에 optional 하게 대응할 수 있도록 코드를 변경합니다. 
it closes #556 
## 변경 내역 및 배경
regionId이 없는 컨텐츠의 인입 가능을 위해 변경하게 되었습니다.
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
