### PR TITLE
[core-elements] feature: container 에서 width, height 의 unit, bg color 를 지원하는 prop 을 추가합니다

### DIFF
--- a/packages/core-elements/src/elements/container.ts
+++ b/packages/core-elements/src/elements/container.ts
@@ -4,6 +4,7 @@ import * as CSS from 'csstype'
 
 import { MarginPadding, BaseSizes } from '../commons'
 import { paddingMixin, formatMarginPadding, shadowMixin } from '../mixins'
+import { unit } from '../utils/unit'
 
 export interface ContainerPropsFromTemplate {
   position?: CSS.PositionProperty
@@ -58,41 +59,37 @@ const Container = styled.div<ContainerPropsFromTemplate>`
   ${({ width }) =>
     width &&
     `
-      width: ${typeof width === 'string' ? width : `${width}px`};
+      width: ${unit(width)};
     `};
 
   ${({ height }) =>
     height &&
     `
-      height: ${typeof height === 'string' ? height : `${height}px`};
+      height: ${unit(height)};
     `};
 
   ${({ minWidth }) =>
     minWidth &&
     `
-     min-width: ${typeof minWidth === 'string' ? minWidth : `${minWidth}px`};
+     min-width: ${unit(minWidth)};
     `};
 
   ${({ maxWidth }) =>
     maxWidth &&
     `
-    max-width: ${typeof maxWidth === 'string' ? maxWidth : `${maxWidth}px`};
+    max-width: ${unit(maxWidth)};
     `};
 
   ${({ minHeight }) =>
     minHeight &&
     `
-      min-height: ${
-        typeof minHeight === 'string' ? minHeight : `${minHeight}px`
-      };
+      min-height: ${unit(minHeight)};
     `};
 
   ${({ maxHeight }) =>
     maxHeight &&
     `
-      max-height: ${
-        typeof maxHeight === 'string' ? maxHeight : `${maxHeight}px`
-      };
+      max-height: ${unit(maxHeight)};
     `};
 
   float: ${({ floated }) => floated || 'none'};


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

container 에서 width, height 의 unit, bg color 를 지원하는 prop 을 추가합니다

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

이런적 없으셨나요 선배님들 ... Container 의 bgColor가 필요하여 불필요한 상속을 했다거나 ..
넓이와 높이가 px 단위만 가능하기에 상속하여 다른 unit (ex. 100vh) 같은걸 사용했다거나 .. 

이를 위해 우리는 달라져야합니다 ... unit 을 따로 받기에는 관리포인트가 애매하기에.. string | number 로 분류합니다..

다만 걱정되는건 ts 가 아닌 프로젝트에서 <Container width="40" /> 요런식으로 쓰고있었다면 곤란한 상황이
발생합니다 ... 

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->
DOCS

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
