### PR TITLE
CSSTransition의 mountOnEnter, unmountOnExit 옵션 사용

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### common
 
-- `CSSTransition`의 `mountOnEnter`, `unmountOnExit` 사용
+- 등장, 퇴장 애니메이션이 있는 컴포넌트에
+  `CSSTransition`의 `mountOnEnter`, `unmountOnExit` 설정하는 prop 추가
 
 ### icons
 

--- a/packages/action-sheet/src/components/action-sheet.tsx
+++ b/packages/action-sheet/src/components/action-sheet.tsx
@@ -59,6 +59,7 @@ const Sheet = styled.div<SheetProps & LayeringMixinProps>`
 
   &:not([class*='action-sheet-slide-']) {
     ${inactiveSheetSlideStyle}
+    display: none;
   }
 
   &.action-sheet-slide-appear,
@@ -86,6 +87,7 @@ const Sheet = styled.div<SheetProps & LayeringMixinProps>`
 
   &.action-sheet-slide-exit-done {
     ${inactiveSheetSlideStyle}
+    display: none;
   }
 
   ${paddingMixin}
@@ -138,6 +140,7 @@ const Overlay = styled.div<OverlayProps & LayeringMixinProps>`
 
   &:not([class*='action-sheet-fade-']) {
     ${inactiveOverlayFadeStyle}
+    display: none;
   }
 
   &.action-sheet-fade-appear,
@@ -166,6 +169,7 @@ const Overlay = styled.div<OverlayProps & LayeringMixinProps>`
 
   &.action-sheet-fade-exit-done {
     ${inactiveOverlayFadeStyle}
+    display: none;
   }
 `
 
@@ -186,6 +190,7 @@ export default function ActionSheet({
   className,
   zTier,
   zIndex,
+  unmountOnExit,
 }: PropsWithChildren<
   {
     open?: boolean
@@ -197,6 +202,7 @@ export default function ActionSheet({
     maxContentHeight?: string | number
     padding?: MarginPadding
     className?: string
+    unmountOnExit?: boolean
   } & LayeringMixinProps
 >) {
   const actionSheetTitle = title ? (
@@ -224,8 +230,8 @@ export default function ActionSheet({
       appear
       classNames="action-sheet-fade"
       timeout={TRANSITION_DURATION}
-      mountOnEnter
-      unmountOnExit
+      mountOnEnter={unmountOnExit}
+      unmountOnExit={unmountOnExit}
     >
       <Overlay
         duration={TRANSITION_DURATION}
@@ -238,8 +244,8 @@ export default function ActionSheet({
           classNames="action-sheet-slide"
           timeout={TRANSITION_DURATION}
           appear
-          mountOnEnter
-          unmountOnExit
+          mountOnEnter={unmountOnExit}
+          unmountOnExit={unmountOnExit}
         >
           <Sheet
             duration={TRANSITION_DURATION}

--- a/packages/app-installation-cta/src/chatbot-cta.tsx
+++ b/packages/app-installation-cta/src/chatbot-cta.tsx
@@ -19,6 +19,7 @@ interface ChatbotCTAProps extends CTAProps {
   available?: boolean
   inventoryId: string
   installUrl: string
+  unmountOnExit?: boolean
 }
 
 /**
@@ -27,6 +28,7 @@ interface ChatbotCTAProps extends CTAProps {
  * @param available CTA 가 표시되어야하는지의 여부 (기본값 false) (controlled)
  * @param inventoryId 표시할 이미지의 인벤토리 ID
  * @param installUrl 앱 설치 URL
+ * @param unmountOnExit 표시되지 않는 상태일 때 컴포넌트 마운트 해제
  */
 export default function ChatbotCTA({
   available = false,
@@ -37,6 +39,7 @@ export default function ChatbotCTA({
   onDismiss,
   zTier,
   zIndex,
+  unmountOnExit,
 }: ChatbotCTAProps & LayeringMixinProps) {
   const [inventoryItem, setInventoryItem] = useState<InventoryItem>()
   const [visibility, setVisibility] = useState(false)
@@ -96,8 +99,8 @@ export default function ChatbotCTA({
       appear
       classNames="chatbot-slide"
       timeout={500}
-      mountOnEnter
-      unmountOnExit
+      mountOnEnter={unmountOnExit}
+      unmountOnExit={unmountOnExit}
     >
       <ChatbotContainer
         visibility={visibility ? 1 : 0}

--- a/packages/app-installation-cta/src/elements.tsx
+++ b/packages/app-installation-cta/src/elements.tsx
@@ -247,6 +247,7 @@ export const FloatingButton = styled.div<
 
   &.floating-button-slide-exit-done {
     ${inactiveFloatingButtonStyle}
+    display: none;
   }
 `
 
