### PR TITLE
🐛 액션시트 기본 zTier를 3으로 설정

### DIFF
--- a/packages/action-sheet/src/components/action-sheet.tsx
+++ b/packages/action-sheet/src/components/action-sheet.tsx
@@ -136,7 +136,7 @@ const Overlay = styled.div<OverlayProps & LayeringMixinProps>`
   right: 0;
   background-color: rgba(58, 58, 58, 0.7);
 
-  ${layeringMixin(1)}
+  ${layeringMixin(3)}
 
   &:not([class*='action-sheet-fade-']) {
     ${inactiveOverlayFadeStyle}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

액션 시트의 기본 zTier를 3으로 설정합니다.

## 변경 내역 및 배경
https://titicaca.slack.com/archives/CEEPB4TDY/p1606187519240800

modal과 마찬가지로 화면 위로 overlay가 깔리기 때문에 modal과 동일한 zTier 3을 가져도 된다고 판단했습니다.

## 사용 및 테스트 방법
canary

## 이 PR의 유형

버그 또는 사소한 수정

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
