### PR TITLE
feat(canary): pr 서브 커맨드 fetch-github-pr 로 변경

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npx @titicaca/gha-tools pr ${{ github.event.issue.number }}
+          npx @titicaca/gha-tools fetch-github-pr ${{ github.event.issue.number }}
 
           PR_SHA=$(cat ./pr.json | jq -r '.head.sha')
           PR_REF=$(cat ./pr.json | jq -r '.head.ref')


### PR DESCRIPTION
## 설명

gha-tools `pr` 서브 커맨드를 `fetch-github-pr` 로 변경합니다.

link: https://github.com/titicacadev/gha-tools/pull/24