### PR TITLE
[react-contexts] EventTrackingContext를 일부 개선합니다.

### DIFF
--- a/packages/react-contexts/src/event-tracking-context/README.md
+++ b/packages/react-contexts/src/event-tracking-context/README.md
@@ -1,0 +1,46 @@
+# EventTrackingContext
+
+앱 내에서 수집하는 Firebase/Google Analytics 및 일반 브라우저에서 수집하는
+Google Analytics 이벤트를 위한 Context입니다.
+
+## Event 정의
+
+### Screen view (page view) events
+
+String 형식 path로 표현하는 스크린(앱 내) 및 페이지(웹 페이지) 뷰를 기혹합니다.
+페이지가 열릴 때마다 `useEffect` 훅이나 `componentDidMount`라이프사이클 이벤트를
+이용해 기록하는 것이 보통이며, 팝업이나 모달 윈도우 등이 열릴 때 별도로 기록하기도
+합니다.
+
+### Interaction events
+
+사용자가 의도하거나 의도하지 않은 페이지 내 인터랙션을 기록하기 위한 이벤트입니다.
+컨텐트/상품 노출이나 클릭, 페이지 내 피쳐 사용에 대한 기록을 남길 수 있습니다.
+트리플에서는 Firebase Analytics와 Google Analytics 서비스를 사용하는데, 서비스에
+따라 이벤트 형식에 다소 차이가 있습니다.
+
+- Google Analytics Events: `category`, `action`, `label`의 3-Tuple로 표현합니다.
+  `category`는 대부분 page label입니다.
+- Firebase Analytics Events: `event_name`, `category`, `action`을 포함한 1-depth
+  object입니다. `event_name`은 `user_interaction`이라는 고정 값을 사용합니다.
+  `category`는 Google Analytics와 마찬가지로 page label을 사용합니다.
+
+## Context
+
+### `EventTrackingProvider`
+
+#### Props
+
+- `pageLabel`: Event category로 사용하는 page label을 정의합니다.
+
+### `useEventTrackingContext()`
+
+#### Return values
+
+- `trackScreen: (screenPath: string) => void`: Screen view event를 기록합니다.
+  Firebase Analytics 및 Google Analytics 이벤트가 동시에 기록됩니다.
+- `trackEvent: (params: { ga?: GAParams; fa?: Partial<FAParams> }) => void`: 위에
+  언급한 서비스별 이벤트를 기록합니다.
+- `trackSimpleEvent: (params: { action, label, ...rest }) => void`: 많은 경우
+  interaction event를 두 서비스에 동시에 기록합니다. 주어진 argument를 사용해
+  적절한 Google Analytics 및 Firebase Analytics를 생성하여 동시에 기록을 요청합니다.

--- a/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
@@ -6,13 +6,7 @@ import {
   viewItem as nativeViewItem,
 } from '@titicaca/triple-web-to-native-interfaces'
 
-interface FAParams {
-  category: string
-  event_name: string // eslint-disable-line @typescript-eslint/camelcase
-  [key: string]: any
-}
-
-type GAParams = (string | undefined)[]
+import { FAParams, GAParams } from './types'
 
 const NOOP = () => {}
 

--- a/packages/react-contexts/src/event-tracking-context/index.ts
+++ b/packages/react-contexts/src/event-tracking-context/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './event-tracking-context'
+export * from './with-event-tracking-provider'

--- a/packages/react-contexts/src/event-tracking-context/types.ts
+++ b/packages/react-contexts/src/event-tracking-context/types.ts
@@ -1,0 +1,7 @@
+export interface FAParams {
+  category: string
+  event_name: string // eslint-disable-line @typescript-eslint/camelcase
+  [key: string]: any
+}
+
+export type GAParams = (string | undefined)[]

--- a/packages/react-contexts/src/event-tracking-context/with-event-tracking-provider.tsx
+++ b/packages/react-contexts/src/event-tracking-context/with-event-tracking-provider.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import { EventTrackingProvider } from './event-tracking-context'
+
+export function withEventTrackingProvider<P>(
+  pageLabel: string,
+  Component: React.ComponentType<P>,
+): React.ComponentType<P> {
+  const Page: React.ComponentType<P> = function (props: P) {
+    return (
+      <EventTrackingProvider pageLabel={pageLabel}>
+        <Component {...props} />
+      </EventTrackingProvider>
+    )
+  }
+
+  return Page
+}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`EventTrackingContext` 파일 구성을 일부 개선하고, 문서를 추가합니다. 이와 함께 triple-air-web에서 사용하던 `withEventTrackingProvider` HoC를 가져옵니다.

## 변경 내역 및 배경

사실 `withEventTrackingProvider`를 쓰고 싶었습니다.

## 사용 및 테스트 방법

Canary

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
