### PR TITLE
[static-map] zoom level과 frame을 제어 가능하도록 합니다.

### DIFF
--- a/packages/static-map/src/index.tsx
+++ b/packages/static-map/src/index.tsx
@@ -26,6 +26,8 @@ export default function StaticMap({
   lon,
   zoom = 16,
   frame = 'mini',
+  mapSize = '320x120',
+  mapScale = '2',
   markerImage,
   onClick,
 }: {
@@ -34,6 +36,8 @@ export default function StaticMap({
   lon: number | string
   zoom?: number | string
   frame?: Parameters<typeof Image.FixedRatioFrame>['0']['frame']
+  mapSize?: string
+  mapScale?: string
   markerImage?: string
   onClick?: (e: React.SyntheticEvent) => void
 }) {
@@ -42,7 +46,7 @@ export default function StaticMap({
       <Image>
         <Image.FixedRatioFrame frame={frame}>
           <Image.Img
-            src={`/api/maps/static-map?size=320x120&scale=2&center=${lat}%2C${lon}&zoom=${zoom}`}
+            src={`/api/maps/static-map?size=${mapSize}&scale=${mapScale}&center=${lat}%2C${lon}&zoom=${zoom}`}
           />
         </Image.FixedRatioFrame>
       </Image>


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

Static map의 zoom/frame 정보를 조절할 수 있도록 합니다.

## 변경 내역 및 배경

최신 디바이스 크기에 맞는 프레임과 zoom level을 찾아보고자 합니다.

## 사용 및 테스트 방법

canary

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
