### PR TITLE
triple-document의 sentry/browser peer 의존성을 완화합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34396,7 +34396,7 @@
         "semver": "^7.3.2"
       },
       "devDependencies": {
-        "@sentry/browser": "^5.4.3",
+        "@sentry/browser": "^6.2.5",
         "@titicaca/content-utilities": "^2.9.0",
         "@types/isomorphic-fetch": "^0.0.35",
         "@types/semver": "^7.3.4"
@@ -34404,6 +34404,87 @@
       "peerDependencies": {
         "@sentry/browser": ">=5 <7",
         "@titicaca/react-contexts": "*"
+      }
+    },
+    "packages/triple-document/node_modules/@sentry/browser": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.2.5.tgz",
+      "integrity": "sha512-nlvaE+D7oaj4MxoY9ikw+krQDOjftnDYJQnOwOraXPk7KYM6YwmkakLuE+x/AkaH3FQVTQF330VAa9d6SWETlA==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/core": "6.2.5",
+        "@sentry/types": "6.2.5",
+        "@sentry/utils": "6.2.5",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/triple-document/node_modules/@sentry/core": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.5.tgz",
+      "integrity": "sha512-I+AkgIFO6sDUoHQticP6I27TT3L+i6TUS03in3IEtpBcSeP2jyhlxI8l/wdA7gsBqUPdQ4GHOOaNgtFIcr8qag==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/hub": "6.2.5",
+        "@sentry/minimal": "6.2.5",
+        "@sentry/types": "6.2.5",
+        "@sentry/utils": "6.2.5",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/triple-document/node_modules/@sentry/hub": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.5.tgz",
+      "integrity": "sha512-YlEFdEhcfqpl2HC+/dWXBsBJEljyMzFS7LRRjCk8QANcOdp9PhwQjwebUB4/ulOBjHPP2WZk7fBBd/IKDasTUg==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "6.2.5",
+        "@sentry/utils": "6.2.5",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/triple-document/node_modules/@sentry/minimal": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.5.tgz",
+      "integrity": "sha512-RKP4Qx3p7Cv0oX1cPKAkNVFYM7p2k1t32cNk1+rrVQS4hwlJ7Eg6m6fsqsO+85jd6Ne/FnyYsfo9cDD3ImTlWQ==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/hub": "6.2.5",
+        "@sentry/types": "6.2.5",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/triple-document/node_modules/@sentry/types": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.5.tgz",
+      "integrity": "sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/triple-document/node_modules/@sentry/utils": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.5.tgz",
+      "integrity": "sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "6.2.5",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "packages/triple-document/node_modules/@titicaca/content-utilities": {
@@ -41721,7 +41802,7 @@
     "@titicaca/triple-document": {
       "version": "file:packages/triple-document",
       "requires": {
-        "@sentry/browser": "^5.4.3",
+        "@sentry/browser": "^6.2.5",
         "@titicaca/color-palette": "^2.15.1",
         "@titicaca/content-utilities": "^2.9.0",
         "@titicaca/core-elements": "^2.15.1",
@@ -41740,6 +41821,69 @@
         "semver": "^7.3.2"
       },
       "dependencies": {
+        "@sentry/browser": {
+          "version": "6.2.5",
+          "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.2.5.tgz",
+          "integrity": "sha512-nlvaE+D7oaj4MxoY9ikw+krQDOjftnDYJQnOwOraXPk7KYM6YwmkakLuE+x/AkaH3FQVTQF330VAa9d6SWETlA==",
+          "dev": true,
+          "requires": {
+            "@sentry/core": "6.2.5",
+            "@sentry/types": "6.2.5",
+            "@sentry/utils": "6.2.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/core": {
+          "version": "6.2.5",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.5.tgz",
+          "integrity": "sha512-I+AkgIFO6sDUoHQticP6I27TT3L+i6TUS03in3IEtpBcSeP2jyhlxI8l/wdA7gsBqUPdQ4GHOOaNgtFIcr8qag==",
+          "dev": true,
+          "requires": {
+            "@sentry/hub": "6.2.5",
+            "@sentry/minimal": "6.2.5",
+            "@sentry/types": "6.2.5",
+            "@sentry/utils": "6.2.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "6.2.5",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.5.tgz",
+          "integrity": "sha512-YlEFdEhcfqpl2HC+/dWXBsBJEljyMzFS7LRRjCk8QANcOdp9PhwQjwebUB4/ulOBjHPP2WZk7fBBd/IKDasTUg==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "6.2.5",
+            "@sentry/utils": "6.2.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "6.2.5",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.5.tgz",
+          "integrity": "sha512-RKP4Qx3p7Cv0oX1cPKAkNVFYM7p2k1t32cNk1+rrVQS4hwlJ7Eg6m6fsqsO+85jd6Ne/FnyYsfo9cDD3ImTlWQ==",
+          "dev": true,
+          "requires": {
+            "@sentry/hub": "6.2.5",
+            "@sentry/types": "6.2.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "6.2.5",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.5.tgz",
+          "integrity": "sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "6.2.5",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.5.tgz",
+          "integrity": "sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "6.2.5",
+            "tslib": "^1.9.3"
+          }
+        },
         "@titicaca/content-utilities": {
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/@titicaca/content-utilities/-/content-utilities-2.9.0.tgz",

--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -34,7 +34,7 @@
     "@titicaca/react-contexts": "*"
   },
   "devDependencies": {
-    "@sentry/browser": "^5.4.3",
+    "@sentry/browser": "^6.2.5",
     "@titicaca/content-utilities": "^2.9.0",
     "@types/isomorphic-fetch": "^0.0.35",
     "@types/semver": "^7.3.4"


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

triple-document가 `@sentry/browser` v5를 의존성으로 가지고 있어, 사용하는 프로젝트의 `@sentry/browser` 의존성을 v6로 업데이트할 수 없었습니다. 버전 제한을 5, 6을 모두 포함하도록 완화하여 유연하게 업데이트할 수 있게 바꿉니다.

## 변경 내역 및 배경

- triple-document의 `@sentry/browser` Peer Dependency를 `>=5 <7`로 변경
- Dev Dependency인 `@sentry/browser`를 최신 버전으로 업데이트

## 이 PR의 유형

사소한 수정