### PR TITLE
fix(user-verification): react-contexts 를 devDeps, peerDeps 로 이동합니다.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.24.0 (2020-06-18)
+
 # 1.23.0 (2020-06-04)
 
 - `react-contexts` device context에 state 추가 #787device context에 state 추가 (#787)

--- a/packages/user-verification/package.json
+++ b/packages/user-verification/package.json
@@ -26,15 +26,16 @@
   "dependencies": {
     "@titicaca/core-elements": "^1.23.0",
     "@titicaca/modals": "^1.23.0",
-    "@titicaca/react-contexts": "^1.23.0",
     "@titicaca/react-hooks": "^1.23.0",
     "isomorphic-fetch": "^2.2.1"
   },
   "devDependencies": {
+    "@titicaca/react-contexts": "^1.23.0",
     "@titicaca/triple-web-to-native-interfaces": "^1.1.2",
     "@types/isomorphic-fetch": "^0.0.35"
   },
   "peerDependencies": {
+    "@titicaca/react-contexts": "*",
     "@titicaca/triple-web-to-native-interfaces": "*"
   }
 }


### PR DESCRIPTION
## 설명
user-verification 모듈에서 HistoryContext 와 연관된 `openWindow` 가 기대치와 다른 동작을 개선합니다.

## 변경 내역 및 배경
- [x] react-contexts 모듈을 devDeps 와 peerDeps 로 이동합니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
- [x] cash-web 에서 동작을 검증합니다.