### PR TITLE
[app-installation-cta] 이미지 배너의 앱설치 버튼 레이블 변경

### DIFF
--- a/packages/app-installation-cta/src/image-banner.tsx
+++ b/packages/app-installation-cta/src/image-banner.tsx
@@ -28,7 +28,7 @@ const BannerImage = styled.img`
   position: relative;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate3d(-50%, -50%, 0);
   display: block;
   width: 320px;
   height: 130px;
@@ -79,7 +79,9 @@ const ImageBanner: FC<ImageBannerProps> = ({
         <BannerImage src={imgUrl} />
       </ImageWrapper>
 
-      <InstallLink href={installUrl}>👋🏻 손쉽게 앱 설치하기</InstallLink>
+      <InstallLink href={installUrl}>
+        👀&nbsp;&nbsp;편하게 앱에서 보기
+      </InstallLink>
 
       <DismissButton onClick={onDismiss}>
         아깝지만 나중에 받을게요


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
- 이미지 배너에 들어간 앱설치 버튼의 레이블을 변경합니다.
- 이미지 배너의 이미지가 흐리게 보일 수 있는 문제를 수정합니다.
   - translate 를 translate3d 로 변경

## 변경 내역 및 배경
> Closes #825

https://titicaca.slack.com/archives/CNWL62EHH/p1592473592035300?thread_ts=1592370031.027600&cid=CNWL62EHH

국내(제주) 오픈 앱 설치 검색 광고 관련 CTA 문구 변경

## 사용 및 테스트 방법
- 스토리북

## 스크린샷
![Screen Shot 2020-06-23 at 10 04 04](https://user-images.githubusercontent.com/189953/85349233-e8fe5700-b538-11ea-888d-1d0947e15559.png)


## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
