### PR TITLE
Fix: SencondaryNavbar의 position 기본값 수정

### DIFF
--- a/packages/core-elements/src/elements/navbar.tsx
+++ b/packages/core-elements/src/elements/navbar.tsx
@@ -140,8 +140,12 @@ const NavbarItem = styled.div.attrs<NavbarItemProps>(({ icon }) => ({
 const SecondaryNavbar = styled.div<NavbarProps & LayeringMixinProps>`
   background-color: ${({ backgroundColor = 'white' }) =>
     `rgba(${getColor(backgroundColor)})`};
-  position: ${({ position = 'sticky' }) => position};
-  top: ${({ position }) => (position === 'sticky' ? '52px' : 0)};
+
+  ${({ position = 'sticky' }) => `
+      position: ${position};
+      top: ${position === 'sticky' ? '52px' : 0};
+  `}
+
   left: 0;
   right: 0;
   box-sizing: border-box;


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
둘로 쪼개진 SecondaryNavbar의 position 설정을 통합합니다.

<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경
SecondaryNavbar의 position 기본 값이 한 쪽에만 되어있어 두가지 옵션중 하나만 작동하고 있었습니다.

## 사용 및 테스트 방법

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

버그 또는 사소한 수정

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
