### PR TITLE
[hub-form] CTA 버튼의 배경색을 변경합니다.

### DIFF
--- a/packages/hub-form/src/cta.tsx
+++ b/packages/hub-form/src/cta.tsx
@@ -15,7 +15,6 @@ export default function Cta({
       fluid
       borderRadius={4}
       disabled={!available}
-      color={available ? 'blue' : 'gray'}
       lineHeight="20px"
       onClick={available ? onSubmit : undefined}
     >


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

호텔 허브와 항공 허브에서 disabled된 CTA 버튼 색이 달랐더랬습니다. 요게 표준이라고 앺팀장님께서 확인해주셨습니다.

## 변경 내역 및 배경

CTA disabled시 blue 배경 + opacity 적용 상태로 합니다.

## 사용 및 테스트 방법

Canary / Docs

## 스크린샷

<img width="415" alt="Screen Shot 2020-07-21 at 7 18 03 PM" src="https://user-images.githubusercontent.com/712260/88042457-ebc78880-cb86-11ea-96e7-4f7e209e7e7c.png">


## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
