### PR TITLE
mdx 린트 플러그인 추가

### DIFF
--- a/docs/.eslintrc
+++ b/docs/.eslintrc
@@ -1,6 +1,7 @@
 {
-  "extends": "@titicaca/eslint-config-triple/typescript",
+  "extends": ["@titicaca/eslint-config-triple/typescript", "plugin:mdx/recommended"],
   "rules": {
-    "@typescript-eslint/no-empty-function": "off"
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-unused-expressions": "off"
   }
 }

--- a/docs/stories/booking-completion/booking-completion.stories.mdx
+++ b/docs/stories/booking-completion/booking-completion.stories.mdx
@@ -1,5 +1,5 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
-import { text, boolean, withKnobs } from '@storybook/addon-knobs'
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { boolean, withKnobs } from '@storybook/addon-knobs'
 import BookingCompletion from '@titicaca/booking-completion'
 
 <Meta title="booking-completion | Booking Complete" decorators={[withKnobs]} />
@@ -17,7 +17,7 @@ import BookingCompletion from '@titicaca/booking-completion'
         '공급사 확인 후 예약이 확정됩니다.',
         '예약이 확정되면 이메일로 바우처가 발송됩니다.',
       ]}
-      region={{ id: regionId, names: { ko: '바르셀로나', en: 'Barcelona' } }}
+      region={{ id: '', names: { ko: '바르셀로나', en: 'Barcelona' } }}
     />
   </Story>
 </Preview>

--- a/docs/stories/color-palette/color-palette.stories.mdx
+++ b/docs/stories/color-palette/color-palette.stories.mdx
@@ -1,6 +1,5 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
-import { action } from '@storybook/addon-actions'
-import { select, text, boolean } from '@storybook/addon-knobs'
+import { Meta } from '@storybook/addon-docs/blocks'
+
 import { ColorBox, FlexBox } from './color-box'
 
 <Meta title="color-palette | Color Palette" />
@@ -67,14 +66,14 @@ import { ColorBox, FlexBox } from './color-box'
 
 - 2020.04.17 체크리스트 color sets
 
-  <FlexBox>
-    <FlexBox flex={1} flexFlow="column" space>
-      <ColorBox color="azul500" />
-      <ColorBox color="azul" />
-    </FlexBox>
-    <FlexBox flex={1} flexFlow="column" space>
-      <ColorBox color="teal100" />
-      <ColorBox color="teal900" />
-      <ColorBox color="teal" />
-    </FlexBox>
+<FlexBox>
+  <FlexBox flex={1} flexFlow="column" space>
+    <ColorBox color="azul500" />
+    <ColorBox color="azul" />
   </FlexBox>
+  <FlexBox flex={1} flexFlow="column" space>
+    <ColorBox color="teal100" />
+    <ColorBox color="teal900" />
+    <ColorBox color="teal" />
+  </FlexBox>
+</FlexBox>

--- a/docs/stories/core-elements/form.stories.mdx
+++ b/docs/stories/core-elements/form.stories.mdx
@@ -1,14 +1,11 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks';
-import { action } from '@storybook/addon-actions'
-import { select as selectAddons, text, boolean } from '@storybook/addon-knobs';
-
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { select as selectAddons, text, boolean } from '@storybook/addon-knobs'
 import {
   Input,
   ConfirmSelector,
   Textarea,
   Select,
   GenderSelector,
-  Radio,
   Text,
 } from '@titicaca/core-elements'
 
@@ -18,7 +15,7 @@ import RadioWrapper from './radio-wrapper'
 
 # Form
 
-<br/>
+<br />
 
 ## Input
 
@@ -38,12 +35,15 @@ onBlur?: (e: React.FocusEvent<any>) => any
 
 <Preview>
   <Story name="Input">
-     <Input
-        error={boolean('error', false)}
-        label={text('label', '이름')}
-        placeholder={text('placeholder', "이름을 입력해주세요")}
-        help={text('placeholder', "고객님의 요청사항은 해당 호텔에 전달됩니다만 호텔 사정에 따라 필요하신 내용이 이루어지지 않을 수 있으니 많은 양해 바랍니다.")}
-      />
+    <Input
+      error={boolean('error', false)}
+      label={text('label', '이름')}
+      placeholder={text('placeholder', '이름을 입력해주세요')}
+      help={text(
+        'placeholder',
+        '고객님의 요청사항은 해당 호텔에 전달됩니다만 호텔 사정에 따라 필요하신 내용이 이루어지지 않을 수 있으니 많은 양해 바랍니다.',
+      )}
+    />
   </Story>
 </Preview>
 
@@ -53,8 +53,11 @@ Focus 와 Error 두 가지의 상태 값을 가지고 있습니다.
 focused, error props 를 이용하여 상태를 다룰 수 있습니다.
 
 <Input
-  placeholder={text('placeholder', "이름을 입력해주세요")}
-  help={text('placeholder', "고객님의 요청사항은 해당 호텔에 전달됩니다만 호텔 사정에 따라 필요하신 내용이 이루어지지 않을 수 있으니 많은 양해 바랍니다.")}
+  placeholder={text('placeholder', '이름을 입력해주세요')}
+  help={text(
+    'placeholder',
+    '고객님의 요청사항은 해당 호텔에 전달됩니다만 호텔 사정에 따라 필요하신 내용이 이루어지지 않을 수 있으니 많은 양해 바랍니다.',
+  )}
   error={true}
 />
 
@@ -64,14 +67,13 @@ mask props 를 이용하여 mask 를 추가 할 수 있습니다.
 
 <Preview>
   <Story name="Input - Mask">
-     <Input
-      mask={text('mask', "99/99")}
+    <Input
+      mask={text('mask', '99/99')}
       maskChar={null}
       value={text('value', 1230)}
     />
   </Story>
 </Preview>
-
 
 ## Select
 
@@ -91,27 +93,30 @@ onChange?: (e?: React.SyntheticEvent, value?: any) => any
 
 <Preview>
   <Story name="Select">
