### PR TITLE
build-watch 스크립트를 개선합니다.

### DIFF
--- a/build-watch.js
+++ b/build-watch.js
@@ -24,16 +24,13 @@ const BUILDERS = {}
 
 function createBuilder(packageName) {
   return () => {
-    log(`@titicaca/${packageName} is changed`)
-
     exec(
-      `lerna exec --scope=@titicaca/${packageName} '${BUILD_RESOURCES}'`,
+      `lerna exec --stream --scope=@titicaca/${packageName} '${BUILD_RESOURCES}'`,
       (err, stdout) => {
         if (err) {
           error(err)
         } else {
           log(stdout)
-          log(`Built @titicaca/${packageName}`)
         }
       },
     )


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`build-watch` 스크립트가 tsbuildinfo 변경에 작동하는 문제를 해결합니다. 또한 로그를 좀 더 알아보기 쉽도록 간소화합니다.

## 변경 내역 및 배경

- 패키지의 src 디렉토리만 지켜보도록 수정
- `exec`을 사용해 빌드
- 로그 간소화

## 사용 및 테스트 방법

`npm run watch:resources`

### AS IS

```bash
$ npm run watch:resources

> watch:resources
> node build-watch

@titicaca/action-sheet is changed
[resources] lerna notice cli v3.22.1
[resources] lerna notice filter including "@titicaca/action-sheet"
[resources] lerna info filter [ '@titicaca/action-sheet' ]
[resources] lerna info Executing command in 1 package: "BABEL_ENV=build babel --root-mode upward src --out-dir lib --source-maps --extensions .ts,.tsx,.js --no-comments"
[resources] Successfully compiled 3 files with Babel (478ms).
[resources] lerna success exec Executed command in 1 package: "BABEL_ENV=build babel --root-mode upward src --out-dir lib --source-maps --extensions .ts,.tsx,.js --no-comments"
[resources] lerna exec --scope=@titicaca/action-sheet 'BABEL_ENV=build babel --root-mode upward src --out-dir lib --source-maps --extensions .ts,.tsx,.js --no-comments' exited with code 0
Built @titicaca/action-sheet
```

### TO BE

```bash
$ npm run watch:resources

> watch:resources
> node build-watch

@titicaca/action-sheet: Successfully compiled 3 files with Babel (473ms).
```

## 이 PR의 유형

개발 경험 개선