### PR TITLE
[core-elements] Radio 컴포넌트에 multiline, textAlign, outline props를 추가합니다.

### DIFF
--- a/packages/core-elements/src/elements/radio.tsx
+++ b/packages/core-elements/src/elements/radio.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
-import styled, { css } from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
+import styled from 'styled-components'
+import { gray100 } from '@titicaca/color-palette'
 
 import Text from './text'
 import { withField } from '../utils/form-field'
 
 type RadioValue = string | null
-type RadioDirection = 'left' | 'right'
+type TextAlign = 'left' | 'right'
 
 interface Option {
   text: string
@@ -16,7 +16,7 @@ interface Option {
 const RADIO_INPUT_SIZE = 26
 
 const RadioFrame = styled.div<{
-  direction?: RadioDirection
+  textAlign?: TextAlign
   outline?: boolean
 }>`
   position: relative;
@@ -26,51 +26,51 @@ const RadioFrame = styled.div<{
     margin-bottom: 0;
   }
 
-  ${({ direction, outline }) =>
-    direction === 'left'
+  ${({ textAlign, outline }) =>
+    textAlign === 'left'
       ? outline
-        ? css`
+        ? `
             padding: 20px ${RADIO_INPUT_SIZE + 20}px 20px 20px;
           `
-        : css`
+        : `
             padding-right: ${RADIO_INPUT_SIZE + 3}px;
           `
       : outline
-      ? css`
+      ? `
           padding: 20px 20px 20px ${RADIO_INPUT_SIZE + 20}px;
         `
-      : css`
+      : `
           padding-left: ${RADIO_INPUT_SIZE + 20}px;
         `};
 
   ${({ outline }) =>
     outline &&
-    css`
+    `
       border-radius: 2px;
-      border: solid 1px rgba(${getColor('gray100')});
+      border: solid 1px ${gray100};
     `}
 `
 
 const RadioText = styled(Text)<{
-  direction?: RadioDirection
+  textAlign?: TextAlign
   multiline?: boolean
 }>`
   vertical-align: middle;
   ${({ multiline }) =>
     !multiline &&
-    css`
+    `
       width: 100%;
     `}
-  ${({ direction }) =>
-    direction === 'right' &&
-    css`
+  ${({ textAlign }) =>
+    textAlign === 'right' &&
+    `
       padding-left: 15px;
     `}
 `
 
 const RadioInput = styled.input.attrs({ type: 'radio' })<{
   selected?: boolean
-  direction?: RadioDirection
+  textAlign?: TextAlign
   outline?: boolean
 }>`
   position: absolute;
@@ -87,22 +87,22 @@ const RadioInput = styled.input.attrs({ type: 'radio' })<{
   outline: none;
   transform: translateY(-50%);
 
-  ${({ direction, outline }) =>
-    direction === 'left'
-      ? css`
+  ${({ textAlign, outline }) =>
+    textAlign === 'left'
+      ? `
           right: ${outline ? '20px' : '0'};
         `
-      : css`
+      : `
           left: ${outline ? '20px' : '0'};
         `};
 
   ${({ selected }) =>
     selected
-      ? css`
+      ? `
           opacity: 1;
           background-image: url('https://assets.triple.guide/images/btn-filter-radio-check.svg');
         `
-      : css`
+      : `
           opacity: 0.5;
           background-image: url('https://assets.triple.guide/images/btn-filter-radio.svg');
         `};
@@ -112,7 +112,7 @@ interface RadioProps {
   name?: string
   value?: RadioValue
   onChange?: (e: React.SyntheticEvent, value: RadioValue) => void
-  direction?: RadioDirection
+  textAlign?: TextAlign
   multiline?: boolean
   outline?: boolean
   options: Option[]
@@ -122,7 +122,7 @@ function Radio({
   name,
   value,
   onChange,
-  direction = 'left',
+  textAlign = 'left',
   multiline = false,
   outline = false,
   options,
@@ -132,14 +132,14 @@ function Radio({
       {options.map(({ text, value: optionValue }, idx) => (
         <RadioFrame
           key={idx}
-          direction={direction}
+          textAlign={textAlign}
           outline={outline}
           onClick={(e) => onChange && onChange(e, optionValue)}
         >
           <RadioText
             inlineBlock
             size="large"
-            direction={direction}
+            textAlign={textAlign}
             multiline={multiline}
             ellipsis={!multiline}
           >
@@ -148,7 +148,7 @@ function Radio({
 
           <RadioInput
             name={name}
-            direction={direction}
+            textAlign={textAlign}
             outline={outline}
             selected={optionValue === value}
           />


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
디자인 변경을 반영하기 위해 Radio 컴포넌트에 추가 props를 받아 기능을 추가합니다.

## 변경 내역 및 배경
* multiline: 기존에 기본으로  radio에는`ellipsis` 로 텍스트를 표현했는데 multiline props로 여러 줄 텍스트를 지원합니다. 
* textAlign: 텍스트 기준입니다. 기본으로 `left` 이지만 `right`로 해서 텍스트를 오른쪽에, 라디오 버튼을 왼쪽에 위치시킬 수 있습니다.
* outline: 라디오 버튼 영역에 border를 부여합니다. 사이즈와 색상은 고정입니다(radius 2px, solid 1px, gray-100)
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->
![image](https://user-images.githubusercontent.com/49010551/86982025-33cbd000-c1c3-11ea-9f3f-c1dbf4282636.png)

## 이 PR의 유형
<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
