### PR TITLE
fix(triple-document): 추천코스 poi 카드 타이틀,메모 말줄임 처리

### DIFF
--- a/docs/stories/__mocks__/triple-document.itinerary.json
+++ b/docs/stories/__mocks__/triple-document.itinerary.json
@@ -164,7 +164,7 @@
                   }
                 },
                 {
-                  "memo": "",
+                  "memo": "동해물과 백두산 마고 닳도록 메모도 너무 너 길어서 말줄임이 되어 합니.메모 영은 최대 2줄까 표될 수 있어야 합니다.",
                   "schedule": "",
                   "transportation": [
                     {
@@ -183,7 +183,7 @@
                       "type": "restaurant",
                       "regionId": "edf1982d-c835-43a7-b06b-af43acbb6f38",
                       "names": {
-                        "ko": "걸리버스 트래블러 터번 카오산 점",
+                        "ko": "이름 매우 길고 길고 길어서 말줄임이 필요한 POI 이름입니다",
                         "en": "Gulliver's Traveler's Tavern",
                         "local": "บริษัท กัลลิเวอร์ ทาเวิร์น จำกัด"
                       },

--- a/packages/triple-document/src/elements/itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary.tsx
@@ -60,9 +60,15 @@ const Timeline = styled(FlexBox)`
 
 const PoiCard = styled(Card)`
   flex: 1;
-  padding: 16px 15px;
 `
 
+const CardWrapper = styled(FlexBox)`
+  min-width: 200px;
+
+  > ${PoiCard} {
+    padding: 16px 15px;
+  }
+`
 const Stack = styled(Container)`
   div:first-child ${Timeline} {
     :before {
@@ -79,6 +85,7 @@ const Duration = styled(Container)`
   position: relative;
   bottom: -10px;
   left: -5px;
+  flex-shrink: 0;
 `
 
 const SaveToItineraryButton = styled(Button)`
@@ -178,7 +185,7 @@ export default function ItineraryElement({
                     ) : null}
                   </FlexBox>
                 </Timeline>
-                <FlexBox
+                <CardWrapper
                   flexGrow={1}
                   as="a"
                   onClick={generatePoiClickHandler(regionId, type, id)}
@@ -196,17 +203,16 @@ export default function ItineraryElement({
                       color="gray500"
                       lineHeight={1.4}
                       padding={{ top: 6 }}
-                      ellipsis
                     >
                       {description}
                     </Text>
                     {memo ? (
-                      <Text size={14} margin={{ top: 10 }}>
+                      <Text size={14} margin={{ top: 10 }} maxLines={2}>
                         {memo}
                       </Text>
                     ) : null}
                   </PoiCard>
-                </FlexBox>
+                </CardWrapper>
               </FlexBox>
             )
           })}


### PR DESCRIPTION
## 설명

triple-document 지도,추천코스 요소 컴포넌트에 말줄임 처리를 추가합니다.

POI 제목은 1줄, 메모 영역은 2줄 처리합니다.

Resolve: #1176 

## 변경 내역 및 배경

flex 에서는 `ellipsis` 처리로 만은 안되고 `flex-shrink` 너비 줄임에 대한 처리도 필요하다고 합뉘다.

참고: https://leonardofaria.net/2020/07/18/using-flexbox-and-text-ellipsis-together/

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

![Kapture 2021-01-21 at 11 59 43](https://user-images.githubusercontent.com/145777/105274969-a7727f00-5be1-11eb-978e-861d3f92040f.gif)

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
