### PR TITLE
[triple-document] webUrlBase prop을 deprecate합니다.

### DIFF
--- a/packages/triple-document/src/coupon/index.tsx
+++ b/packages/triple-document/src/coupon/index.tsx
@@ -117,14 +117,12 @@ const InAppCouponDownloadButton = ({ slugId }: { slugId: string }) => {
 
 export default function Coupon({
   value: { identifier: slugId, description },
-  webUrlBase,
   deepLink,
 }: {
   value: {
     identifier: string
     description: string
   }
-  webUrlBase: string
   deepLink: string
 }) {
   const { isPublic } = useUserAgentContext()
@@ -149,7 +147,7 @@ export default function Coupon({
         </Text>
       ) : null}
 
-      <CouponModal webUrlBase={webUrlBase} />
+      <CouponModal />
       <CouponTransitionModal deepLink={deepLink} />
     </Container>
   )

--- a/packages/triple-document/src/coupon/modals.tsx
+++ b/packages/triple-document/src/coupon/modals.tsx
@@ -46,7 +46,7 @@ const CouponIcon = styled.img`
   margin: 40px auto 10px auto;
 `
 
-export function CouponModal({ webUrlBase }: { webUrlBase: string }) {
+export function CouponModal() {
   const uriHash = useURIHash()
   const { back, navigate } = useHistoryFunctions()
 
@@ -91,7 +91,11 @@ export function CouponModal({ webUrlBase }: { webUrlBase: string }) {
           color="blue"
           onClick={() => {
             back()
-            navigate(`${webUrlBase}/benefit/coupons/my?_triple_no_navbar`)
+            navigate(
+              `/inlink?path=${encodeURIComponent(
+                '/benefit/coupons/my?_triple_no_navbar',
+              )}`,
+            )
           }}
         >
           {CONFIRM_MESSAGE_TYPES[uriHash]}

--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -77,7 +77,6 @@ interface TripleDocumentProps {
   ) => void
   onTNAProductsFetch?: (slotId: number) => Promise<unknown>
   imageSourceComponent?: ImageSourceType
-  webUrlBase?: string
   deepLink?: string
   videoAutoPlay?: boolean
 }
@@ -116,7 +115,6 @@ export function TripleDocument({
   onTNAProductClick,
   onTNAProductsFetch,
   imageSourceComponent,
-  webUrlBase,
   deepLink,
   videoAutoPlay,
 }: TripleDocumentProps) {
@@ -137,7 +135,6 @@ export function TripleDocument({
               onTNAProductsFetch={onTNAProductsFetch}
               ImageSource={imageSourceComponent}
               deepLink={deepLink}
-              webUrlBase={webUrlBase}
               videoAutoPlay={videoAutoPlay}
             />
           )


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`TripleDocument`의 webUrlBase prop을 deprecate합니다.

## 변경 내역 및 배경

`/inlink`를 활용하면 `webUrlBase`없이도 구현할 수 있는 인터랙션입니다.

## 사용 및 테스트 방법

Canary

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
