### PR TITLE
[react-contexts] in-app navigation 시 /outlink 형식의 링크는 그대로 사용합니다.

### DIFF
--- a/packages/react-contexts/src/history-context/canonization.ts
+++ b/packages/react-contexts/src/history-context/canonization.ts
@@ -5,10 +5,12 @@ export function canonizeTargetAddress({
   href,
   webUrlBase,
   expandInlinkStrictly,
+  allowRawOutlink,
 }: {
   href: string
   webUrlBase: string
   expandInlinkStrictly: boolean
+  allowRawOutlink?: boolean
 }): string {
   const { host: webUrlBaseHost } = parseUrl(webUrlBase)
   const { host, path, query, ...rest } = parseUrl(href)
@@ -24,7 +26,7 @@ export function canonizeTargetAddress({
     return !expandInlinkStrictly || shouldExpandOnStrictMode
       ? (path as string)
       : href
-  } else if (path === '/outlink') {
+  } else if (!allowRawOutlink && path === '/outlink') {
     const { url } = parse(query as string)
 
     return canonizeTargetAddress({

--- a/packages/react-contexts/src/history-context/history-context.tsx
+++ b/packages/react-contexts/src/history-context/history-context.tsx
@@ -276,8 +276,9 @@ export function HistoryProvider({
         href: rawHref,
         webUrlBase,
         expandInlinkStrictly: false,
+        allowRawOutlink: true,
       })
-      const { scheme } = parseUrl(canonizedHref)
+      const { scheme, path } = parseUrl(canonizedHref)
 
       if (scheme === 'http' || scheme === 'https') {
         const outlinkParams = qs.stringify({
@@ -286,7 +287,11 @@ export function HistoryProvider({
         })
 
         window.location.href = `${appUrlScheme}:///outlink?${outlinkParams}`
-      } else if (hasSessionId || checkIfRoutable({ href: canonizedHref })) {
+      } else if (
+        hasSessionId ||
+        path === '/outlink' ||
+        checkIfRoutable({ href: canonizedHref })
+      ) {
         window.location.href = generateUrl({ scheme: appUrlScheme }, rawHref)
       } else {
         loginCTAModalHash && push(loginCTAModalHash)


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`navigateInApp` 호출 시 아래 시나리오에 문제가 있었습니다.

- `outlinkParams`를 명시하지 않는 환경
- `/outlink?target=browser` 형식의 링크 처리

위 링크를 Canonize할 때 `/outlink`의 query 부분에서 `url`만 살아남고 있었어요. 외부 브라우저에서는 (차이가 없으니까) 이게 맞는 동작인데, 인앱 브라우저에서는 유실되면 안 되는 동작이네요. 결국 Canonization 로직이 `/outlink`를 처리하는 방식이 외부-인앱 브라우저에서 달라야 한다는 뜻인데, 아래와 같은 처리를 해주었습니다.


## 변경 내역 및 배경

- `canonizeTargetAddress`에 `allowRawOutlink` 라는 옵션을 추가하여 동작을 달리할 수 있도록 합니다.
- `checkIfRoutable`을 (당분간... 이건 곧 달라질 확률이 높긴 합니다) 동일하게 사용할 수 있도록, `navigateInApp`의 세션 방어 로직에 `path === '/outlink'` 조건을 추가합니다.

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
