### PR TITLE
fix(triple-document): 추천코스 컴포넌트 > 일정담기 이벤트 핸들 처리 로직 추가

### DIFF
--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -21,16 +21,17 @@
     "@titicaca/map": "^2.9.2",
     "@titicaca/modals": "^2.9.2",
     "@titicaca/poi-list-elements": "^2.9.2",
-    "@titicaca/react-contexts": "^2.9.2",
     "@titicaca/standard-action-handler": "^2.9.2",
     "@titicaca/triple-media": "^2.9.2",
     "@titicaca/type-definitions": "^2.9.2",
     "@titicaca/view-utilities": "^2.9.2",
+    "@titicaca/ui-flow": "^2.9.2",
     "isomorphic-fetch": "^2.2.1",
     "semver": "^7.3.2"
   },
   "peerDependencies": {
-    "@sentry/browser": "^5.4.3"
+    "@sentry/browser": "^5.4.3",
+    "@titicaca/react-contexts": "^2.9.2"
   },
   "devDependencies": {
     "@sentry/browser": "^5.4.3",

--- a/packages/triple-document/src/elements/itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary.tsx
@@ -27,6 +27,7 @@ import {
   Plane,
   Download,
 } from './itinerary/icons'
+import useHandleAddPoisToTrip from './itinerary/use-handle-add-pois-to-trip'
 
 interface Props {
   value: {
@@ -94,12 +95,10 @@ const SaveToItineraryButton = styled(Button)`
   }
 `
 
-export default function ItineraryElement({
-  value,
-  onClickSaveToItinerary,
-}: Props) {
+export default function ItineraryElement({ value }: Props) {
   const { navigate } = useHistoryFunctions()
   const { courses, regionId, poiIds } = useItinerary(value)
+  const addPoisToTrip = useHandleAddPoisToTrip(regionId)
 
   const generatePoiClickHandler = useCallback(
     (
@@ -120,8 +119,9 @@ export default function ItineraryElement({
   )
 
   const handleSaveToItinerary = useCallback(() => {
-    onClickSaveToItinerary(regionId, poiIds)
-  }, [onClickSaveToItinerary, regionId, poiIds])
+    addPoisToTrip(poiIds)
+    /** TODO: event tracking */
+  }, [poiIds, addPoisToTrip])
 
   return (
     <Container margin={{ top: 10, bottom: 10 }}>

--- a/packages/triple-document/src/elements/itinerary/use-handle-add-pois-to-trip.ts
+++ b/packages/triple-document/src/elements/itinerary/use-handle-add-pois-to-trip.ts
@@ -1,0 +1,35 @@
+import qs from 'qs'
+import { useCallback } from 'react'
+import { TransitionType } from '@titicaca/modals'
+import { generateUrl } from '@titicaca/view-utilities'
+import { useHistoryFunctions, useEnv } from '@titicaca/react-contexts'
+import { useAppCallback, useSessionCallback } from '@titicaca/ui-flow'
+
+/**
+ * TODO: hotels-web, content-web 일정추가 액션 중복코드
+ */
+export default function useHandleAddPoiToTrip(regionId?: string) {
+  const { appUrlScheme } = useEnv()
+  const { navigate } = useHistoryFunctions()
+
+  const handleFn = useCallback(
+    (poiId: string | string[]) => {
+      const pois = Array.isArray(poiId) ? poiId.join(',') : poiId
+
+      navigate(
+        generateUrl({
+          scheme: appUrlScheme,
+          path: '/action/add_trip_plan',
+          query: qs.stringify({
+            region_id: regionId,
+            pois,
+          }),
+        }),
+      )
+      return true
+    },
+    [navigate, regionId, appUrlScheme],
+  )
+
+  return useAppCallback(TransitionType.General, useSessionCallback(handleFn))
+}


### PR DESCRIPTION
## 설명

누락된 지도, 추천코스 일정담기 앱 기능 연동을 로직을 추가합니다. (✋🏻 🦶🏻 또 고생중 😢 ) 

## 변경 내역 및 배경

일정에 담기 클릭 핸들러를 props 으로 받아 사용하는 쪽에서 처리할려고 봤더니 triple-document 의 경우에는 그렇게 하면 복잡해지는군요. 그래서 다시 집어 넣었습니다.

호텔에서 일정담기 때 사용하는 로직(use-handle-add-pois-to-trip.ts)을 그대로 사용하여서 중복코드인데요. 이부분도 #1171 에서 함께 처리하면 좋을꺼 같습니다.
요고 랩업하면서 추가 공유 드릴께요.

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