-     <Select
-        error={boolean('error', false)}
-        label="투어티켓 시간"
-        help={text('placeholder', "고객님의 요청사항은 해당 호텔에 전달됩니다만 호텔 사정에 따라 필요하신 내용이 이루어지지 않을 수 있으니 많은 양해 바랍니다.")}
-        placeholder="시간을 선택해주세요"
-        value={selectAddons('value', ['12:00', '12:10', '12:20'], '12:00')}
-        options={[
-          {
-            label: '12:00',
-            value: '12:00',
-          },
-          {
-            label: '12:10',
-            value: '12:10',
-          },
-          {
-            label: '12:20',
-            value: '12:20',
-          },
-        ]}
-        disabled={boolean('disabled', false)}
+    <Select
+      error={boolean('error', false)}
+      label="투어티켓 시간"
+      help={text(
+        'placeholder',
+        '고객님의 요청사항은 해당 호텔에 전달됩니다만 호텔 사정에 따라 필요하신 내용이 이루어지지 않을 수 있으니 많은 양해 바랍니다.',
+      )}
+      placeholder="시간을 선택해주세요"
+      value={selectAddons('value', ['12:00', '12:10', '12:20'], '12:00')}
+      options={[
+        {
+          label: '12:00',
+          value: '12:00',
+        },
+        {
+          label: '12:10',
+          value: '12:10',
+        },
+        {
+          label: '12:20',
+          value: '12:20',
+        },
+      ]}
+      disabled={boolean('disabled', false)}
     />
   </Story>
 </Preview>
@@ -133,11 +138,10 @@ error?: string
 
 <Preview>
   <Story name="Confirm Selector">
-     <ConfirmSelector
+    <ConfirmSelector
       value={boolean('value', false)}
       borderless={boolean('borderless', false)}
       textAlign={selectAddons('textAlign', ['left', 'right'], 'left')}
-      padding={{ top: 16, left: 16, bottom: 16 }}
       fillType={selectAddons('fillType', ['full', 'border', 'text'], 'full')}
       padding={{ top: 16, right: 50, left: 16, bottom: 16 }}
     >
@@ -161,9 +165,9 @@ options: option[]
 ```
 
 <Preview>
-   <Story name="Radio">
-     <RadioWrapper />
-   </Story>
+  <Story name="Radio">
+    <RadioWrapper />
+  </Story>
 </Preview>
 
 ## Gender Selector
@@ -177,9 +181,9 @@ onChange?: (e: React.SyntheticEvent, arg1: string) => any
 ```
 
 <Preview>
-   <Story name="Gender Selector">
-     <GenderSelector value={selectAddons('value', ['MALE', 'FEMALE'], 'MALE')} />
-   </Story>
+  <Story name="Gender Selector">
+    <GenderSelector value={selectAddons('value', ['MALE', 'FEMALE'], 'MALE')} />
+  </Story>
 </Preview>
 
 ## Textarea
@@ -195,14 +199,15 @@ onBlur?: (e: React.FocusEvent<any>) => any
 ```
 
 <Preview>
-   <Story name="Textarea">
-     <Textarea
-       error={boolean('error', false)}
-       label={text('label', '요청사항')}
-       placeholder={text('placeholder', "요청사항을 입력해주세요")}
-       help={text('placeholder', "고객님의 요청사항은 해당 호텔에 전달됩니다만 호텔 사정에 따라 필요하신 내용이 이루어지지 않을 수 있으니 많은 양해 바랍니다.")}
-     />
-   </Story>
+  <Story name="Textarea">
+    <Textarea
+      error={boolean('error', false)}
+      label={text('label', '요청사항')}
+      placeholder={text('placeholder', '요청사항을 입력해주세요')}
+      help={text(
+        'placeholder',
+        '고객님의 요청사항은 해당 호텔에 전달됩니다만 호텔 사정에 따라 필요하신 내용이 이루어지지 않을 수 있으니 많은 양해 바랍니다.',
+      )}
+    />
+  </Story>
 </Preview>
-
-

--- a/docs/stories/core-elements/list.stories.mdx
+++ b/docs/stories/core-elements/list.stories.mdx
@@ -1,14 +1,8 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
-import { List, Container } from '@titicaca/core-elements'
-import { action } from '@storybook/addon-actions'
-import {
-  withKnobs,
-  select,
-  text,
-  boolean,
-  number,
-} from '@storybook/addon-knobs'
-import { ColorBox, FlexBox } from '../color-palette/color-box'
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { List } from '@titicaca/core-elements'
+import { withKnobs, text, boolean, number } from '@storybook/addon-knobs'
+
+import { ColorBox } from '../color-palette/color-box'
 
 <Meta title="Core-Elements | List" decorators={[withKnobs]} />
 
@@ -21,15 +15,17 @@ import { ColorBox, FlexBox } from '../color-palette/color-box'
 <Preview>
   <Story name="List">
     <List
-      verticalGap={(number('verticalGap(리스트 간격)', 20))}
+      verticalGap={number('verticalGap(리스트 간격)', 20)}
       divided={boolean('divided', false)}
       dividerColor={text('deviderColor(구분선 색상)', '#ff0000')}
       dividerWeight={number('dividerWeight(구분선 두께)', 1)}
-      >
+    >
       {[...Array(5).keys()].map((_, idx) => (
         <List.Item
           key={idx}
-          noDivider={boolean('짝수 번째 아래 라인 생략', false) && idx % 2 === 0}
+          noDivider={
+            boolean('짝수 번째 아래 라인 생략', false) && idx % 2 === 0
+          }
         >
           <ColorBox color="blue" />
         </List.Item>

--- a/docs/stories/core-elements/segment.stories.mdx
+++ b/docs/stories/core-elements/segment.stories.mdx
@@ -1,7 +1,5 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
-import { Text, Card, Container } from '@titicaca/core-elements'
-import { action } from '@storybook/addon-actions'
-import { select, text, boolean } from '@storybook/addon-knobs'
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { Card, Container } from '@titicaca/core-elements'
 
 <Meta title="Core-Elements | Card" component={Card} />
 
@@ -11,7 +9,7 @@ Card 를 표현할때 사용하는 컴포넌트입니다.
 
 <Preview>
   <Story name="Basic">
-    <Container width={300} margin={{bottom: 50}}>
+    <Container width={300} margin={{ bottom: 50 }}>
       <Card>default card</Card>
     </Container>
   </Story>
@@ -20,25 +18,25 @@ Card 를 표현할때 사용하는 컴포넌트입니다.
 <Preview>
   <Story name="Shadow Props">
     {['small', 'medium', 'large'].map((item, i) => (
-      <Container width={300} margin={{bottom: 50}}>
+      <Container key={item} width={300} margin={{ bottom: 50 }}>
         <Card
           shadow={item}
           padding={{ top: 20, left: 20, right: 20, bottom: 20 }}
-          margin={{ top: i*10+10, bottom: i*10+10 }}
+          margin={{ top: i * 10 + 10, bottom: i * 10 + 10 }}
         >
           {item}/radius(default)
         </Card>
         <Card
           shadow={item}
           padding={{ top: 20, left: 20, right: 20, bottom: 20 }}
-          margin={{ top: i*10+10, bottom: i*10+10 }}
+          margin={{ top: i * 10 + 10, bottom: i * 10 + 10 }}
         >
           {item}/radius(default)
         </Card>
         <Card
           shadow={item}
           padding={{ top: 20, left: 20, right: 20, bottom: 20 }}
-          margin={{ top: i*10+10, bottom: i*10+10 }}
+          margin={{ top: i * 10 + 10, bottom: i * 10 + 10 }}
         >
           {item}/radius(default)
         </Card>
@@ -139,14 +137,29 @@ Card 를 표현할때 사용하는 컴포넌트입니다.
 
 ## Events
 
-<Card shadow="small" padding={{top:10, left:10, right:10, bottom:10}} onClick={() => { alert('')}}>Click</Card>
+<Card
+  shadow="small"
+  padding={{ top: 10, left: 10, right: 10, bottom: 10 }}
+  onClick={() => {
+    alert('')
+  }}
+>
+  Click
+</Card>
 
 ## Container shadow
 
-<Container shadow="small" width={200}>Container</Container>
-<Container shadow="large" width={200}
+<Container shadow="small" width={200}>
+  Container
+</Container>
+<Container
+  shadow="large"
+  width={200}
   padding={{ top: 20, left: 20, right: 20, bottom: 20 }}
-  margin={{ top: 30, bottom: 30 }}>Container</Container>
+  margin={{ top: 30, bottom: 30 }}
+>
+  Container
+</Container>
 
 ```js
 <Container shadow="small" width={200}>Container</Container>

