### PR TITLE
[social-reviews] Support placeholder image for social reviews

### DIFF
--- a/docs/stories/social-reviews/social-reviews.stories.tsx
+++ b/docs/stories/social-reviews/social-reviews.stories.tsx
@@ -8,6 +8,7 @@ export default {
 export function BaseSocialReviews() {
   return (
     <SocialReviews
+      placeholderImageUrl="https://assets.triple-dev.titicaca-corp.com/images/img-empty-contents@3x.png"
       socialReviews={[
         {
           imageUrl:

--- a/packages/social-reviews/src/index.tsx
+++ b/packages/social-reviews/src/index.tsx
@@ -27,9 +27,11 @@ export interface SocialReview {
 }
 
 export default function SocialReviews({
+  placeholderImageUrl,
   socialReviews,
   ...props
 }: {
+  placeholderImageUrl?: string
   socialReviews?: SocialReview[]
 } & Parameters<typeof Section>['0']) {
   const { trackSimpleEvent } = useEventTrackingContext()
@@ -69,7 +71,13 @@ export default function SocialReviews({
                           imageUrl,
                         )}&transformation=${encodeURIComponent(
                           'c_fill,f_auto,q_auto,h_256,w_256',
-                        )}`
+                        )}${
+                          placeholderImageUrl
+                            ? `&placeholder=${encodeURIComponent(
+                                placeholderImageUrl,
+                              )}`
+                            : ''
+                        }`
                       }
                       alt={`${title} 썸네일`}
                     />


### PR DESCRIPTION
소셜리뷰 이미지 placeholder를 지원합니다.

## 설명

images-api가 소셜리뷰 이미지 업로드를 실패한 경우 엑박 대신에 placeholder 이미지를 넣을 수 있도록 합니다.
`<img onerror="" />`를 이용하는 방법도 있지만 경험상 생각대로 잘 동작하지 않았던 기억이..
따라서 images-api의 /cast API에서 placeholder 쿼리를 지원하도록 했습니다.

## 변경 내역 및 배경

`SocialReviews` 컴포넌트에 optional prop으로 `placeholderImageUrl`을 받습니다.

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

![스크린샷 2021-01-25 오후 5 10 04](https://user-images.githubusercontent.com/722173/105678213-3825c380-5f30-11eb-8b0f-d34a5b88b08d.png)

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [x] docs의 스토리를 변경했습니다.
