### PR TITLE
[#818] slider: step이 배수가 아닐 경우 가까운 숫자로 조정

### DIFF
--- a/docs/stories/slider/slider.stories.tsx
+++ b/docs/stories/slider/slider.stories.tsx
@@ -74,14 +74,14 @@ BaseRangeSlider.story = {
 
 
 export function AdjustedRangeSlider() {
-  const [values, setValues] = useState([1, 13])
+  const [values, setValues] = useState([1, 31])
   return (
     <div>
       컴포넌트 외부: {values.join(', ')}
       <RangeSlider
         initialValues={values}
         min={1}
-        max={13}
+        max={31}
         step={3}
         onChange={([form, to]) => {
           setValues([form, to])

--- a/packages/slider/src/slider-base.tsx
+++ b/packages/slider/src/slider-base.tsx
@@ -1,6 +1,7 @@
 import React, {
   useState,
   useEffect,
+  useMemo,
   useCallback,
   ComponentType,
   PropsWithChildren,
@@ -96,14 +97,18 @@ export default function SliderBase({
     debounceTime,
   ])
 
+  const adjustedValues = useMemo(
+    () => [Math.max(min, values[0]), Math.min(max, values[1])],
+    [max, min, values],
+  )
+
   useEffect(() => {
-    const adjustedValue = [Math.max(min, values[0]), Math.min(max, values[1])]
-    debouncedChangeHandler(adjustedValue)
-  }, [values, min, max]) // eslint-disable-line react-hooks/exhaustive-deps
+    debouncedChangeHandler(adjustedValues)
+  }, [adjustedValues]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Container>
-      {LabelComponent ? <LabelComponent values={values} /> : null}
+      {LabelComponent ? <LabelComponent values={adjustedValues} /> : null}
 
       <SliderContainer>
         <OriginalSlider


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
슬라이더의 min max가 step의 배수가 아닐 경우 가까운 값으로 조정합니다.

## 변경 내역 및 배경
this closes #818 

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
