### PR TITLE
760 대신 768을 기준으로 큰 화면 레이아웃을 구성합니다.

### DIFF
--- a/packages/app-installation-cta/src/elements.tsx
+++ b/packages/app-installation-cta/src/elements.tsx
@@ -34,7 +34,8 @@ export const BottomFixedContainer = styled.div<LayeringMixinProps>`
 `
 
 const CONTENT_MIN_WIDTH = 320
-const CONTENT_MAX_WIDTH = 760
+const CONTENT_MAX_WIDTH = 768
+
 export const ImageBannerWrapper = styled.div`
   box-sizing: border-box;
   min-width: ${CONTENT_MIN_WIDTH}px;
@@ -43,6 +44,7 @@ export const ImageBannerWrapper = styled.div`
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.07);
   background-color: #0179ff;
 `
+
 export const ImageWrapper = styled.div`
   margin: 0 auto;
   height: 130px;

--- a/packages/core-elements/src/elements/image-source.tsx
+++ b/packages/core-elements/src/elements/image-source.tsx
@@ -4,7 +4,7 @@ import formatSourceURL from '../utils/format-source-url'
 
 export type ImageSourceType = typeof ImageSource
 
-export default function ImageSource({ sourceUrl }: { sourceUrl: string }) {
+export default function ImageSource({ sourceUrl }: { sourceUrl?: string }) {
   if (!sourceUrl) {
     return null
   }

--- a/packages/core-elements/src/elements/section.tsx
+++ b/packages/core-elements/src/elements/section.tsx
@@ -8,7 +8,7 @@ export default function Section({
   anchor,
   children,
   minWidth = 320,
-  maxWidth = 760,
+  maxWidth = 768,
   padding = { left: 30, right: 30 },
   ...props
 }: {

--- a/packages/poi-detail/src/recommended-articles/recommended-articles.tsx
+++ b/packages/poi-detail/src/recommended-articles/recommended-articles.tsx
@@ -57,7 +57,7 @@ export default function RecommendedArticles({
       maxWidth={0}
       padding={{ left: 0, right: 0 }}
     >
-      <Responsive minWidth={760}>
+      <Responsive minWidth={768}>
         <H1 textAlign="center">함께 보면 좋을 추천 가이드</H1>
 
         <Carousel
@@ -79,7 +79,7 @@ export default function RecommendedArticles({
           가이드 더보기
         </MoreButton>
       </Responsive>
-      <Responsive maxWidth={759}>
+      <Responsive maxWidth={767}>
         <H1 margin={{ left: 30 }}>{`함께 보면 좋을\n추천 가이드`}</H1>
 
         <Carousel

--- a/packages/recommended-contents/src/index.tsx
+++ b/packages/recommended-contents/src/index.tsx
@@ -124,7 +124,7 @@ export default function RecommendedContents<T extends ContentElementProps>({
 
   return (
     <RecommendedContentsContainer margin={margin}>
-      <Responsive maxWidth={759}>
+      <Responsive maxWidth={767}>
         <Container padding={{ right: 15 }}>
           {contents.map((content, index) => (
             <IntersectionObserver
@@ -154,7 +154,7 @@ export default function RecommendedContents<T extends ContentElementProps>({
           ))}
         </Container>
       </Responsive>
-      <Responsive minWidth={760}>
+      <Responsive minWidth={768}>
         {contents.map((content, index) => (
           <IntersectionObserver
             key={index}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

각종 컴포넌트 로직에 포함된 760을 768로 변경합니다.

## 변경 내역 및 배경

https://github.com/titicacadev/triple-articles-web/pull/237 에서 발견했습니다.

## 사용 및 테스트 방법

Canary?

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
