### PR TITLE
[triple-document] display="block" 형식의 links element가 level을 가지도록 합니다.

### DIFF
--- a/docs/stories/triple-document/triple-document.links.stories.js
+++ b/docs/stories/triple-document/triple-document.links.stories.js
@@ -58,17 +58,17 @@ storiesOf('TripleDocument | TripleDocument.링크', module)
       }}
     />
   ))
-  .add('확장 + Type', () => (
+  .add('확장 + Level', () => (
     <Links
       value={{
         links: [
           {
             label: '장소 보기',
-            type: 'primary',
+            level: 'primary',
           },
           {
             label: '장소 보기',
-            type: 'secondary',
+            level: 'secondary',
           },
         ],
         display: 'block',

--- a/packages/triple-document/src/links.tsx
+++ b/packages/triple-document/src/links.tsx
@@ -75,16 +75,16 @@ function ButtonLink({
 
 function BlockLink({
   children,
-  type,
+  level,
   ...props
 }: React.PropsWithChildren<ButtonProps & Link>) {
   return (
     <Button
-      basic={type !== 'primary'}
+      basic={level !== 'primary'}
       fluid
       size="small"
-      compact={!(type === 'primary' || type === 'secondary')}
-      color={type === 'primary' ? 'blue' : 'gray'}
+      compact={!(level === 'primary' || level === 'secondary')}
+      color={level === 'primary' ? 'blue' : 'gray'}
       borderRadius={4}
       margin={{ top: 10 }}
       {...props}

--- a/packages/triple-document/src/types.ts
+++ b/packages/triple-document/src/types.ts
@@ -23,7 +23,7 @@ export type ImageEventHandler = (e: SyntheticEvent, image: MediaMeta) => void
 export type Link = {
   href?: string
   label?: string
-  type?: string
+  level?: string
 }
 
 export type LinkEventHandler = (e: React.SyntheticEvent, link: Link) => void


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`display="block"` 속성을 가진 links element가 `level`에 따라 다른 모양의 버튼을 렌더링하도록 합니다.

#876 작성 당시에는 `display` 속성을 추가해서 해결하려 했었는데,

  - 버튼 사이의 margin이 links 요소의 margin과 다른 점
  - 편집자의 의도는 하나의 `"links"` 속성을 다루는 것에 가까워 보이는 점

을 반영하여 `"display"` 외에 추가로 뷰 렌더링 분기가 일어나는 속성을 sublevel에 추가해 보았습니다.

Related to #876 

## 변경 내역 및 배경

  - `"links"` 멤버로 포함되는 `Link` 컴포넌트에 `"level"` 속성을 추가합니다.
  - `"display"` 속성이 `"block"`일 경우, 멤버의 `"level"` 에 따라 다른 뷰를 버튼으로 렌더링합니다.
    - `"primary"`: `#368fff` 배경색의 fluid 버튼
    - `"secondary"`: `#ffffff` 배경색의 basic fluid 버튼
    - Default: as-is
  - `"display"` 속성이 `"block"`일 경우, 멤버 버튼 사이의 margin을 정의합니다.

## 사용 및 테스트 방법

Canary/docs

## 스크린샷

차례로 `"primary"`, `"secondary"` 버튼입니다.

<img width="687" alt="Screen Shot 2020-07-27 at 2 22 32 PM" src="https://user-images.githubusercontent.com/712260/88506628-49d7ee00-d015-11ea-8d62-611df704d81c.png">


## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
