### PR TITLE
Fix: 이미지에 size, frame이 모두 없을 때 FixedRatioFrame 사용

### DIFF
--- a/packages/core-elements/src/elements/image/fixed-ratio-frame.tsx
+++ b/packages/core-elements/src/elements/image/fixed-ratio-frame.tsx
@@ -47,7 +47,7 @@ const FixedRatioFrameContainer = styled.div<{
 `
 
 export default function ImageFixedRatioFrame({
-  frame,
+  frame = 'small',
   floated,
   margin,
   onClick,
@@ -64,7 +64,7 @@ export default function ImageFixedRatioFrame({
 
   return (
     <FixedRatioFrameContainer
-      frame={frame || 'small'}
+      frame={frame}
       overflowHidden={!originalFrame}
       floated={floated}
       borderRadius={borderRadius}

--- a/packages/image-carousel/src/index.tsx
+++ b/packages/image-carousel/src/index.tsx
@@ -153,16 +153,14 @@ export default class ImageCarousel extends React.PureComponent<
                 >
                   {renderContent()}
                 </Image.FixedDimensionsFrame>
-              ) : null}
-
-              {frame ? (
+              ) : (
                 <Image.FixedRatioFrame
                   frame={frame}
                   onClick={onImageClick && ((e) => onImageClick(e, image))}
                 >
                   {renderContent()}
                 </Image.FixedRatioFrame>
-              ) : null}
+              )}
             </Image>
           )
         })}


### PR DESCRIPTION


<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
이미지 데이터에 size, frame이 모두 없을 때 이미지가 표시되지 않는 문제를 수정합니다.
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경
https://github.com/titicacadev/triple-frontend/blob/924ce8849ee37a00226dc189448f847737fa8f60/packages/core-elements/src/elements/image/compound-image.tsx

frame도 없으면 FixedRatioFrame을 사용했습니다.
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법
canary

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

버그 또는 사소한 수정

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
