### PR TITLE
[core-elements] Navbar의 TitleContainer의 영역를 확장합니다.

### DIFF
--- a/packages/core-elements/src/elements/navbar.tsx
+++ b/packages/core-elements/src/elements/navbar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as CSS from 'csstype'
 import styled, { css } from 'styled-components'
-import { Color, getColor } from '@titicaca/color-palette'
+import { Color, getColor, brightGray } from '@titicaca/color-palette'
 
 const NavbarFrame = styled.header<{
   borderless?: boolean
@@ -19,7 +19,7 @@ const NavbarFrame = styled.header<{
     borderless
       ? ''
       : css`
-          box-shadow: 0 1px 0 0 #efefef;
+          box-shadow: 0 1px 0 0 ${brightGray};
         `};
   box-sizing: border-box;
   padding: 9px 12px;


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
close #834 

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
- TitleContainer에 line-height를 navrbar 높이인 `52px`을 추가해줍니다. 요 방식은  TitleContainer의 텍스트가 한줄일때만 가능합니다.
- #efefef -> brightGray 로 수정합니다.

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->
storybook

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->
- https://github.com/titicacadev/triple-frontend/pull/778 수정 전의 영역
<img width="821" alt="스크린샷 2020-06-29 오후 5 40 39" src="https://user-images.githubusercontent.com/51554632/85994118-495a3080-ba32-11ea-9b05-023fcd989ea5.png">


- https://github.com/titicacadev/triple-frontend/pull/778 수정 후의 영역
<img width="821" alt="스크린샷 2020-06-29 오후 6 00 37" src="https://user-images.githubusercontent.com/51554632/85994435-c1285b00-ba32-11ea-8c08-21a37fb28ca4.png">

- 이번 pr 수정 후의 영역
<img width="821" alt="스크린샷 2020-06-29 오후 5 42 21" src="https://user-images.githubusercontent.com/51554632/85994462-ca192c80-ba32-11ea-8d2a-bd85ff047899.png">


## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
