### PR TITLE
list 타입의 triple-document links 컴포넌트 deprecate

### DIFF
--- a/packages/triple-document/src/elements/links.tsx
+++ b/packages/triple-document/src/elements/links.tsx
@@ -144,6 +144,9 @@ function getDefaultImageUrl(image: ImageMeta | undefined) {
 const LINK_CONTAINERS = {
   button: ButtonContainer,
   block: BlockContainer,
+  /**
+   * @deprecated 어드민에서 만들 수 없어서 기본 타입으로 fallback합니다.
+   */
   list: LinksContainer,
   default: LinksContainer,
   image: ResourceList,
@@ -152,6 +155,9 @@ const LINK_CONTAINERS = {
 const LINK_ELEMENTS = {
   button: ButtonLink,
   block: BlockLink,
+  /**
+   * @deprecated 어드민에서 만들 수 없어서 기본 타입으로 fallback합니다.
+   */
   list: SimpleLink,
   default: SimpleLink,
   image: ImageLink,


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

triple-document의 links 컴포넌트 중 "list" 타입을 기본 타입으로 fallback합니다.

## 변경 내역 및 배경

Related to #1158 

v3에서 제거하기 전 기본 링크로 fallback 처리하고 list 타입은 deprecate 처리합니다.

## 이 PR의 유형

사소한 수정