### PR TITLE
[Docs] release-docs 를 GHA workflow 로 옮깁니다.

### DIFF
--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -1,0 +1,111 @@
+name: Release Docs
+
+on:
+  push:
+    tags:
+      - 'v[12].[0-9]+.[0-9]+'
+      - 'release-docs'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    env:
+      SLACK_CHANNEL: '#triple-web-dev-notifications'
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SLACK_USERNAME: 'Triple Frontend'
+      SLACK_ICON_EMOJI: ':triple_new:'
+      SLACK_COLOR: gray
+      SLACK_FOOTER: 'Triple Frontend'
+      SLACK_TOPIC: 'Release docs'
+      SLACK_AUTHOR_NAME: ${{ github.event.sender.login }}
+      SLACK_AUTHOR_ICON: '${{ github.event.sender.avatar_url }}'
+      SLACK_GITHUB_REF: '${{ github.event.ref }}'
+      SLACK_GITHUB_EVENT_NAME: '${{ github.event_name }}'
+      SLACK_GITHUB_REPOSITORY: ${{ github.repository }}
+      SLACK_DETAIL_URL: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+
+    steps:
+      - uses: actions/checkout@v2-beta
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Define variables
+        run: |
+          VERSION="v$(cat ./lerna.json | jq -r '.version')"
+          echo "::set-env name=SLACK_TOPIC::Release docs of `$VERSION`"
+
+      - name: Docker Login
+        uses: azure/docker-login@v1
+        with:
+          login-server: docker.pkg.github.com
+          username: $GITHUB_ACTOR
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify build start to slack
+        env:
+          SLACK_TITLE: ':rocket: Build/Deploy Started'
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: |
+          npx @titicaca/gha-tools notify
+
+      - name: Restore Docker build caches
+        run: |
+          docker pull docker.pkg.github.com/titicacadev/triple-frontend/triple-frontend-docs-base || true
+          docker pull docker.pkg.github.com/titicacadev/triple-frontend/triple-frontend-docs-build || true
+
+      - name: Package release image
+        run: |
+          SHORT_SHA=${GITHUB_SHA::6}
+          CLUSTER="triple-dev"
+          SVC_BASENAME="triple-frontend-docs"
+          curl -f --request POST --url https://api.github.com/repos/${{ github.repository }}/deployments \
+            -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Content-Type: application/json' \
+            -d "{\"ref\":\"${GITHUB_REF}\",\"auto_merge\":false,\"required_contexts\":[],\"environment\":\"${ENVIRONMENT}\",\"sha\":\"${TAG_SHA}\"}" > deployment.json
+          DEPLOYMENT_ID=$(cat ./deployment.json | jq -r '.id')
+          IMG_TAG="${SHORT_SHA}"
+          docker build \
+            --file Dockrfile.docs \
+            --build-arg npm_token=$NODE_AUTH_TOKEN \
+            --cache-from docker.pkg.github.com/titicacadev/triple-frontend/${SVC_BASENAME}-base \
+            --cache-from docker.pkg.github.com/titicacadev/triple-frontend/${SVC_BASENAME}-build \
+            --tag 107243714588.dkr.ecr.ap-northeast-1.amazonaws.com/${SVC_BASENAME}:$IMG_TAG \
+            --tag 107243714588.dkr.ecr.ap-northeast-1.amazonaws.com/${SVC_BASENAME}:latest \
+            .
+          curl -sS --fail "https://ops.triple-corp.com/api/v1/gcp-ecr-auth?token=$OPS_API_KEY&script=1&region=ap-northeast-1" | bash
+          docker push 107243714588.dkr.ecr.ap-northeast-1.amazonaws.com/$SVC_BASENAME:$IMG_TAG
+          docker push 107243714588.dkr.ecr.ap-northeast-1.amazonaws.com/$SVC_BASENAME:latest
+          curl -sS --fail --max-time 60 -X POST "https://ops.triple-corp.com/api/v1/gcp-ecs-deploy/$CLUSTER/$SVC_BASENAME/$IMG_TAG?token=$OPS_API_KEY&region=ap-northeast-1"
+          curl -f --request POST --url https://api.github.com/repos/${{ github.repository }}/deployments/${DEPLOYMENT_ID}/statuses \
+            -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'Content-Type: application/json' \
+            -d "{\"state\":\"success\"}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          OPS_API_KEY: ${{ secrets.OPS_API_KEY }}
+
+      - name: Notify deploy success to slack
+        if: success()
+        env:
+          SLACK_TITLE: ':tada: Deploy Succeed'
+          SLACK_COLOR: success
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npx @titicaca/gha-tools notify
+
+      - name: Notify deploy fail to slack
+        if: failure()
+        env:
+          SLACK_TITLE: ':pleading: Deploy Failed'
+          SLACK_COLOR: fail
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npx @titicaca/gha-tools notify


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
- #552

gcp 의 release-docs 트리거를 GHA 의 workflow 로 옮깁니다.

## 변경 내역 및 배경
GHA 트리거를 이용해서, docs 독립 빌드를 구현하기 위한 작업을 시작합니다.


## 사용 및 테스트 방법
머지 또는 base 브랜치를 이 브랜치로 바꾸고, slack 커맨드로 release-docs 테스트


## 스크린샷

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
