### PR TITLE
Fix: 리뷰 목록 조회 API URL에서 trailing slash 제거

### DIFF
--- a/packages/review/src/use-paging.ts
+++ b/packages/review/src/use-paging.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState, useCallback } from 'react'
 import humps from 'humps'
+import qs from 'qs'
 import { useFetch } from '@titicaca/react-hooks'
+import { generateUrl } from '@titicaca/view-utilities'
 
 import { ResourceType, ReviewData } from './types'
 
@@ -21,11 +23,17 @@ export default function usePaging({
   const [endOfList, setEndOfList] = useState(false)
   const [reviews, setReviews] = useState<ReviewData[]>([])
   const { error, loading, data } = useFetch(
-    `/api/reviews/v2${
-      sortingOption ? `/${sortingOption}` : '/'
-    }?resource_id=${resourceId}&resource_type=${resourceType}&from=${
-      (currentPage - 1) * perPage
-    }&size=${perPage}`,
+    generateUrl({
+      path: `/api/reviews/v2${sortingOption ? `/${sortingOption}` : ''}`,
+      query: qs.stringify({
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        resource_id: resourceId,
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        resource_type: resourceType,
+        from: (currentPage - 1) * perPage,
+        size: perPage,
+      }),
+    }),
     OPTIONS,
   )
   const fetchNext = useCallback(


### PR DESCRIPTION


<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
리뷰 목록 조회 API의 URL에서 trailing slash를 제거하고 `generateUrl` 함수를 사용합니다.

## 변경 내역 및 배경
호텔 웹 로컬에서 리뷰 목록이 표시되지 않는 문제가 있었습니다.
리뷰 목록 조회 API URL을 generateUrl 함수를 사용하고, trailing slash를 없앱니다.

## 사용 및 테스트 방법
canary

## 이 PR의 유형

버그 또는 사소한 수정