### PR TITLE
[public-header] 로고 이미지 비율을 바로잡습니다.

### DIFF
--- a/packages/public-header/src/index.tsx
+++ b/packages/public-header/src/index.tsx
@@ -62,16 +62,16 @@ const Logo = styled.a`
     left: 50px;
     width: 68px;
     height: 24px;
-    background-size: 68px 24px;
+    background-size: cover;
     margin-top: -12px;
   }
 
   @media (max-width: ${MAX_PHONE_WIDTH}px) {
     left: 14px;
     width: 56px;
-    height: 18px;
-    background-size: 56px 18px;
-    margin-top: -9px;
+    height: 20px;
+    background-size: cover;
+    margin-top: -10px;
   }
 `
 


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

모바일 뷰에서 로고가 찌그러져보이는 문제를 해결합니다.

## 변경 내역 및 배경

전에 로고 이미지 변경할 때 잘 못 챙겼나봐요 ㅠㅠ 이 참에 `background-size: cover` 스타일을 적용합니다.

## 사용 및 테스트 방법

Storybook, canary

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
