### PR TITLE
응답의 content-type에 json이 포함되어있을 때만 json 파싱

### DIFF
--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -67,13 +67,18 @@ export async function fetcher<T = any>(
   const response = await getResponse(retryable ? 3 : 0)
 
   try {
+    const responseContentType = response.headers.get('content-type')
+
     /**
      * TODO:
-     * - [ ] 서버에서 모든 응답값 response.body 가 json 이여야 한다.
      * - [ ] 서버에서 모든 에러 포맷이 json 이 보장되거나 status 코드로만 처리할 수 있도록 한다.
      * - 현재 string like boolean | undefined | json string 이 2xx, 4xx 에서 혼용되고 있다.
      */
-    if (response.status === 200) {
+    if (
+      response.status === 200 &&
+      responseContentType &&
+      /json/.test(responseContentType)
+    ) {
       response.result = await response.json()
     }
 


### PR DESCRIPTION


<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

응답의 content-type이 json임이 보장될 때만 문제 없이 json을 파싱할 수 있습니다.
result에 json 응답을 넣는 분기에 조건을 추가합니다.

## 변경 내역 및 배경


호텔에는 조건이 있었지만 TF fetcher에는 없었습니다.

## 사용 및 테스트 방법
canary


## 이 PR의 유형

잠재적인 버그 수정 || 기능 추가