### PR TITLE
🏷️ AB 테스트 conversion 트래커의 파라미터 타입 개선

### DIFF
--- a/packages/react-contexts/src/ab-experiment-context/context.tsx
+++ b/packages/react-contexts/src/ab-experiment-context/context.tsx
@@ -94,21 +94,28 @@ function useABExperimentMeta(slug: string, onError?: (error: Error) => void) {
  * @param slug 실험 slug
  * @param onError
  */
+
+type ReservedParameters =
+  | 'action'
+  | 'experiment_name'
+  | 'experiment_id'
+  | 'variant_id'
 export function useABExperimentConversionTracker(
   slug: string,
   onError?: (error: Error) => void,
-): (params?: {
-  [key: string]: string | undefined
-  content_type?: string
-  item_id?: string
-  item_name?: string
-  region_id?: string
-  zone_id?: string
-  action: never
-  experiment_name: never
-  experiment_id: never
-  variant_id: never
-}) => void {
+): <
+  T = {
+    content_type?: string
+    item_id?: string
+    item_name?: string
+    region_id?: string
+    zone_id?: string
+  }
+>(
+  params?: keyof T & ReservedParameters extends never
+    ? T
+    : Omit<T, ReservedParameters>,
+) => void {
   const { trackEvent } = useEventTrackingContext()
   const meta = useABExperimentMeta(slug, onError)
 


### PR DESCRIPTION


<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
conversion Tracker의 타입을 개선합니다.
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경
action: never로 타이핑하면 action을 넣지 않았다는 에러가 발생합니다.
그런데 never는 넣어줄 값이 없기 때문에 사용할 수 없습니다.

## 사용 및 테스트 방법
canary

## 이 PR의 유형

버그 또는 사소한 수정