--- a/docs/stories/core-elements/text.stories.mdx
+++ b/docs/stories/core-elements/text.stories.mdx
@@ -1,7 +1,7 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks';
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
 import { Text } from '@titicaca/core-elements'
 import { action } from '@storybook/addon-actions'
-import { select, text, boolean } from '@storybook/addon-knobs';
+import { select, text, boolean } from '@storybook/addon-knobs'
 
 <Meta title="Core-Elements | Text" component={Text} />
 
@@ -11,24 +11,28 @@ Text 를 표현할때 사용하는 컴포넌트입니다.
 
 <Preview>
   <Story name="Basic">
-     <Text
-        size={select(
-          '크기',
-          ['mini', 'tiny', 'small', 'medium', 'large', 'big', 'huge', 'massive'],
-          'tiny',
-        )}
-        color={select('색깔', ['blue', 'gray', 'gray20', 'gray100', 'white'], 'gray')}
-        center={boolean('중앙정렬')}
-        textAlign={select('정렬', [undefined, 'left', 'center', 'right'])}
-        onClick={action('clicked')}
-      >
-        {text('텍스트', '호텔 최저가 보상!')}
+    <Text
+      size={select(
+        '크기',
+        ['mini', 'tiny', 'small', 'medium', 'large', 'big', 'huge', 'massive'],
+        'tiny',
+      )}
+      color={select(
+        '색깔',
+        ['blue', 'gray', 'gray20', 'gray100', 'white'],
+        'gray',
+      )}
+      center={boolean('중앙정렬')}
+      textAlign={select('정렬', [undefined, 'left', 'center', 'right'])}
+      onClick={action('clicked')}
+    >
+      {text('텍스트', '호텔 최저가 보상!')}
     </Text>
   </Story>
 </Preview>
 
 ```jsx
-<Text size="medium" color="blue" onClick={() => 'clicked'}> 
+<Text size="medium" color="blue" onClick={() => 'clicked'}>
   호텔 최저가 보상!
 </Text>
 ```
@@ -66,8 +70,7 @@ strikethrough?: boolean
 <Text size="tiny"> tiny: 13px </Text>
 <Text size="small"> small: 14px </Text>
 <Text size="medium"> medium: 15px </Text>
-<Text size="large"> large: 16px </Text>
-<Text>default size="large"</Text>
+<Text size="large"> large: 16px (default) </Text>
 <Text size="big"> big: 19px </Text>
 <Text size="huge"> huge: 21px </Text>
 <Text size="massive"> massive: 24px </Text>
@@ -88,17 +91,32 @@ strikethrough?: boolean
 
 ## Color
 
-<Text size="big" color="blue"> color: blue </Text>
-<Text size="big" color="gray"> color: gray </Text>
-<Text size="big" color="gray" alpha={0.5}> color: gray alpha = 0.5 </Text>
+<Text size="big" color="blue">
+  {' '}
+  color: blue{' '}
+</Text>
+<Text size="big" color="gray">
+  {' '}
+  color: gray{' '}
+</Text>
+<Text size="big" color="gray" alpha={0.5}>
+  {' '}
+  color: gray alpha = 0.5{' '}
+</Text>
 
 ## LineHeight
 