@@ -358,6 +359,7 @@ export const ChatbotContainer = styled.div<
 
   &:not([class*='chatbot-slide-']) {
     ${inactiveChatbotContainerStyle}
+    display: none;
   }
 
   &.chatbot-slide-appear,
@@ -386,5 +388,6 @@ export const ChatbotContainer = styled.div<
 
   &.chatbot-slide-exit-done {
     ${inactiveChatbotContainerStyle}
+    display: none;
   }
 `

--- a/packages/app-installation-cta/src/floating-button-cta.tsx
+++ b/packages/app-installation-cta/src/floating-button-cta.tsx
@@ -32,6 +32,7 @@ interface FloatingButtonCTAProps extends CTAProps {
   margin?: MarginPadding
   trackEvent?: any
   trackEventParams?: any
+  unmountOnExit?: boolean
 }
 
 /**
@@ -45,6 +46,7 @@ interface FloatingButtonCTAProps extends CTAProps {
  * @param trackEvent 이벤트 트래킹 함수
  * @param margin 버튼 주변 margin 값 (optional)
  * @param trackEventParams GA/FA 수집 파라미터
+ * @param unmountOnExit 버튼이 표시되지 않을 때 컴포넌트 마운트 해제 여부
  */
 export default function FloatingButtonCTA({
   exitStrategy = BannerExitStrategy.NONE,
@@ -60,6 +62,7 @@ export default function FloatingButtonCTA({
   onDismiss,
   zTier,
   zIndex,
+  unmountOnExit,
 }: FloatingButtonCTAProps & LayeringMixinProps) {
   const [buttonVisibility, setButtonVisibility] = useState(false)
   const [available, setAvailable] = useState(true)
@@ -122,8 +125,8 @@ export default function FloatingButtonCTA({
       appear
       classNames="floating-button-slide"
       timeout={500}
-      mountOnEnter
-      unmountOnExit
+      mountOnEnter={unmountOnExit}
+      unmountOnExit={unmountOnExit}
     >
       <FloatingButton
         visibility={buttonVisibility ? 1 : 0}

--- a/packages/core-elements/src/elements/drawer.tsx
+++ b/packages/core-elements/src/elements/drawer.tsx
@@ -33,6 +33,7 @@ const DrawerContainer = styled.div<DrawerContainerProps & LayeringMixinProps>`
 
   &:not([class*='drawer-slide-']) {
     ${inactiveDrawerStyle}
+    display: none;
   }
 
   &.drawer-slide-appear,
@@ -61,6 +62,7 @@ const DrawerContainer = styled.div<DrawerContainerProps & LayeringMixinProps>`
 
   &.drawer-slide-exit-done {
     ${inactiveDrawerStyle}
+    display: none;
   }
 `
 
