### PR TITLE
불필요한 객체 참조 제거

### DIFF
--- a/packages/core-elements/src/elements/checkbox.tsx
+++ b/packages/core-elements/src/elements/checkbox.tsx
@@ -8,7 +8,6 @@ import { MarginPadding } from '../commons'
 import { paddingMixin } from '../mixins'
 
 type FillType = 'full' | 'border' | 'text'
-type TextAlignType = CSS.Property.TextAlign
 
 const generateFillStyles = ({
   fillType,
@@ -51,7 +50,7 @@ const generateFillStyles = ({
 // eslint-disable-next-line no-unexpected-multiline
 const ConfirmFrame = styled.div.attrs({})<{
   name?: string
-  textAlign?: TextAlignType
+  textAlign?: CSS.Property.TextAlign
   borderless?: boolean
   checked?: boolean
   fillType?: FillType
@@ -104,7 +103,7 @@ interface ConfirmSelectorProps {
   value: any
   placeholder: string
   onChange?: (e?: React.SyntheticEvent, value?: any) => any
-  textAlign?: TextAlignType
+  textAlign?: CSS.Property.TextAlign
   borderless?: boolean
   fillType?: FillType
   children?: React.ReactNode

--- a/packages/form/src/confirm-checkbox/index.tsx
+++ b/packages/form/src/confirm-checkbox/index.tsx
@@ -7,7 +7,6 @@ import { MarginPadding, paddingMixin } from '@titicaca/core-elements'
 import withField from '../with-field'
 
 type FillType = 'full' | 'border' | 'text'
-type TextAlignType = CSS.Property.TextAlign
 
 const generateFillStyles = ({
   fillType,
@@ -50,7 +49,7 @@ const generateFillStyles = ({
 // eslint-disable-next-line no-unexpected-multiline
 const ConfirmFrame = styled.div.attrs({})<{
   name?: string
-  textAlign?: TextAlignType
+  textAlign?: CSS.Property.TextAlign
   borderless?: boolean
   checked?: boolean
   fillType?: FillType
@@ -103,7 +102,7 @@ interface ConfirmCheckboxProps {
   value: boolean
   placeholder: string
   onChange?: (e?: React.SyntheticEvent, value?: boolean) => void
-  textAlign?: TextAlignType
+  textAlign?: CSS.Property.TextAlign
   borderless?: boolean
   fillType?: FillType
   children?: React.ReactNode


### PR DESCRIPTION

<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
text-align 스타일을 적용하는 방식을 간소화합니다.

## 변경 내역 및 배경
적용하는 스타일 값과 key 값이 일치하기 때문에
prop을 TextAlign property로 정의하고 그 prop을 직접 사용해도 무방합니다.

https://github.com/titicacadev/triple-frontend/pull/913#discussion_r467723365

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