-<Text style={{border: '1px solid gray'}}>lineHeight default: 1.2 <br/> lineHeight</Text>
+<Text style={{ border: '1px solid gray' }}>
+  lineHeight default: 1.2 <br /> lineHeight
+</Text>
 
-<Text lineHeight={1.8} style={{border: '1px solid gray'}}>lineHeight 1.8 <br/> lineHeight</Text>
+<Text lineHeight={1.8} style={{ border: '1px solid gray' }}>
+  lineHeight 1.8 <br /> lineHeight
+</Text>
 
-<Text lineHeight="50px" style={{border: '1px solid gray'}}>lineHeight 50px <br/> lineHeight</Text>
+<Text lineHeight="50px" style={{ border: '1px solid gray' }}>
+  lineHeight 50px <br /> lineHeight
+</Text>
 
 ## LetterSpacing
 
@@ -108,24 +126,23 @@ strikethrough?: boolean
 <Text letterSpacing={5}>letterSpacing</Text>
 ```
 
-
 ## TextStyle
 
-<Text textStyle="L6">textStyle="L6"</Text>
-<Text textStyle="M8">textStyle="M8"</Text>
-<Text textStyle="M6">textStyle="M6"</Text>
-<Text textStyle="M4">textStyle="M4"</Text>
-<Text textStyle="M2">textStyle="M2"</Text>
-<Text textStyle="M1">textStyle="M1"</Text>
-<Text textStyle="M">textStyle="M"</Text>
-<Text textStyle="S9">textStyle="S9"</Text>
-<Text textStyle="S8">textStyle="S8"</Text>
-<Text textStyle="S7">textStyle="S7"</Text>
-<Text textStyle="S6">textStyle="S6"</Text>
-<Text textStyle="S5">textStyle="S5"</Text>
-<Text textStyle="S4">textStyle="S4"</Text>
-<Text textStyle="S3">textStyle="S3"</Text>
-<Text textStyle="S2">textStyle="S2"</Text>
+<Text textStyle="L6">L6</Text>
+<Text textStyle="M8">M8</Text>
+<Text textStyle="M6">M6</Text>
+<Text textStyle="M4">M4</Text>
+<Text textStyle="M2">M2</Text>
+<Text textStyle="M1">M1</Text>
+<Text textStyle="M">M</Text>
+<Text textStyle="S9">S9</Text>
+<Text textStyle="S8">S8</Text>
+<Text textStyle="S7">S7</Text>
+<Text textStyle="S6">S6</Text>
+<Text textStyle="S5">S5</Text>
+<Text textStyle="S4">S4</Text>
+<Text textStyle="S3">S3</Text>
+<Text textStyle="S2">S2</Text>
 
 ```jsx
 <Text textStyle="L6">textStyle="L6"</Text>
@@ -145,34 +162,51 @@ strikethrough?: boolean
 <Text textStyle="S2">textStyle="S2"</Text>
 ```
 
-<Text textStyle="M8">서비스메인, 도시메인 타이틀
-</Text>
+<Text textStyle="M8">서비스메인, 도시메인 타이틀</Text>
 
 ```jsx
-<Text textStyle="M8"> 
-  서비스메인, 도시메인 타이틀
-</Text>
+<Text textStyle="M8">서비스메인, 도시메인 타이틀</Text>
 ```
 
-<Text size="tiny" textStyle="S2">Tiny Size Text</Text>
+<Text size="tiny" textStyle="S2">
+  Tiny Size Text
+</Text>
 
 > `size`, `lineHeight` 과 같은 기존 `props` 을 함께 사용할 경우 `textStyle` 이 최종 적용됩니다.
 
 ```jsx
-<Text size="tiny" lineHeight={1.5} textStyle="S2">Tiny Size Text</Text>
+<Text size="tiny" lineHeight={1.5} textStyle="S2">
+  Tiny Size Text
+</Text>
 ```
-
 
 ## TextAlign
 
 `center` 는 deprecated property 입니다. (`textAlign` 이 없을때만 동작합니다.)
 
-<Text center margin={{ bottom: 10 }} style={{border: '1px solid gray'}}>center</Text>
-<Text center textAlign="right" margin={{ bottom: 10 }} style={{border: '1px solid gray'}}>center textAlign="right"</Text>
-<Text textAlign="center" margin={{ bottom: 10 }} style={{border: '1px solid gray'}}>textAlign="center"</Text>
-<Text center style={{border: '1px solid gray'}}>
+<Text center margin={{ bottom: 10 }} style={{ border: '1px solid gray' }}>
   center
-  <Text textAlign="left" style={{border: '1px solid lightgray'}}>textAlign="left"</Text>
+</Text>
+<Text
+  center
+  textAlign="right"
+  margin={{ bottom: 10 }}
+  style={{ border: '1px solid gray' }}
+>
+  center and textAlign right
+</Text>
+<Text
+  textAlign="center"
+  margin={{ bottom: 10 }}
+  style={{ border: '1px solid gray' }}
+>
+  textAlign center
+</Text>
+<Text center style={{ border: '1px solid gray' }}>
+  center
+  <Text textAlign="left" style={{ border: '1px solid lightgray' }}>
+    textAlign left
+  </Text>
 </Text>
 
 ```jsx

--- a/docs/stories/core-elements/video.stories.mdx
+++ b/docs/stories/core-elements/video.stories.mdx
@@ -1,5 +1,4 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
-import { storiesOf } from '@storybook/react'
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
 import { boolean, select, text } from '@storybook/addon-knobs'
 import { Video } from '@titicaca/core-elements'
 
@@ -11,61 +10,57 @@ import { Video } from '@titicaca/core-elements'
 
 <Preview>
   <Story name="비디오 with Autoplay">
