### PR TITLE
Fix: 롤링 스피너 무한히 반복될 수 있도록 수정

### DIFF
--- a/packages/core-elements/src/elements/spinner/rolling-spinner.tsx
+++ b/packages/core-elements/src/elements/spinner/rolling-spinner.tsx
@@ -13,15 +13,6 @@ const marquee = keyframes`
  }
 `
 
-const swap = keyframes`
-    0%, 50% {
-      left: 0%;
-    }
-    50.01%,
-    100% {
-      left: 100%;
-  }
-`
 const RollingSpinnerFrame = styled.div`
   position: fixed;
   top: 0;
@@ -76,20 +67,41 @@ const TrackContainer = styled.div`
 `
 
 const Track = styled.div<{ duration: number }>`
+  position: relative;
   display: inline-block;
   animation: ${marquee} linear infinite;
   ${({ duration }) => `animation-duration: ${duration}s;`}
 `
 
-const ImageContainer = styled.div`
+const ImageContainer = styled.div<{
+  duration: number
+  offset: number
+}>`
+  position: relative;
   display: inline-block;
   vertical-align: top;
   font-size: 0;
-  &:first-child {
-    position: relative;
-    left: 0%;
-  }
-  animation: ${swap} linear infinite;
+
+  ${({ offset }) => {
+    const keyframeName = `swap-${offset}`
+    const snap = (offset + 1) * 20
+
+    return `
+      @keyframes ${keyframeName} {
+        0%, ${snap}% {
+          left: 0%;
+        }
+
+        ${snap + 0.01}%, 100% {
+          left: 100%;
+        }
+      }
+
+      animation: ${keyframeName} linear infinite;
+  `
+  }}
+
+  ${({ duration }) => `animation-duration: ${duration}s;`}
 `
 
 const Image = styled.img<{ size: number }>`
@@ -118,14 +130,14 @@ export default function RollingSpinner({
     () =>
       [...Array(5).keys()].map((_, idx) => {
         return (
-          <ImageContainer key={idx}>
+          <ImageContainer key={idx} duration={duration} offset={idx}>
             {imageUrls.map((url: string, index: number) => (
               <Image src={url} size={size} key={index} alt="rolling_image" />
             ))}
           </ImageContainer>
         )
       }),
-    [imageUrls, size],
+    [duration, imageUrls, size],
   )
 
   return (


### PR DESCRIPTION

<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
롤링 스피너의 swap 애니메이션을 작동할 수 있도록 수정하고 고도화합니다.

## 변경 내역 및 배경
기존엔 swap 애니메이션이 제대로 작동하지 않아 작은 width에서도 끝이 보일 수 있었습니다.
화면에 가려진 로고 묶음을 맨 뒤로 보내는 애니메이션을 추가합니다.

## 사용 및 테스트 방법
docs

## 스크린샷
![화면 기록 2020-07-27 오전 11 54 35 mov](https://user-images.githubusercontent.com/26055001/88499227-379f8500-d000-11ea-90b5-31f345e5f553.gif)

## 이 PR의 유형

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
