### PR TITLE
[poi-detail] feature: hr 구분선을 제거 할 수 있는 prop 을 추가합니다

### DIFF
--- a/packages/poi-detail/src/actions.tsx
+++ b/packages/poi-detail/src/actions.tsx
@@ -15,7 +15,7 @@ export default function Actions({
   onScrapedChange,
   onContentShare,
   onReviewEdit,
-  hideUnderLine,
+  noDivider,
   ...props
 }: {
   poiId: string
@@ -27,7 +27,7 @@ export default function Actions({
   onReviewEdit: () => void
   margin?: MarginPadding
   padding?: MarginPadding
-  hideUnderLine?: boolean
+  noDivider?: boolean
 }) {
   const { t } = useI18n()
 
@@ -68,7 +68,7 @@ export default function Actions({
           {t('common:share', '공유하기')}
         </ActionButton>
       </Button.Group>
-      {!hideUnderLine && <HR1 margin={{ top: 8, bottom: 0 }} />}
+      {!noDivider && <HR1 margin={{ top: 8, bottom: 0 }} />}
     </Section>
   )
 }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

poi-detail-action 의  hr 구분선을 제거 할 수 있는 prop 을 추가합니다

## 변경 내역 및 배경
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

기본적으로 hr1 을 탑재하고있으나, 변경된 디자인에서는 다른 구분선을 원합니다.
이를 위해 기본 구분선을 가릴 수 있는 prop 을 추가합니다

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

![image](https://user-images.githubusercontent.com/27910236/86561353-64c9bc00-bf9b-11ea-892b-179c7256703e.png)


## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [x] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
