### PR TITLE
⏪ 팝업에서 최대 너비 제한 해제

### DIFF
--- a/packages/popup/src/index.tsx
+++ b/packages/popup/src/index.tsx
@@ -10,7 +10,6 @@ import {
   Navbar,
   layeringMixin,
   LayeringMixinProps,
-  Container,
 } from '@titicaca/core-elements'
 
 type NavbarIcon = 'close' | 'back'
@@ -134,9 +133,7 @@ export default function Popup({
           </Navbar>
         )}
 
-        <Container maxWidth={768} centered>
-          {children}
-        </Container>
+        {children}
       </PopupContainer>
     </CSSTransition>
   )


### PR DESCRIPTION

<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

팝업의 최대 너비 제한을 해제합니다.

## 변경 내역 및 배경

#1212 에서 팝업의 최대 너비를 제한했지만, #1216 DatePicker의 배경이 width: 100%여야 하기 때문에 팝업의 최대 너비 제한을 해제합니다.

프로젝트에서 최대 너비를 제한할 때 그냥 Container를 사용하고 있으니 굳이 새로운 인터페이스를 추가할 필요는 없는 것 같아 원상복구만 합니다.

## 이 PR의 유형

사소한 수정