-    {
-      boolean('Visible', true) ? (
-        <Video
-          autoPlay
-          frame={select(
-            'Frame',
-            ['mini', 'small', 'medium', 'large', 'big', 'huge'],
-            'small',
-          )}
-          src={text(
-            'URL',
-            'https://media.triple.guide/triple-dev/video/upload/c_fill,h_256,w_256,f_auto/580e50be-d1d5-4ad8-a477-ad13f4faec9d.mp4',
-          )}
-          fallbackImageUrl={text(
-            'Fallback URL',
-            'https://media.triple.guide/triple-dev/video/upload/c_limit,f_auto,h_1024,w_1024/580e50be-d1d5-4ad8-a477-ad13f4faec9d.jpeg',
-          )}
-          cloudinaryId={text(
-            'Cloudinary ID',
-            '580e50be-d1d5-4ad8-a477-ad13f4faec9d',
-          )}
-          cloudinaryBucket={text('Cloudinary Bucket', 'triple-dev')}
-        />
-      ) : (
-        <div>Hidden</div>
-      )
-    }
+    {boolean('Visible', true) ? (
+      <Video
+        autoPlay
+        frame={select(
+          'Frame',
+          ['mini', 'small', 'medium', 'large', 'big', 'huge'],
+          'small',
+        )}
+        src={text(
+          'URL',
+          'https://media.triple.guide/triple-dev/video/upload/c_fill,h_256,w_256,f_auto/580e50be-d1d5-4ad8-a477-ad13f4faec9d.mp4',
+        )}
+        fallbackImageUrl={text(
+          'Fallback URL',
+          'https://media.triple.guide/triple-dev/video/upload/c_limit,f_auto,h_1024,w_1024/580e50be-d1d5-4ad8-a477-ad13f4faec9d.jpeg',
+        )}
+        cloudinaryId={text(
+          'Cloudinary ID',
+          '580e50be-d1d5-4ad8-a477-ad13f4faec9d',
+        )}
+        cloudinaryBucket={text('Cloudinary Bucket', 'triple-dev')}
+      />
+    ) : (
+      <div>Hidden</div>
+    )}
   </Story>
   <Story name="비디오 without Autoplay">
-    {
-      boolean('Visible', true) ? (
-        <Video
-          frame={select(
-            'Frame',
-            ['mini', 'small', 'medium', 'large', 'big', 'huge'],
-            'small',
-          )}
-          src={text(
-            'URL',
-            'https://media.triple.guide/triple-dev/video/upload/c_fill,h_256,w_256,f_auto/580e50be-d1d5-4ad8-a477-ad13f4faec9d.mp4',
-          )}
-          fallbackImageUrl={text(
-            'Fallback URL',
-            'https://media.triple.guide/triple-dev/video/upload/c_limit,f_auto,h_1024,w_1024/580e50be-d1d5-4ad8-a477-ad13f4faec9d.jpeg',
-          )}
-          cloudinaryId={text(
-            'Cloudinary ID',
-            '580e50be-d1d5-4ad8-a477-ad13f4faec9d',
-          )}
-          cloudinaryBucket={text('Cloudinary Bucket', 'triple-dev')}
-        />
-      ) : (
-        <div>Hidden</div>
-      )
-    }
+    {boolean('Visible', true) ? (
+      <Video
+        frame={select(
+          'Frame',
+          ['mini', 'small', 'medium', 'large', 'big', 'huge'],
+          'small',
+        )}
+        src={text(
+          'URL',
+          'https://media.triple.guide/triple-dev/video/upload/c_fill,h_256,w_256,f_auto/580e50be-d1d5-4ad8-a477-ad13f4faec9d.mp4',
+        )}
+        fallbackImageUrl={text(
+          'Fallback URL',
+          'https://media.triple.guide/triple-dev/video/upload/c_limit,f_auto,h_1024,w_1024/580e50be-d1d5-4ad8-a477-ad13f4faec9d.jpeg',
+        )}
+        cloudinaryId={text(
+          'Cloudinary ID',
+          '580e50be-d1d5-4ad8-a477-ad13f4faec9d',
+        )}
+        cloudinaryBucket={text('Cloudinary Bucket', 'triple-dev')}
+      />
+    ) : (
+      <div>Hidden</div>
+    )}
   </Story>
 </Preview>
 
@@ -81,14 +76,14 @@ import { Video } from '@titicaca/core-elements'
 
 ## Props
 
-  - `frame: GlobalSizes`: `"mini"`, `"small"`, `"medium"`, `"large"`, `"big"`,
-    `"huge"` 중 하나의 값을 가집니다.
-  - `src: string`: 비디오 원본의 URL입니다.
-  - `srcType: string`: 비디오 원본의 Content-Type입니다.
-  - `fallbackImageUrl: string`: 브라우저가 비디오를 지원하지 않거나, 파일이
-    로딩 전일 때 보일 이미지 URL입니다.
-  - `cloudinaryBucket? string`: Cloudinary Bucket 이름입니다.
-  - `cloudinaryId: string`: 비디오 파일의 Cloudinary ID입니다.
+- `frame: GlobalSizes`: `"mini"`, `"small"`, `"medium"`, `"large"`, `"big"`,
+  `"huge"` 중 하나의 값을 가집니다.
+- `src: string`: 비디오 원본의 URL입니다.
+- `srcType: string`: 비디오 원본의 Content-Type입니다.
+- `fallbackImageUrl: string`: 브라우저가 비디오를 지원하지 않거나, 파일이
+  로딩 전일 때 보일 이미지 URL입니다.
+- `cloudinaryBucket? string`: Cloudinary Bucket 이름입니다.
+- `cloudinaryId: string`: 비디오 파일의 Cloudinary ID입니다.
 
 ## URL Generation
 

--- a/docs/stories/form/form.stories.mdx
+++ b/docs/stories/form/form.stories.mdx
@@ -1,13 +1,11 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
-import { action } from '@storybook/addon-actions'
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
 import { text, boolean, select as selectAddons } from '@storybook/addon-knobs'
 import {
   Input,
   Select,
-  ActionSheetSelector,
   Textarea,
   ConfirmCheckbox,
-  GenderRadio
+  GenderRadio,
 } from '@titicaca/form'
 
 import RadioWrapper from './components/radio.tsx'
