### PR TITLE
🐛 컴포넌트의 underline 설정이 우선하도록 && hack 추가

### DIFF
--- a/packages/core-elements/src/elements/content-elements.tsx
+++ b/packages/core-elements/src/elements/content-elements.tsx
@@ -80,6 +80,10 @@ export const SimpleLink = styled.a`
   font-size: 15px;
   font-weight: bold;
   color: #2987f0;
-  text-decoration: underline;
   cursor: pointer;
+
+  /* HACK: global-style의 underline 설정보다 우선하도록 수정 */
+  && {
+    text-decoration: underline;
+  }
 `

--- a/packages/core-elements/src/elements/text.tsx
+++ b/packages/core-elements/src/elements/text.tsx
@@ -182,11 +182,14 @@ const Html = styled(TextBase)`
     color: ${({ color = 'gray' }) => rgba({ color, alpha: 1 })};
   }
 
-  a {
-    font-size: 15px;
-    font-weight: bold;
-    color: #2987f0;
-    text-decoration: underline;
+  /* HACK: global-style의 underline 설정보다 우선하도록 수정 */
+  && {
+    a {
+      font-size: 15px;
+      font-weight: bold;
+      color: #2987f0;
+      text-decoration: underline;
+    }
   }
 `
 

--- a/packages/triple-document/src/elements/links.tsx
+++ b/packages/triple-document/src/elements/links.tsx
@@ -34,9 +34,13 @@ const ListLinkContainer = styled.div`
 `
 
 const ListLink = styled.a`
-  text-decoration: underline;
   color: rgba(${getColor('gray900')});
   font-weight: 500;
+
+  /* HACK: global-style의 underline 설정보다 우선하도록 수정 */
+  && {
+    text-decoration: underline;
+  }
 `
 
 const ButtonContainer = styled.div<{ compact?: boolean }>`


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

global style에서 지정한 스타일을 컴포넌트에서 덮어쓰도록 `&&` hack을 추가합니다.

## 변경 내역 및 배경

Fixes #1156 

## 사용 및 테스트 방법

docs

## 스크린샷
<img width="381" alt="스크린샷 2021-01-04 오후 3 13 10" src="https://user-images.githubusercontent.com/26055001/103506153-5d7a6100-4e9f-11eb-9de0-f54315629cec.png">
<img width="368" alt="스크린샷 2021-01-04 오후 3 13 19" src="https://user-images.githubusercontent.com/26055001/103506162-623f1500-4e9f-11eb-96cb-2b20d1890e81.png">
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

 버그 또는 사소한 수정

