### PR TITLE
앱설치 배너 제목을 입력할 수 있는 기능 추가

### DIFF
--- a/docs/stories/app-installation-cta/app-installation-cta.stories.tsx
+++ b/docs/stories/app-installation-cta/app-installation-cta.stories.tsx
@@ -19,6 +19,7 @@ export function FloatingButton() {
     <FloatingButtonCTA
       appInstallLink={'https://triple.onelink.me/aZP6/21d43a81'}
       fixed={boolean('화면 고정', true)}
+      title={text('제목', '제목을 입력하세요.')}
       description={text('설명', '설명 텍스트가 들어갑니다.')}
       trackEvent={action('tracked')}
       trackEventParams={{

--- a/packages/app-installation-cta/src/floating-button-cta.tsx
+++ b/packages/app-installation-cta/src/floating-button-cta.tsx
@@ -23,6 +23,7 @@ interface FloatingButtonCTAProps extends CTAProps {
   exitStrategy?: BannerExitStrategy
   fixed?: boolean
   appInstallLink?: string
+  title?: string
   description?: string
   margin?: MarginPadding
   trackEvent?: any
@@ -35,7 +36,8 @@ interface FloatingButtonCTAProps extends CTAProps {
  * @param exitStrategy 이 버튼 컴포넌트가 사라져야하는 조건 또는 전략 (기본값 NONE)
  * @param fixed 스크롤 위치와 관계없이 fixed position 인지의 여부
  * @param appInstallLink 앱 설치 URL
- * @param description 앱 설치 안내문구
+ * @param title 앱 설치 안내 문구 제목
+ * @param description 앱 설치 안내 문구 설명
  * @param trackEvent 이벤트 트래킹 함수
  * @param margin 버튼 주변 margin 값 (optional)
  * @param trackEventParams GA/FA 수집 파라미터
@@ -44,6 +46,7 @@ export default function FloatingButtonCTA({
   exitStrategy = BannerExitStrategy.NONE,
   fixed,
   appInstallLink,
+  title = '트리플 앱 설치하기',
   description = '가이드북, 일정짜기, 길찾기, 맛집',
   margin,
   trackEvent,
@@ -118,7 +121,7 @@ export default function FloatingButtonCTA({
           <InstallAnchor href={appInstallLink} onClick={handleClick}>
             <InstallDescription>
               <Text floated="left" color="white">
-                트리플 앱 설치하기
+                {title}
               </Text>
               <GoAppButton src="https://assets.triple.guide/images/ico-arrow@4x.png" />
             </InstallDescription>


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
앱설치 배너 제목을 쉽게 수정할 수 있도록 prop을 추가합니다.

## 변경 내역 및 배경
https://titicaca.slack.com/archives/CH71ATQA1/p1597124447408400?thread_ts=1597027110.365900&cid=CH71ATQA1
호텔 웹에서 문구 변경을 쉽게 하려고 합니다.

## 사용 및 테스트 방법
docs에 knob을 추가했습니다.

## 스크린샷
<img width="630" alt="스크린샷 2020-08-11 오후 2 59 17" src="https://user-images.githubusercontent.com/26055001/89862580-3dda5780-dbe3-11ea-90ed-24faf49d35b1.png">

## 이 PR의 유형
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)

## 체크리스트
- [x] docs의 스토리를 변경했습니다.