@@ -38,7 +36,6 @@ import CheckboxWrapper from './components/checkbox.tsx'
   </Story>
 </Preview>
 
-
 ## Textarea
 
 <Preview>
@@ -68,10 +65,6 @@ import CheckboxWrapper from './components/checkbox.tsx'
       )}
       placeholder="시간을 선택해주세요"
       value={selectAddons('value', ['12:00', '12:10', '12:20'], '12:00')}
-      help={text(
-        'placeholder',
-        '고객님의 요청사항은 해당 호텔에 전달됩니다만 호텔 사정에 따라 필요하신 내용이 이루어지지 않을 수 있으니 많은 양해 바랍니다.',
-      )}
       options={[
         {
           label: '12:00',
@@ -106,32 +99,30 @@ import CheckboxWrapper from './components/checkbox.tsx'
   </Story>
 </Preview>
 
-# GenderRadio 
+# GenderRadio
 
 <Preview>
-   <Story name="Gender Radio">
-     <GenderRadio value={selectAddons('value', ['MALE', 'FEMALE'], 'MALE')} />
-   </Story>
+  <Story name="Gender Radio">
+    <GenderRadio value={selectAddons('value', ['MALE', 'FEMALE'], 'MALE')} />
+  </Story>
 </Preview>
-
 
 # CheckBox
 
 <Preview>
-   <Story name="Checkbox">
-     <CheckboxWrapper />
-   </Story>
+  <Story name="Checkbox">
+    <CheckboxWrapper />
+  </Story>
 </Preview>
 
 # ConfirmCheckbox
 
 <Preview>
   <Story name="Confirm Checkbox">
-     <ConfirmCheckbox
+    <ConfirmCheckbox
       value={boolean('value', false)}
       borderless={boolean('borderless', false)}
       textAlign={selectAddons('textAlign', ['left', 'right'], 'left')}
-      padding={{ top: 16, left: 16, bottom: 16 }}
       fillType={selectAddons('fillType', ['full', 'border', 'text'], 'full')}
       padding={{ top: 16, right: 50, left: 16, bottom: 16 }}
     >
@@ -139,6 +130,3 @@ import CheckboxWrapper from './components/checkbox.tsx'
     </ConfirmCheckbox>
   </Story>
 </Preview>
-
-
-

--- a/docs/stories/style-box/atom.stories.mdx
+++ b/docs/stories/style-box/atom.stories.mdx
@@ -1,17 +1,4 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
-import { action } from '@storybook/addon-actions'
-import { select as selectAddons, text, boolean } from '@storybook/addon-knobs'
-
-import {
-  Input,
-  ConfirmSelector,
-  Textarea,
-  Select,
-  GenderSelector,
-  Radio,
-  Text,
-  Container,
-} from '@titicaca/core-elements'
+import { Meta } from '@storybook/addon-docs/blocks'
 
 <Meta title="Style-Box | atom" />
 

--- a/docs/stories/style-box/molecular.stories.mdx
+++ b/docs/stories/style-box/molecular.stories.mdx
@@ -1,18 +1,4 @@
-import { Meta, Story, Props, Preview } from '@storybook/addon-docs/blocks'
-import { action } from '@storybook/addon-actions'
-import { select as selectAddons, text, boolean } from '@storybook/addon-knobs'
-
-import {
-  Input,
-  ConfirmSelector,
-  Textarea,
-  Select,
-  GenderSelector,
-  Radio,
-  Text,
-  Container,
-} from '@titicaca/core-elements'
-import { margin } from '@titicaca/style-box'
+import { Meta } from '@storybook/addon-docs/blocks'
 
 <Meta title="Style-Box | molecular" />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2760,6 +2760,53 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/core": {
+      "version": "10.0.28",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.28.tgz",
+      "integrity": "sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "dev": true,
+      "optional": true
+    },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
@@ -2775,6 +2822,51 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "dev": true
     },
+    "@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
+      "dev": true,
+      "optional": true
+    },
+    "@emotion/styled": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
+      "integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emotion/styled-base": "^10.0.27",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "@emotion/styled-base": {
+      "version": "10.0.31",
+      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
+      "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/is-prop-valid": "0.8.8",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3"
+      }
+    },
     "@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
@@ -2786,6 +2878,20 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
       "dev": true
+    },
+    "@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
+      "dev": true,
+      "optional": true
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
+      "dev": true,
+      "optional": true
     },
     "@evocateur/libnpmaccess": {
       "version": "3.1.2",
@@ -4316,6 +4422,12 @@
         }
       }
     },
