### PR TITLE
POICardElement의 스크랩 버튼을 무조건 표시합니다.

### DIFF
--- a/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
+++ b/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
@@ -79,6 +79,9 @@ export default function POICardElement({
   id: string
   type: ListingPOI['type']
   scraped: boolean
+  /**
+   * @deprecated 더이상 사용하지 않습니다.
+   */
   regionId?: string
   image: ImageMeta | undefined
   names: TranslatedProperty


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`POICardElement`의 스크랩 버튼을 `regionId` 유무에 상관 없이 무조건 표시합니다.

## 변경 내역 및 배경

https://github.com/titicacadev/triple-hotels-web/pull/2221

리전 바깥의 호텔도 스크랩할 수 있게 되었습니다. 그래서 `regionId` 유무로 스크랩 버튼을 표시 여부를 결정하던 로직은 필요 없어졌습니다.

## 사용 및 테스트 방법
canary

## 이 PR의 유형

기능 추가

## 머지 후 할 일
- [ ] `regionId` prop 제거하는 이슈 생성