### PR TITLE
🏷️ H1Props의 children을 PropsWithChildren을 이용해 표현

### DIFF
--- a/packages/core-elements/src/elements/typography.tsx
+++ b/packages/core-elements/src/elements/typography.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import * as CSS from 'csstype'
 
 import { MarginPadding } from '../commons'
@@ -6,14 +6,15 @@ import { MarginPadding } from '../commons'
 import Text, { TextProps } from './text'
 import Container from './container'
 
-export interface H1Props extends TextProps {
-  href?: string
-  headline?: string
-  emphasize?: boolean
-  margin?: MarginPadding
-  textAlign?: CSS.Property.TextAlign
-  children?: string
-}
+export type H1Props = PropsWithChildren<
+  TextProps & {
+    href?: string
+    headline?: string
+    emphasize?: boolean
+    margin?: MarginPadding
+    textAlign?: CSS.Property.TextAlign
+  }
+>
 
 export type H2Props = TextProps
 export type H3Props = TextProps


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
`H1Props`의 `children` 속성을 리액트가 제공하는 `PropsWithChildren`을 이용해 표현합니다.

<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경
Fixes #1071 

`H1Props` 타입 개선

## 사용 및 테스트 방법
canary

## 이 PR의 유형

버그 또는 사소한 수정

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
