### PR TITLE
[chore] tsconfig.tsbuildinfo 파일의 change event를 무시합니다.

### DIFF
--- a/build-watch.js
+++ b/build-watch.js
@@ -7,7 +7,7 @@ const BUILD_RESOURCES =
 const BUILD_DECLARATIONS = 'tsc --incremental'
 
 const watcher = chokidar.watch('packages/', {
-  ignored: /(node_modules|lib|(^|[/\\])\..)/,
+  ignored: /(node_modules|lib|tsconfig\.tsbuildinfo|(^|[/\\])\..)/,
   persistent: true,
 })
 


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`build-watch` 스크립트에서 `tsc`의 incremental build를 활용하는데, 이 옵션을 사용하면 빌드 캐시인 `tsconfig.tsbuildinfo` 파일이 모든 패키지마다 생성됩니다. 특정 패키지의 타입 정보가 변경되면 `tsconfig.tsbuildinfo` 파일에도 변경이 일어나고, 이 때문에 빌드 작업이 반복해서 일어나고 있는 문제를 발견했습니다.

Ignore 패턴에 이 파일을 추가하여 recursive build가 일어나지 않도록 합니다.

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
