### PR TITLE
[triple-document] TripleDocument의 기본 Action handler를 구현합니다.

### DIFF
--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -110,7 +110,9 @@ export function TripleDocument({
 
   const defaultHandleResourceClick = useCallback(
     (e: React.SyntheticEvent, resource) => {
-      handleAction(composeResourceUrl(resource))
+      const url = composeResourceUrl(resource)
+
+      url && handleAction(url)
     },
     [handleAction],
   )


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`<TripleDocument>`에 `onLinkClick`과 `onResourceClick`이 주어지지 않더라도 링크 액션 핸들링이 가능하도록 합니다.

## 변경 내역 및 배경

`@titicaca/standard-action-handler`를 이용해 sensible default 동작을 지원합니다.

## 사용 및 테스트 방법

Canary

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
