### PR TITLE
poi-card-element에 priceLabelOverride 추가

### DIFF
--- a/docs/stories/poi-list-elements/poi.stories.tsx
+++ b/docs/stories/poi-list-elements/poi.stories.tsx
@@ -192,6 +192,13 @@ export function PoiCardElementsTypeHotel() {
       reviewsRating={number('reviewsRating', 5)}
       reviewsCount={number('reviewsCount', 1)}
       nightlyPrice={number('nightlyPrice', 120094)}
+      priceLabelOverride={
+        boolean('use priceLabelOverride', false) ? (
+          <Text inlineBlock size="small" color="gray300" bold>
+            판매 완료
+          </Text>
+        ) : undefined
+      }
       scraped={boolean('scraped', false)}
       scrapsCount={number('scrapesCount', 0)}
       distance={text('distance', '300m')}

--- a/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
+++ b/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
@@ -65,6 +65,7 @@ export default function POICardElement({
   reviewsRating,
   reviewsCount,
   nightlyPrice,
+  priceLabelOverride,
   scraped,
   scrapsCount,
   distance,
@@ -84,6 +85,7 @@ export default function POICardElement({
   reviewsCount?: number
   scrapsCount?: number
   nightlyPrice?: number
+  priceLabelOverride?: JSX.Element
   distance?: string
   categoryName?: string
   areaName?: string
@@ -159,7 +161,9 @@ export default function POICardElement({
             margin={{ top: 4 }}
           />
 
-          {distance || nightlyPrice !== undefined ? (
+          {distance ||
+          nightlyPrice !== undefined ||
+          priceLabelOverride !== undefined ? (
             <Container margin={{ top: 6 }}>
               {distance ? (
                 <Text
@@ -172,11 +176,13 @@ export default function POICardElement({
                 </Text>
               ) : null}
 
-              {nightlyPrice !== undefined ? (
-                <Text inlineBlock size="small">
-                  {formatNumber(nightlyPrice)}원
-                </Text>
-              ) : null}
+              {/* TODO: pricing과 관련 로직 통합 */}
+              {priceLabelOverride ||
+                (nightlyPrice !== undefined ? (
+                  <Text inlineBlock size="small">
+                    {formatNumber(nightlyPrice)}원
+                  </Text>
+                ) : null)}
             </Container>
           ) : null}
         </Container>


### PR DESCRIPTION
## 설명
`POICardElement`에 가격 대신 다른 것을 표시할 수 있는 기능을 추가합니다.

## 변경 내역 및 배경
[관련 버그 리포트](https://docs.google.com/spreadsheets/d/17BZcGSAtrsmiOg9CQLRIHV-sEZok54gnR0Eu2tAg4zw/edit#gid=0&range=4:4)

호텔 지도 뷰에서 "판매 완료" 문구를 표시해야 하는데 해당 기능이 없었습니다. 더불어 "쿠폰 적용시 무료" 문구도 표시해야할 것 같습니다.

## 사용 및 테스트 방법
docs & canary 

## 스크린샷
<img width="583" alt="스크린샷 2020-08-24 오전 11 09 42" src="https://user-images.githubusercontent.com/26055001/90996637-53477c80-e5fa-11ea-9555-b97b3bc1eb1c.png">

## 이 PR의 유형
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)


## 체크리스트
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
