### PR TITLE
📌 @types/googlemaps 버전 고정

### DIFF
--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -20,6 +20,6 @@
     "@titicaca/core-elements": "^2.6.0"
   },
   "devDependencies": {
-    "@types/googlemaps": "3.40.5"
+    "@types/googlemaps": "~3.40.5"
   }
 }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
`@react-google-maps/api`에서 사용하는 googlemaps 타입과 최신 `@types/googlemaps`의 인터페이스가 달라서 [에러](https://github.com/titicacadev/triple-frontend/runs/1598296828)가 발생했습니다.

`@types/googlemaps` minor 버전을 고정하여 문제를 해결합니다.

## 이 PR의 유형

버그 또는 사소한 수정
