### PR TITLE
[react-contexts] withEventTrackingProvider에 options 파라미터추가

### DIFF
--- a/packages/react-contexts/src/event-tracking-context/with-event-tracking-provider.tsx
+++ b/packages/react-contexts/src/event-tracking-context/with-event-tracking-provider.tsx
@@ -5,10 +5,13 @@ import { EventTrackingProvider } from './event-tracking-context'
 export function withEventTrackingProvider<P>(
   pageLabel: string,
   Component: React.ComponentType<P>,
+  options?: {
+    onError?: (error: Error) => void
+  },
 ): React.ComponentType<P> {
   const Page: React.ComponentType<P> = function (props: P) {
     return (
-      <EventTrackingProvider pageLabel={pageLabel}>
+      <EventTrackingProvider pageLabel={pageLabel} {...(options || {})}>
         <Component {...props} />
       </EventTrackingProvider>
     )


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
- EventTrackingProvider Hoc에서도 onError를 사용할수 있도록합니다

## 변경 내역 및 배경
- options파라미터 추가
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->