+    "@mdx-js/util": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.5.tgz",
+      "integrity": "sha512-ljr9hGQYW3kZY1NmQbmSe4yXvgq3KDRt0FMBOB5OaDWqi4X2WzEsp6SZ02KmVrieNW1cjWlj13pgvcf0towZPw==",
+      "dev": true
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -4568,6 +4680,146 @@
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
+      }
+    },
+    "@styled-system/background": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/background/-/background-5.1.2.tgz",
+      "integrity": "sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/border": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/border/-/border-5.1.5.tgz",
+      "integrity": "sha512-JvddhNrnhGigtzWRCVuAHepniyVi6hBlimxWDVAdcTuk7aRn9BYJUwfHslURtwYFsF5FoEs8Zmr1oZq2M1AP0A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/color": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/color/-/color-5.1.2.tgz",
+      "integrity": "sha512-1kCkeKDZkt4GYkuFNKc7vJQMcOmTl3bJY3YBUs7fCNM6mMYJeT1pViQ2LwBSBJytj3AB0o4IdLBoepgSgGl5MA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/core": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/core/-/core-5.1.2.tgz",
+      "integrity": "sha512-XclBDdNIy7OPOsN4HBsawG2eiWfCcuFt6gxKn1x4QfMIgeO6TOlA2pZZ5GWZtIhCUqEPTgIBta6JXsGyCkLBYw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
+    },
+    "@styled-system/css": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.1.5.tgz",
+      "integrity": "sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A==",
+      "dev": true,
+      "optional": true
+    },
+    "@styled-system/flexbox": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/flexbox/-/flexbox-5.1.2.tgz",
+      "integrity": "sha512-6hHV52+eUk654Y1J2v77B8iLeBNtc+SA3R4necsu2VVinSD7+XY5PCCEzBFaWs42dtOEDIa2lMrgL0YBC01mDQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/grid": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/grid/-/grid-5.1.2.tgz",
+      "integrity": "sha512-K3YiV1KyHHzgdNuNlaw8oW2ktMuGga99o1e/NAfTEi5Zsa7JXxzwEnVSDSBdJC+z6R8WYTCYRQC6bkVFcvdTeg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/layout": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/layout/-/layout-5.1.2.tgz",
+      "integrity": "sha512-wUhkMBqSeacPFhoE9S6UF3fsMEKFv91gF4AdDWp0Aym1yeMPpqz9l9qS/6vjSsDPF7zOb5cOKC3tcKKOMuDCPw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/position": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/position/-/position-5.1.2.tgz",
+      "integrity": "sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/shadow": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/shadow/-/shadow-5.1.2.tgz",
+      "integrity": "sha512-wqniqYb7XuZM7K7C0d1Euxc4eGtqEe/lvM0WjuAFsQVImiq6KGT7s7is+0bNI8O4Dwg27jyu4Lfqo/oIQXNzAg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/should-forward-prop": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/should-forward-prop/-/should-forward-prop-5.1.5.tgz",
+      "integrity": "sha512-+rPRomgCGYnUIaFabDoOgpSDc4UUJ1KsmlnzcEp0tu5lFrBQKgZclSo18Z1URhaZm7a6agGtS5Xif7tuC2s52Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emotion/is-prop-valid": "^0.8.1",
+        "@emotion/memoize": "^0.7.1",
+        "styled-system": "^5.1.5"
+      }
+    },
+    "@styled-system/space": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/space/-/space-5.1.2.tgz",
+      "integrity": "sha512-+zzYpR8uvfhcAbaPXhH8QgDAV//flxqxSjHiS9cDFQQUSznXMQmxJegbhcdEF7/eNnJgHeIXv1jmny78kipgBA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/typography": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@styled-system/typography/-/typography-5.1.2.tgz",
+      "integrity": "sha512-BxbVUnN8N7hJ4aaPOd7wEsudeT7CxarR+2hns8XCX1zp0DFfbWw4xYa/olA0oQaqx7F1hzDg+eRaGzAJbF+jOg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/core": "^5.1.2"
+      }
+    },
+    "@styled-system/variant": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/variant/-/variant-5.1.5.tgz",
+      "integrity": "sha512-Yn8hXAFoWIro8+Q5J8YJd/mP85Teiut3fsGVR9CAxwgNfIAiqlYxsk5iHU7VHJks/0KjL4ATSjmbtCDC/4l1qw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/core": "^5.1.2",
+        "@styled-system/css": "^5.1.5"
       }
     },
     "@stylelint/postcss-css-in-js": {
@@ -5228,6 +5480,37 @@
       "dev": true,
       "requires": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-emotion": {
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      }
+    },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
       }
     },
     "babel-plugin-styled-components": {
@@ -7129,6 +7412,19 @@
         "resolve": "^1.13.1"
       }
     },
+    "eslint-mdx": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-mdx/-/eslint-mdx-1.7.0.tgz",
+      "integrity": "sha512-92pxUaau8BxE1cblg5uMBE0MgVIianJiB7QuCdSz1WBNYP93HxxdBIxY8s5USEO9XnKlB7ZOuNKxfjboqphEmQ==",
+      "dev": true,
+      "requires": {
+        "espree": "^6.2.1",
+        "remark-mdx": "^1.6.0",
+        "remark-parse": "^8.0.2",
+        "tslib": "^1.11.1",
+        "unified": "^9.0.0"
+      }
+    },
     "eslint-module-utils": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
