### PR TITLE
session-context의 getSessionId가 클라이언트 쪽에서도 쿠키를 가져오도록 수정

### DIFF
--- a/packages/react-contexts/src/session-context/session-context.tsx
+++ b/packages/react-contexts/src/session-context/session-context.tsx
@@ -31,8 +31,8 @@ const SessionContext = createContext<SessionContextValue | null>(null)
 export function getSessionID(
   req: IncomingMessage | undefined,
 ): string | undefined {
-  const cookie = req?.headers.cookie
-  return cookie ? new Cookies(cookie).get(SESSION_KEY) : undefined
+  const cookieHeader = req?.headers.cookie
+  return new Cookies(cookieHeader).get(SESSION_KEY)
 }
 
 export function setSessionID(sessionId: string | undefined) {


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
`getSessionId`가 브라우저에서 작동할 때도 쿠키값을 가져오도록 합니다.
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경
Fixes #1046 

## 사용 및 테스트 방법
canary

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

버그 또는 사소한 수정

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
