### PR TITLE
[Date-Picker] range-picker에서 맨 처음 월을 오늘 날짜 기준 월로 고칩니다.

### DIFF
--- a/packages/date-picker/src/range-picker.tsx
+++ b/packages/date-picker/src/range-picker.tsx
@@ -54,7 +54,7 @@ const RangeContainer = styled(PickerFrame)<{
 `
 
 function getInitialMonth() {
-  return moment().add(1, 'day').startOf('day').toDate()
+  return moment().startOf('day').toDate()
 }
 
 function RangePicker({


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
this closes https://titicaca.slack.com/archives/CA3QE80QL/p1593497355082100?thread_ts=1593419043.069000&cid=CA3QE80QL

## 변경 내역 및 배경
- range-picker에서 오늘이 말일 일때 오늘 날짜를 선택할 수 없는 문제 수정
  - `getInitialMonth`에서 +1 day 하던 로직을 삭제합니다.


## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
