### PR TITLE
Search 컴포넌트에서 backOrClose 제거

### DIFF
--- a/packages/search/src/index.tsx
+++ b/packages/search/src/index.tsx
@@ -14,10 +14,7 @@ import {
   SearchNavbar,
 } from '@titicaca/core-elements'
 import { useUserAgentContext } from '@titicaca/react-contexts'
-import {
-  backOrClose,
-  closeKeyboard,
-} from '@titicaca/triple-web-to-native-interfaces'
+import { closeKeyboard } from '@titicaca/triple-web-to-native-interfaces'
 import { useDebouncedState } from '@titicaca/react-hooks'
 
 const ContentsContainer = styled(Container)<{ isIOS: boolean }>`
@@ -132,17 +129,12 @@ export default function FullScreenSearchView({
     handleInputFocus()
   }
 
-  const handleBack = useCallback(() => {
-    onBackClick()
-    backOrClose()
-  }, [onBackClick])
-
   return (
     <>
       <SearchNavbar
         placeholder={placeholder}
         value={keyword}
-        onBackClick={handleBack}
+        onBackClick={onBackClick}
         onDeleteClick={handleDelete}
         onInputChange={handleChange}
         onInputClick={onInputClick}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
Search 컴포넌트의 back 버튼을 눌렀을 때 `backOrClose` 호출을 제거합니다.

<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경

[허브에서 검색창에 작성하다가 그냥 뒤로 가기 했을 때 발생하는 에러](https://titicaca.slack.com/archives/CEEPB4TDY/p1606458091251000)를 검토하던 중 발견했습니다. 해당 버그는 검색어 입력과 상관없이 일정 시간을 기다렸다가 뒤로가기를 누르면 발생합니다. 호텔 허브엔 asPath 중복 방지 workaround가 들어가있는데 이것이 작동하는 시간 차이인 것으로 보입니다.

`Search`의 뒤로 가기를 눌렀을 때 `onBackClick` 콜백을 호출하고 `backOrClose` 함수를 호출하게 되어있었습니다. 그런데 이 컴포넌트를 사용하고 있는 여러 지점에서 `onBackClick` 콜백에 `back` 함수를 넣어주고 있었습니다. 결국 두 번 back되는 현상이 일어납니다. 안드로이드에서 에러는 재현 안 되지만 허브 창이 닫히는 문제는 이 때문입니다.

## 논의할 점
### 수정 계획

이 변경이 breaking change이긴 하지만 치명적인 이슈로 보입니다.
사용하는 지점 자체가 얼마 없고, back이 없는 곳이 더 적으므로 이 PR을 머지하고 back이 없는 곳을 수정하면 좋겠습니다.
https://github.com/titicacadev/triple-hotels-web/pull/2052

#### back이 없는 곳
[호텔 검색](https://github.com/titicacadev/triple-hotels-web/blob/5a1b2f005817b89d74ee29326c2ae82ee2d4b54f/src/search/index.tsx#L118)

#### back이 있는 곳
[search-web](https://github.com/titicacadev/triple-search-web/blob/634b5fa7af404150cf751c423dc8057b52684245/src/components/main.tsx#L159)
[호텔 허브 검색](https://github.com/titicacadev/triple-hotels-web/blob/5a1b2f005817b89d74ee29326c2ae82ee2d4b54f/src/hub/search-section/search-target-cell/search-popup.tsx#L192)
[지니 출도착지 검색](https://github.com/titicacadev/triple-genie-web/blob/90630a68bee06db9974fddd11ac88ef861706686/src/components/poi-search/index.tsx#L164)

### 재발 방지 대책

콜백 prop의 이름을 지을 때 엘리먼트의 `onClick` prop에 들어가지 않는 이상 `onXXXClick` 네이밍은 사용하지 않으면 좋겠습니다.
예를 들어, 이벤트를 로깅하고 라우팅하는 링크를 컴포넌트화 할 때 이벤트 로깅하는 시점을 외부에서 넣어주기 위해 해당 부분을 callback prop으로 만듭니다. 이때 `onLinkClick` 등의 이름을 사용하게 되는데, 이러면 실제 핸들러가 어떤 역할인지 구분하기 힘들게 됩니다.
`onBeforeURLChange` 등의 구체적인 이름을 사용하면 좋겠습니다.

```ts
const handleLinkClick = () => {
  onLinkClick() // 이 콜백에 어느 로직까지 넣어줄 수 있는지 감이 안 옴.
  routeToFooPage()
}
```

```ts
const handleLinkClick = () => {
  onBeforeRouteToFooPage() // 라우팅 전에 작동하는 콜백인지 명확해짐.
  routeToFooPage()
}
```

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- 버그 또는 사소한 수정
- Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
