### PR TITLE
[Navbar] fixed 사용에 대응합니다.

### DIFF
--- a/packages/core-elements/src/elements/navbar.tsx
+++ b/packages/core-elements/src/elements/navbar.tsx
@@ -5,7 +5,6 @@ import { Color, getColor, brightGray } from '@titicaca/color-palette'
 
 import { FALLBACK_ACTION_CLASS_NAME } from '../constants'
 import { layeringMixin, LayeringMixinProps } from '../mixins'
-import Container from './container'
 
 type NavbarProps = {
   maxWidth?: number
@@ -13,13 +12,6 @@ type NavbarProps = {
   backgroundColor?: Color
   position?: CSS.Property.Position
 }
-
-const NavbarsWrapper = styled(Container)<NavbarProps & LayeringMixinProps>`
-  > header,
-  > header + div {
-    position: relative;
-  }
-`
 
 const NavbarFrame = styled.header<NavbarProps & LayeringMixinProps>`
   background-color: ${({ backgroundColor = 'white' }) =>
@@ -127,7 +119,7 @@ const SecondaryNavbar = styled.div<NavbarProps & LayeringMixinProps>`
   background-color: ${({ backgroundColor = 'white' }) =>
     `rgba(${getColor(backgroundColor)})`};
   position: ${({ position = 'sticky' }) => position};
-  top: 52px;
+  top: ${({ position }) => (position === 'sticky' ? '52px' : 0)};
   left: 0;
   right: 0;
   box-sizing: border-box;
@@ -172,6 +164,5 @@ Navbar.Item = NavbarItem
 Navbar.Secondary = SecondaryNavbar
 Navbar.NavbarFrame = NavbarFrame
 Navbar.TitleContainer = TitleContainer
-Navbar.Wrapper = NavbarsWrapper
 
 export default Navbar


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
close #784 
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경
- Navbar에 position를 prop으로 받을수 있도록 추가합니다.
- SecondaryNavbar에도 NavbarProps, LayeringMixinProps를 받을수 있도록 합니다.
- <del>Navbar를 부득이하게 `position:fixed`처리를 할 경우에 사용할수 있는 `Navbar.Wrapper`를 추가합니다. Navbar.Wrapper안에 Navbar 및 SecondaryNavbar가 직속 자식으로 들어와야 합니다. 근데 요 아이는 구지 필요할까라는 생각도 드네요;</del>
- @zprime0920 께서 주신 [의견](https://github.com/titicacadev/triple-frontend/issues/784#issuecomment-638605026)의견은 반영을 못했습니다. 기존 사용하는곳에서 코드 수정이 넘나 많아질듯한 예상때문에 ㅜ
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
