### PR TITLE
[nearby-pois] Region 없는 POI를 지원합니다.

### DIFF
--- a/packages/nearby-pois/src/nearby-pois.tsx
+++ b/packages/nearby-pois/src/nearby-pois.tsx
@@ -53,7 +53,7 @@ export default function NearbyPois({
   ...props
 }: {
   poiId: string
-  regionId: string
+  regionId?: string
   initialTab?: PoiType
   geolocation: PointGeoJSON
   optimized?: boolean

--- a/packages/nearby-pois/src/poi-entry.tsx
+++ b/packages/nearby-pois/src/poi-entry.tsx
@@ -49,7 +49,9 @@ export default function PoiEntry({
       label: `${eventLabel}_${index + 1}_${id}`,
     })
 
-    navigate(`/regions/${regionId}/${type}s/${id}`)
+    navigate(
+      regionId ? `/regions/${regionId}/${type}s/${id}` : `/${type}s/${id}`,
+    )
   }, [eventLabel, id, index, navigate, regionId, trackSimpleEvent, type])
 
   return (

--- a/packages/nearby-pois/src/service.ts
+++ b/packages/nearby-pois/src/service.ts
@@ -6,7 +6,7 @@ import { PoiType, ListingPOI } from './types'
 export async function fetchPois({
   type,
   excludedIds = [],
-  regionId,
+  regionId = null,
   lat,
   lon,
   distance = 1000,
@@ -15,7 +15,7 @@ export async function fetchPois({
 }: {
   type: PoiType
   excludedIds?: string[]
-  regionId: string
+  regionId?: string | null
   lat: number
   lon: number
   distance?: number | string


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

기존의 `@titicaca/nearby-pois` 패키지는 `regionId`를 필수로 요구하고 있었습니다. 이를 Optional props로 변경하고, 목록에 노출되는 POI들의 Path도 바로잡습니다.

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] 기능 추가 및 breaking change에 대한 CHANGELOG를 추가했습니다.
- [ ] docs의 스토리를 변경했습니다.
