### PR TITLE
[app-installation-cta] 각 CTA 에서 모두 지표 트래킹을 가능하게합니다.

### DIFF
--- a/docs/stories/app-installation-cta/app-installation-cta.stories.tsx
+++ b/docs/stories/app-installation-cta/app-installation-cta.stories.tsx
@@ -26,6 +26,9 @@ export function FloatingButton() {
         onSelect: 'onSelect(click)',
         onClose: 'onClose(dismiss)',
       }}
+      onShow={action('onShow')}
+      onClick={action('onClick')}
+      onDismiss={action('onDismiss')}
     />
   )
 }
@@ -39,13 +42,9 @@ export function BaseImageBanner() {
     <ImageBanner
       imgUrl={text('이미지 URL', '')}
       installUrl={text('설치 URL', 'https://triple-dev.titicaca-corp.com')}
-      onDismiss={action('banner dismissed')}
-      trackEvent={action('tracked')}
-      trackEventParams={{
-        onShow: 'onShow',
-        onSelect: 'onSelect(click)',
-        onDismiss: 'onDismiss(close)',
-      }}
+      onShow={action('onShow')}
+      onClick={action('onClick')}
+      onDismiss={action('onDismiss')}
     />
   )
 }
@@ -59,11 +58,8 @@ export function BaseTextBanner() {
     <TextBanner
       message={text('표시할 메시지', '앱 다운로드시 가이드북 무료')}
       installUrl={text('설치 URL', 'https://triple-dev.titicaca-corp.com')}
-      trackEvent={action('tracked')}
-      trackEventParams={{
-        onShow: 'onShow',
-        onSelect: 'onSelect(click)',
-      }}
+      onShow={action('onShow')}
+      onClick={action('onClick')}
     />
   )
 }
@@ -81,13 +77,9 @@ export function BaseBannerCTA() {
           'app-install-cta-poi-v1',
         )}
         installUrl={text('설치 URL', 'https://triple-dev.titicaca-corp.com')}
-        onDismiss={action('banner dismissed')}
-        trackEvent={action('tracked')}
-        trackEventParams={{
-          onShow: 'onShow',
-          onSelect: 'onSelect(click)',
-          onDismiss: 'onDismiss(close)',
-        }}
+        onShow={action('onShow')}
+        onClick={action('onClick')}
+        onDismiss={action('onDismiss')}
       />
 
       <div style={{ height: '2000px' }} />
@@ -109,13 +101,9 @@ export function ChatBotBanner() {
           'app-install-cta-chatbot-v1',
         )}
         installUrl={text('설치 URL', 'https://triple.guide/magazine')}
-        onDismiss={action('banner dismissed')}
-        trackEvent={action('tracked')}
-        trackEventParams={{
-          onShow: 'onShow',
-          onSelect: 'onSelect(click)',
-          onDismiss: 'onDismiss(close)',
-        }}
+        onShow={action('onShow')}
+        onClick={action('onClick')}
+        onDismiss={action('onDismiss')}
       />
     </div>
   )
@@ -143,6 +131,9 @@ export function FloatingButtonWithChatBot() {
           onSelect: 'onSelect(click)',
           onClose: 'onClose(dismiss)',
         }}
+        onShow={action('onShow')}
+        onClick={action('onClick')}
+        onDismiss={action('onDismiss')}
       />
       <ChatbotCTA
         available={boolean('챗봇 사용 가능상태', false)}
@@ -151,13 +142,9 @@ export function FloatingButtonWithChatBot() {
           'app-install-cta-chatbot-v1',
         )}
         installUrl={text('설치 URL', 'https://triple.guide/magazine')}
-        onDismiss={action('banner dismissed')}
-        trackEvent={action('tracked')}
-        trackEventParams={{
-          onShow: 'onShow',
-          onSelect: 'onSelect(click)',
-          onDismissClose: 'onDismiss(close)',
-        }}
+        onShow={action('onShow')}
+        onClick={action('onClick')}
+        onDismiss={action('onDismiss')}
       />
     </div>
   )