@@ -7224,6 +7520,24 @@
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-mdx": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mdx/-/eslint-plugin-mdx-1.7.0.tgz",
+      "integrity": "sha512-imsjx2FATGv9dZR7vU4XCmgh84QgXFCe8QgNd9emttv1r6gAYP3QolLD0v4JdqyugqHDZ473Vliot6+UNH0DtQ==",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^6.0.0",
+        "eslint-mdx": "^1.7.0",
+        "eslint-plugin-react": "^7.19.0",
+        "rebass": "^4.0.7",
+        "remark-mdx": "^1.6.0",
+        "remark-parse": "^8.0.2",
+        "remark-stringify": "^8.0.0",
+        "tslib": "^1.11.1",
+        "unified": "^9.0.0",
+        "vfile": "^4.1.0"
       }
     },
     "eslint-plugin-node": {
@@ -7728,6 +8042,13 @@
           }
         }
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true,
+      "optional": true
     },
     "find-up": {
       "version": "2.1.0",
@@ -12036,6 +12357,16 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "rebass": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/rebass/-/rebass-4.0.7.tgz",
+      "integrity": "sha512-GJot6j6Qcr7jk1QIgf9qBoud75CGRpN8pGcEo98TSp4KNSWV01ZLvGwFKGI35oEBuNs+lpEd3+pnwkQUTSFytg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "reflexbox": "^4.0.6"
+      }
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -12044,6 +12375,20 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
+      }
+    },
+    "reflexbox": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/reflexbox/-/reflexbox-4.0.6.tgz",
+      "integrity": "sha512-UNUL4YoJEXAPjRKHuty1tuOk+LV1nDJ2KYViDcH7lYm5yU3AQ+EKNXxPU3E14bQNK/pE09b1hYl+ZKdA94tWLQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emotion/core": "^10.0.0",
+        "@emotion/styled": "^10.0.0",
+        "@styled-system/css": "^5.0.0",
+        "@styled-system/should-forward-prop": "^5.0.0",
+        "styled-system": "^5.0.0"
       }
     },
     "regenerate": {
@@ -12149,6 +12494,214 @@
         "remark-parse": "^8.0.0",
         "remark-stringify": "^8.0.0",
         "unified": "^9.0.0"
+      }
+    },
+    "remark-mdx": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.5.tgz",
+      "integrity": "sha512-zItwP3xcVQAEPJTHseFh+KZEyJ31+pbVJMOMzognqTuZ2zfzIR4Xrg0BAx6eo+paV4fHne/5vi2ugWtCeOaBRA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "7.9.6",
+        "@babel/helper-plugin-utils": "7.8.3",
+        "@babel/plugin-proposal-object-rest-spread": "7.9.6",
+        "@babel/plugin-syntax-jsx": "7.8.3",
+        "@mdx-js/util": "^1.6.5",
+        "is-alphabetical": "1.0.4",
+        "remark-parse": "8.0.2",
+        "unified": "9.0.0"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz",
+          "integrity": "sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.6",
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helpers": "^7.9.6",
+            "@babel/parser": "^7.9.6",
+            "@babel/template": "^7.8.6",
+            "@babel/traverse": "^7.9.6",
+            "@babel/types": "^7.9.6",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
+          "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.2",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+          "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.1",
+            "@babel/template": "^7.10.1",
+            "@babel/types": "^7.10.1"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.10.1",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+              "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.10.1"
+              }
+            },
+            "@babel/template": {
+              "version": "7.10.1",
+              "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+              "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+              "dev": true,
+              "requires": {
+                "@babel/code-frame": "^7.10.1",
+                "@babel/parser": "^7.10.1",
+                "@babel/types": "^7.10.1"
+              }
+            }
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+          "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+          "dev": true
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+          "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+          "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+          "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+          "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+          "dev": true
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.6.tgz",
+          "integrity": "sha512-Ga6/fhGqA9Hj+y6whNpPv8psyaK5xzrQwSPsGPloVkvmH+PqW1ixdnfJ9uIO06OjQNYol3PMnfmJ8vfZtkzF+A==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+            "@babel/plugin-transform-parameters": "^7.9.5"
+          }
+        },
+        "@babel/plugin-syntax-jsx": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.3.tgz",
+          "integrity": "sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.3"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
+          "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.1",
+            "@babel/generator": "^7.10.1",
+            "@babel/helper-function-name": "^7.10.1",
+            "@babel/helper-split-export-declaration": "^7.10.1",
+            "@babel/parser": "^7.10.1",
+            "@babel/types": "^7.10.1",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.10.1",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+              "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+              "dev": true,
+              "requires": {
+                "@babel/highlight": "^7.10.1"
+              }
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "remark-parse": {
@@ -13074,6 +13627,28 @@
         "hoist-non-react-statics": "^3.0.0",
         "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
+      }
+    },
+    "styled-system": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.1.5.tgz",
+      "integrity": "sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@styled-system/background": "^5.1.2",
+        "@styled-system/border": "^5.1.5",
+        "@styled-system/color": "^5.1.2",
+        "@styled-system/core": "^5.1.2",
+        "@styled-system/flexbox": "^5.1.2",
+        "@styled-system/grid": "^5.1.2",
+        "@styled-system/layout": "^5.1.2",
+        "@styled-system/position": "^5.1.2",
+        "@styled-system/shadow": "^5.1.2",
+        "@styled-system/space": "^5.1.2",
+        "@styled-system/typography": "^5.1.2",
+        "@styled-system/variant": "^5.1.5",
+        "object-assign": "^4.1.1"
       }
     },
     "stylelint": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-declarations": "lerna exec --ignore @titicaca/triple-frontend-docs --ignore @titicaca/triple-frontend-tests tsc -- --incremental",
     "dev-docs": "lerna exec --scope @titicaca/triple-frontend-docs npm run dev",
     "lint-json": "prettier --check '**/*.json'",
-    "lint-es": "eslint '{docs,packages,tests/src}/**/*.{ts,tsx,js}'",
+    "lint-es": "eslint '{docs,packages,tests/src}/**/*.{ts,tsx,js,mdx}'",
     "lint-style": "stylelint './**/*.{ts,tsx,js}'",
     "lint": "concurrently --names eslint,stylelint,jsonlint 'npm:lint-es' 'npm:lint-style' 'npm:lint-json'",
     "test": "cd tests && npm test",
@@ -40,6 +40,7 @@
     "concurrently": "^4.1.2",
     "csstype": "^2.6.6",
     "eslint-plugin-cypress": "^2.11.1",
+    "eslint-plugin-mdx": "^1.7.0",
     "husky": "^3.0.5",
     "lerna": "^3.22.1",
     "lint-staged": "^10.2.9",
@@ -59,6 +60,9 @@
     "**/*.{js,ts,tsx}": [
       "eslint",
       "stylelint"
+    ],
+    "**/*.mdx": [
+      "eslint"
     ],
     "**/*.json": [
       "prettier --check"


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
mdx 파일을 린팅할 수 있도록 eslint-mdx 플러그인을 추가합니다.

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
Closes #807 

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

`npm run lint-es`

### For VSCode users
[vscode-mdx](https://marketplace.visualstudio.com/items?itemName=JounQin.vscode-mdx)를 설치해주세요. 그리고 eslint가 mdx 파일을 읽을 수 있도록 다음 설정을 settings에 추가해주세요.
```json
{
  "eslint.options": {
    "extensions": [".js", ".ts", ".tsx", ".mdx"]
  },
  "eslint.validate": ["mdx"],
}
```
[공식 문서](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)에서 `eslint.validate` 옵션은 
> This is an old legacy setting and should in normal cases not be necessary anymore. 

라고 하지만 mdx를 읽게 하려면 이 옵션을 사용해야 합니다.

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)