### PR TITLE
Fix: docs/ 디렉토리를 prettierignore에서 제외

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,5 +6,3 @@ lerna.json
 
 .vscode/*
 tests/dist/*
-docs/*
-

--- a/docs/stories/date-picker/date-picker.stories.tsx
+++ b/docs/stories/date-picker/date-picker.stories.tsx
@@ -1,11 +1,5 @@
 import React, { useState } from 'react'
-import {
-  array,
-  text,
-  number,
-  button,
-  boolean,
-} from '@storybook/addon-knobs'
+import { array, text, number, button, boolean } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
 import { DayPicker, RangePicker } from '@titicaca/date-picker'
 
@@ -100,12 +94,16 @@ export function DayPickerStory() {
   const beforeBlock: string | undefined = useOptionalKnob({
     name: 'beforeBlock',
     knob: text,
-    initialValue: `${today.getFullYear()}-${padZero(today.getMonth() + 1)}-${padZero(today.getDate())}`,
+    initialValue: `${today.getFullYear()}-${padZero(
+      today.getMonth() + 1,
+    )}-${padZero(today.getDate())}`,
   })
   const afterBlock: string | undefined = useOptionalKnob({
     name: 'afterBlock',
     knob: text,
-    initialValue: `${initialAfterBlock.getFullYear()}-${padZero(initialAfterBlock.getMonth() + 1)}-${padZero(initialAfterBlock.getDate())}`,
+    initialValue: `${initialAfterBlock.getFullYear()}-${padZero(
+      initialAfterBlock.getMonth() + 1,
+    )}-${padZero(initialAfterBlock.getDate())}`,
   })
   const disabledDays = useOptionalKnob({
     name: 'disabledDays',
@@ -157,12 +155,16 @@ export function RangePickerStory() {
   const beforeBlock: string | undefined = useOptionalKnob({
     name: 'beforeBlock',
     knob: text,
-    initialValue: `${today.getFullYear()}-${padZero(today.getMonth() + 1)}-${padZero(today.getDate())}`,
+    initialValue: `${today.getFullYear()}-${padZero(
+      today.getMonth() + 1,
+    )}-${padZero(today.getDate())}`,
   })
   const afterBlock: string | undefined = useOptionalKnob({
     name: 'afterBlock',
     knob: text,
-    initialValue: `${initialAfterBlock.getFullYear()}-${padZero(initialAfterBlock.getMonth() + 1)}-${padZero(initialAfterBlock.getDate())}`,
+    initialValue: `${initialAfterBlock.getFullYear()}-${padZero(
+      initialAfterBlock.getMonth() + 1,
+    )}-${padZero(initialAfterBlock.getDate())}`,
   })
   const disabledDays = useOptionalKnob({
     name: 'disabledDays',


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
docs/* 디렉토리가 prettier 처리가 될 수 있도록 합니다.

## 변경 내역 및 배경
머지 과정에서 누락되었던 것 같습니다.

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
