### PR TITLE
fix(map): performance warning 이슈 개선

### DIFF
--- a/packages/map/src/index.tsx
+++ b/packages/map/src/index.tsx
@@ -34,25 +34,23 @@ export interface WithGoogleMapProps extends GoogleMapProps {
     /**
      * google map additional libraries
      * default: ['geometry'] - https://developers.google.com/maps/documentation/javascript/libraries */
-    libraries?: Libraries
+    // libraries?: Libraries
   }
 }
+
+const GOOGLE_MAP_LIBRARIES: Libraries = ['geometry']
 
 export default function MapView({
   options: _options,
   mapContainerStyle: _mapContainerStyle,
-  googleMapLoadOptions: {
-    googleMapsApiKey,
-    region = 'kr',
-    libraries = ['geometry'],
-  },
+  googleMapLoadOptions: { googleMapsApiKey, region = 'kr' },
   children,
   ...props
 }: PropsWithChildren<WithGoogleMapProps>) {
   const { isLoaded, loadError } = useLoadScript({
     googleMapsApiKey,
     region,
-    libraries,
+    libraries: GOOGLE_MAP_LIBRARIES,
   })
 
   const options: google.maps.MapOptions = useMemo(


### PR DESCRIPTION
## 설명

구글맵 API 에 drawing lib 을 로딩하기 위해 `Libraries` 타입의 인자를 받습니다. 
MapView 에 이 값을 props 로 받아 전달하니 아래와 같은 성능 이슈에 대한 경고가 발생하여 이를 개선합니다. 

> Performance warning! LoadScript has been reloaded unintentionally! You should not pass `libraries` prop as new array. Please keep an array of libraries as static class property for Components and PureComponents, or just a const variable outside of component, or somewhere in config files or ENV variables 

## 변경 내역 및 배경

- props 으로 전달하던 Libraries 를 const 로 분리합니다.

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
