### PR TITLE
Use image-api cast API for image of social reviews

### DIFF
--- a/packages/social-reviews/src/index.tsx
+++ b/packages/social-reviews/src/index.tsx
@@ -63,7 +63,14 @@ export default function SocialReviews({
                 <Image borderRadius={4}>
                   <Image.FixedRatioFrame frame="big">
                     <Image.Img
-                      src={`/api/images/cast?url=${imageUrl}&transformation=c_fill,f_auto,q_auto,h_256,w_256`}
+                      src={
+                        imageUrl &&
+                        `/api/images/cast?url=${encodeURIComponent(
+                          imageUrl,
+                        )}&transformation=${encodeURIComponent(
+                          'c_fill,f_auto,q_auto,h_256,w_256',
+                        )}`
+                      }
                       alt={`${title} 썸네일`}
                     />
                   </Image.FixedRatioFrame>


### PR DESCRIPTION
소셜리뷰 이미지 렌더링 시에 images-api의 [cast API](https://github.com/titicacadev/triple-images-api/pull/46) 사용


## 설명

소셜리뷰의 이미지를 images-api에 업로드 하고 우리의 cdn을 통해 보여줍니다.

## 변경 내역 및 배경

소셜리뷰의 경우 cross-origin https 이슈로 이미지가 뜨지 않고 있습니다. (과거엔 떴으나 네이버의 정책 변경으로 지금은 엑박이 뜹니다.) 따라서 images-api에 업로드 하고 보여줄 수 있도록 [cast API](https://github.com/titicacadev/triple-images-api/pull/46)를 사용합니다.

## 사용 및 테스트 방법

canary 배포 및 적용

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
