### PR TITLE
root에 정의된 colorSet만 사용하도록 getCssVariableColor 함수를 추가합니다.

### DIFF
--- a/packages/core-elements/src/commons.ts
+++ b/packages/core-elements/src/commons.ts
@@ -85,3 +85,44 @@ export type CarouselSizes = Exclude<
   GlobalSizes,
   'mini' | 'tiny' | 'huge' | 'massive'
 >
+
+export type Color =
+  | 'gray'
+  | 'gray20'
+  | 'gray50'
+  | 'gray100'
+  | 'gray200'
+  | 'gray300'
+  | 'gray400'
+  | 'gray500'
+  | 'gray600'
+  | 'gray700'
+  | 'gray800'
+  | 'gray900'
+  | 'brightGray'
+  | 'blue'
+  | 'blue60'
+  | 'blue100'
+  | 'blue980'
+  | 'mint'
+  | 'mint100'
+  | 'orange'
+  | 'red'
+  | 'red100'
+  | 'deepOrange'
+  | 'mediumRed'
+  | 'deepRed'
+  | 'purple'
+  | 'purple100'
+  | 'emerald'
+  | 'white'
+  | 'white600'
+  | 'azul'
+  | 'azul500'
+  | 'teal'
+  | 'teal100'
+  | 'teal900'
+
+export function getCssVariableColor(color: Color) {
+  return `var(--color-${color})`
+}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
GlobalStyle의 :root에 정의 colorSet만 사용할수 있도록 getCssVariableColor를 추가합니다.
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경
- 정의된 colorSet에 대한 Color type을 추가
- var(--color-color)로 리턴하는 getCssVariableColor를 함수를 추가
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
사용하는 colorSet관리가 결국엔 2군데에서 관리가 되어야 하네요 ㅜ
globalStyle의 :root와, Color Type에서 
<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
