### PR TITLE
Fix: index page에서 asPath가 '/'인 상황 대응

### DIFF
--- a/packages/react-contexts/src/history-context.tsx
+++ b/packages/react-contexts/src/history-context.tsx
@@ -45,7 +45,7 @@ function parseQuery(query: string | undefined): ReturnType<typeof parseUrl> {
 }
 
 function addHashToCurrentUrl(hash: string) {
-  return generateUrl({ hash }, Router.asPath)
+  return generateUrl({ hash }, Router.asPath === '/' ? '' : Router.asPath)
 }
 
 const URIHashContext = React.createContext<URIHash>('')


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
history context가 라우터 push/replace를 할 때 index page에서 trailing slash가 생기지 않도록 수정합니다.

## 변경 내역 및 배경
Fixes #998 - 문제의 근본적인 원인은 해결 못하지만, next.js의 문제기 때문에 일단 Fix 표시합니다.

index 페이지에서 사용하면 asPath가 "/"가 됩니다. 그래서 최종 리다이렉트 결과물이 `/#hash`가 됩니다.
이를 수정하여 `#hash`가 되도록 합니다. 이 때 next에서 basePath를 붙여주므로 basePath는 제외합니다.
예를 들어 `/hotels`에서 hash push 하면 `/hotels#hash`가 됩니다.

## 사용 및 테스트 방법
canary
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