--- a/packages/app-installation-cta/src/banner-cta.tsx
+++ b/packages/app-installation-cta/src/banner-cta.tsx
@@ -3,17 +3,11 @@ import React, { useState, useEffect } from 'react'
 import { Overlay, BottomFixedContainer } from './elements'
 import ImageBanner from './image-banner'
 import TextBanner from './text-banner'
-import { EventTrackingProps } from './interfaces'
+import { InventoryItem, CTAProps } from './interfaces'
 
-type CTAImage = {
-  image?: string
-  desc?: string
-}
-
-interface BannerCTAProps extends EventTrackingProps {
+interface BannerCTAProps extends CTAProps {
   inventoryId: string
   installUrl: string
-  onDismiss?: (ctaImage?: CTAImage) => void
 }
 
 /**
@@ -25,13 +19,13 @@ interface BannerCTAProps extends EventTrackingProps {
 export default function BannerCTA({
   inventoryId,
   installUrl,
+  onShow,
+  onClick,
   onDismiss,
-  trackEvent,
-  trackEventParams,
 }: BannerCTAProps) {
-  const [ctaImage, setCTAImage] = useState<CTAImage>()
+  const [inventoryItem, setInventoryItem] = useState<InventoryItem>()
   const [isImageBannerOpen, setIsImageBannerOpen] = useState(true)
-  const { image = '', desc = '' } = ctaImage || {}
+  const { image = '', desc = '' } = inventoryItem || {}
 
   useEffect(() => {
     async function fetchCTAImage() {
@@ -45,7 +39,7 @@ export default function BannerCTA({
         if (items.length > 0) {
           const item = items[0]
 
-          setCTAImage({
+          setInventoryItem({
             image: item.image ? item.image.replace(/\.jpg$/, '.png') : '',
             desc: item.desc,
           })
@@ -58,19 +52,19 @@ export default function BannerCTA({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inventoryId])
 
-  return ctaImage ? (
-    isImageBannerOpen ? (
+  return inventoryItem ? (
+    isImageBannerOpen && image ? (
       <Overlay>
         <BottomFixedContainer>
           <ImageBanner
             imgUrl={image}
             installUrl={installUrl}
+            onShow={onShow}
+            onClick={onClick}
             onDismiss={() => {
               setIsImageBannerOpen(false)
-              onDismiss && onDismiss(ctaImage)
+              onDismiss && onDismiss(inventoryItem)
             }}
-            trackEvent={trackEvent}
-            trackEventParams={trackEventParams}
           />
         </BottomFixedContainer>
       </Overlay>
@@ -78,8 +72,8 @@ export default function BannerCTA({
       <TextBanner
         message={desc}
         installUrl={installUrl}
-        trackEvent={trackEvent}
-        trackEventParams={trackEventParams}
+        onShow={onShow}
+        onClick={onClick}
       />
     )
   ) : null

--- a/packages/app-installation-cta/src/image-banner.tsx
+++ b/packages/app-installation-cta/src/image-banner.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import {
   ImageBannerWrapper,
@@ -7,44 +7,40 @@ import {
   InstallLink,
   DismissButton,
 } from './elements'
-import { EventTrackingProps } from './interfaces'
+import { CTAProps } from './interfaces'
 
-interface ImageBannerProps extends EventTrackingProps {
+interface ImageBannerProps extends CTAProps {
   imgUrl?: string
   installUrl: string
-  onDismiss: () => void
 }
 
 export default function ImageBanner({
   imgUrl,
   installUrl,
+  onShow,
+  onClick,
   onDismiss,
-  trackEvent,
-  trackEventParams,
 }: ImageBannerProps) {
   const imgSrc =
     (imgUrl ?? '').trim() ||
     'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
 
-  const sendTrackEventRequest = useCallback(
-    (param) => {
-      trackEvent && param && trackEvent(param)
-    },
-    [trackEvent],
+  const inventoryItem = useMemo(
+    () => (imgUrl ? { image: imgUrl } : undefined),
+    [imgUrl],
   )
 
   useEffect(() => {
-    sendTrackEventRequest(trackEventParams && trackEventParams.onShow)
-  }, [sendTrackEventRequest, trackEventParams])
+    onShow && onShow(inventoryItem)
+  }, [onShow, inventoryItem])
 
   const handleClick = useCallback(() => {
-    sendTrackEventRequest(trackEventParams && trackEventParams.onSelect)
-  }, [sendTrackEventRequest, trackEventParams])
+    onClick && onClick(inventoryItem)
+  }, [onClick, inventoryItem])
 
   const handleDismiss = useCallback(() => {
-    onDismiss()
-    sendTrackEventRequest(trackEventParams && trackEventParams.onDismiss)
-  }, [onDismiss, sendTrackEventRequest, trackEventParams])
+    onDismiss && onDismiss(inventoryItem)
+  }, [onDismiss, inventoryItem])
 
   return (
     <ImageBannerWrapper>

--- a/packages/app-installation-cta/src/interfaces.ts
+++ b/packages/app-installation-cta/src/interfaces.ts
@@ -1,9 +1,12 @@
-export interface EventTrackingProps {
-  trackEvent?: any
-  trackEventParams?: {
-    onShow?: any
-    onSelect?: any
-    onDismiss?: any
-    onClose?: any
-  }
+export interface InventoryItem {
+  image?: string
+  desc?: string
+  detailedDesc?: string
+  text?: string
+}
+
+export interface CTAProps {
+  onShow?: (item?: InventoryItem) => void
+  onClick?: (item?: InventoryItem) => void
+  onDismiss?: (item?: InventoryItem) => void
 }

--- a/packages/app-installation-cta/src/text-banner.tsx
+++ b/packages/app-installation-cta/src/text-banner.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import { TextBannerWrapper, DownloadIcon } from './elements'
-import { EventTrackingProps } from './interfaces'
+import { CTAProps } from './interfaces'
 
-interface TextBannerProps extends EventTrackingProps {
+interface TextBannerProps extends CTAProps {
   message: string
   installUrl: string
 }
@@ -11,23 +11,21 @@ interface TextBannerProps extends EventTrackingProps {
 export default function TextBanner({
   message,
   installUrl,
-  trackEvent,
-  trackEventParams,
+  onShow,
+  onClick,
 }: TextBannerProps) {
-  const sendTrackEventRequest = useCallback(
-    (param) => {
-      trackEvent && param && trackEvent(param)
-    },
-    [trackEvent],
+  const inventoryItem = useMemo(
+    () => (message ? { desc: message } : undefined),
+    [message],
   )
 
   useEffect(() => {
-    sendTrackEventRequest(trackEventParams && trackEventParams.onShow)
-  }, [sendTrackEventRequest, trackEventParams])
+    onShow && onShow(inventoryItem)
+  }, [onShow, inventoryItem])
 
   const handleClick = useCallback(() => {
-    sendTrackEventRequest(trackEventParams && trackEventParams.onSelect)
-  }, [sendTrackEventRequest, trackEventParams])
+    onClick && onClick(inventoryItem)
+  }, [onClick, inventoryItem])
 
   return (
     <TextBannerWrapper href={installUrl} onClick={handleClick}>


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
FloatingButtonCTA 를 제외한 나머지 CTA 가 지표 트래킹이 되지 않던 문제를 수정합니다.

## 변경 내역 및 배경
검색광고 인입등으로 표시되는 CTA 들의 노출, 클릭 지표를 트래킹할 수 있도록 합니다.

- ~모든 CTA 가 trackEvent, trackEventParams prop 을 받도록 합니다. (FloatingButtonCTA 와 동일)~
- `onShow`, `onClick` 그리고 `onDismiss` 이벤트 핸들러를 제공합니다.
   - FloatingButtonCTA 는 하위 호환을 위해 trackEvent 관련 prop 을 유지합니다.
- 일부 트래킹이 중복되거나 누락될 수 있는 로직 오류를 수정합니다.

## 사용 및 테스트 방법
app-installation-cta 스토리북 참조


## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