@@ -70,9 +72,11 @@ export default function Drawer({
   children,
   zTier,
   zIndex,
+  unmountOnExit,
 }: {
   active?: boolean
   overflow?: string
+  unmountOnExit?: boolean
   children?: React.ReactNode
 } & LayeringMixinProps) {
   return (
@@ -81,8 +85,8 @@ export default function Drawer({
       appear
       classNames="drawer-slide"
       timeout={TRANSITION_DURATION}
-      mountOnEnter
-      unmountOnExit
+      mountOnEnter={unmountOnExit}
+      unmountOnExit={unmountOnExit}
     >
       <DrawerContainer
         duration={TRANSITION_DURATION}

--- a/packages/popup/src/index.tsx
+++ b/packages/popup/src/index.tsx
@@ -51,6 +51,7 @@ const PopupContainer = styled.div<LayeringMixinProps>`
 
   &:not([class*='popup-slide-']) {
     ${inactivePopupContainerStyle}
+    display: none;
   }
 
   &.popup-slide-appear,
@@ -79,6 +80,7 @@ const PopupContainer = styled.div<LayeringMixinProps>`
 
   &.popup-slide-exit-done {
     ${inactivePopupContainerStyle}
+    display: none;
   }
 
   ${layeringMixin(2)}
@@ -94,6 +96,7 @@ export default function Popup({
   children,
   zTier,
   zIndex,
+  unmountOnExit,
 }: PropsWithChildren<
   {
     open: boolean
@@ -102,6 +105,7 @@ export default function Popup({
     title?: string
     icon?: NavbarIcon
     noNavbar?: boolean
+    unmountOnExit?: boolean
   } & LayeringMixinProps
 >) {
   const popupRef = useRef<HTMLDivElement>(null)
@@ -118,8 +122,8 @@ export default function Popup({
       in={open}
       classNames="popup-slide"
       appear
-      mountOnEnter
-      unmountOnExit
+      mountOnEnter={unmountOnExit}
+      unmountOnExit={unmountOnExit}
     >
       {/* https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451 */}
       <PopupContainer ref={popupRef} zTier={zTier} zIndex={zIndex}>


### PR DESCRIPTION
## 설명
`react-transition-group`의 `CSSTransition` 사용하는 부분에 `mountOnEnter`, `unmountOnExit` 옵션을 사용하여 컴포넌트가 가려져있을 때 unmount 합니다.

## 변경 내역 및 배경
- [제보된 이슈](https://docs.google.com/spreadsheets/d/17BZcGSAtrsmiOg9CQLRIHV-sEZok54gnR0Eu2tAg4zw/edit#gid=0&range=5:5)
- 사파리에서 탭 목록 뷰로 이동했을 때 화면 아래에 `DrawerButton`이 보이는 문제
- [스크롤 빠르게 하면 팝업이 보이는 문제](https://github.com/titicacadev/triple-hotels-web/issues/1648#issuecomment-665558576)
이런 문제들을 해결할 수 있을 것으로 보입니다.

### `display: none;`(#932 ) 보다 나은 점
자식 컴포넌트를 모두 언마운트하게 되므로 context 구독이나 prop 업데이트에 반응하지 않게 됩니다. 그러므로 화면에 보이지 않는 컴포넌트가 렌더링되는 것을 방지할 수 있습니다.

## 사용 및 테스트 방법
canary & docs

- [x] 애니메이션 작동 테스트

## 이 PR의 유형
하위호환이 유지되지 않습니다. 인터페이스는 같지만 그동안 컴포넌트가 처음 마운트 되고 해제되지 않는다고 가정하여 짜여진 코드가 많기 때문에 (ex. api fetch 타이밍) 사용하는 부분을 찾아서 수정해줘야 합니다.

### 대응 방안
Popup은 Transition 애니메이션이 붙어있고 history context가 연관되어있습니다. `uriHash` 변경에 영향을 덜 받도록 `useHistoryFunctions`를 사용해야합니다.

불필요한 렌더링을 최대한 방지하기 위해 페이지 최상단 컴포넌트에 memo를 걸어줍니다. hash가 추가되면 컴포넌트 트리 제일 위부터 렌더링이 다시 일어나는데 이때 중간에 memo한 컴포넌트가 없으면 부모가 렌더링되면서 자식도 렌더링 됩니다. 실제로는 RouterContext의 hash 값만 변한 것일텐데, 큰 렌더링 비용이 들게 됩니다.

memo를 걸어줄 때 `pages/`의 페이지 컴포넌트는 `getInitialProps`가 있음을 유의해야합니다.

```tsx
const Memoed = React.memo(XXXPage)

// Memoed의 타입이 MemoExoticComponent으로 명시되어버리기 때문에 getInitialProps가 없다는 타입에러가 남
(Memoed as any).getInitialProps = () => {}
```

반면, `getServerSideProps`는 단순 export로 작성하면 되기 때문에 이런 상황에서 더 좋은 해결책이라고 할 수 있습니다.


## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [x] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
