### PR TITLE
[image-carousel] flicking isPlaying 시 clickEvent를 발생시키지 않습니다

### DIFF
--- a/packages/image-carousel/src/carousel.tsx
+++ b/packages/image-carousel/src/carousel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { RefObject } from 'react'
 import styled from 'styled-components'
 import { FlickingEvent, FlickingOptions } from '@egjs/flicking'
 import Flicking, { FlickingProps } from '@egjs/react-flicking'
@@ -6,6 +6,7 @@ import { Container, MarginPadding } from '@titicaca/core-elements'
 
 export interface CarouselProps
   extends Partial<FlickingProps & FlickingOptions> {
+  flickingRef: RefObject<Flicking>
   margin?: MarginPadding
   borderRadius?: number
   pageLabelRenderer: (params: { currentIndex: number }) => React.ReactNode
@@ -93,7 +94,13 @@ export default class Carousel extends React.PureComponent<
   }
 
   render() {
-    const { margin, borderRadius, pageLabelRenderer, children } = this.props
+    const {
+      margin,
+      borderRadius,
+      pageLabelRenderer,
+      children,
+      flickingRef,
+    } = this.props
     const PageLabel: React.ComponentType<{ currentIndex: number }> = ({
       currentIndex,
     }) => {
@@ -108,7 +115,9 @@ export default class Carousel extends React.PureComponent<
         margin={margin}
         borderRadius={borderRadius}
       >
-        <Flicking {...this.flickingProps}>{children}</Flicking>
+        <Flicking ref={flickingRef} {...this.flickingProps}>
+          {children}
+        </Flicking>
 
         <PageLabel currentIndex={this.state.currentIndex} />
       </CarouselContainer>

--- a/packages/image-carousel/src/index.tsx
+++ b/packages/image-carousel/src/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { createRef, RefObject } from 'react'
 import styled from 'styled-components'
 import { ImageSourceType, Image } from '@titicaca/core-elements'
 import {
@@ -6,6 +6,7 @@ import {
   GlobalSizes,
   FrameRatioAndSizes,
 } from '@titicaca/type-definitions'
+import Flicking from '@egjs/react-flicking'
 
 import Carousel, { CarouselProps } from './carousel'
 
@@ -45,8 +46,15 @@ interface ImageCarouselProps extends Omit<CarouselProps, 'pageLabelRenderer'> {
 export default class ImageCarousel extends React.PureComponent<
   ImageCarouselProps
 > {
+  private flickingRef: RefObject<Flicking>
+
   static defaultProps: Partial<ImageCarousel['props']> = {
     pageLabelRenderer: (props) => PageLabel(props),
+  }
+
+  constructor(props: ImageCarouselProps) {
+    super(props)
+    this.flickingRef = createRef<Flicking>()
   }
 
   get carouselProps(): CarouselProps {
@@ -78,6 +86,7 @@ export default class ImageCarousel extends React.PureComponent<
           currentIndex,
           totalCount,
         }) || null,
+      flickingRef: this.flickingRef,
     }
   }
 
@@ -147,14 +156,24 @@ export default class ImageCarousel extends React.PureComponent<
               {size ? (
                 <Image.FixedDimensionsFrame
                   size={size}
-                  onClick={onImageClick && ((e) => onImageClick(e, image))}
+                  onClick={
+                    onImageClick &&
+                    ((e) =>
+                      !this.flickingRef.current?.isPlaying() &&
+                      onImageClick(e, image))
+                  }
                 >
                   {renderContent()}
                 </Image.FixedDimensionsFrame>
               ) : (
                 <Image.FixedRatioFrame
                   frame={frame}
-                  onClick={onImageClick && ((e) => onImageClick(e, image))}
+                  onClick={
+                    onImageClick &&
+                    ((e) =>
+                      !this.flickingRef.current?.isPlaying() &&
+                      onImageClick(e, image))
+                  }
                 >
                   {renderContent()}
                 </Image.FixedRatioFrame>


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
- useRef로 react-flicking 내부 인터페이스를 사용했습니다
