### PR TITLE
[public-header] PublicHeader에 내 예약 목록으로 가는 링크를 추가합니다.

### DIFF
--- a/packages/public-header/src/index.tsx
+++ b/packages/public-header/src/index.tsx
@@ -143,7 +143,7 @@ const MarketLink = styled.a<{ marketType: MarketType }>`
 `
 
 export default function PublicHeader({
-  href,
+  href = 'https://triple.guide',
   playStoreUrl,
   appStoreUrl,
   children,
@@ -168,7 +168,7 @@ export default function PublicHeader({
       borderless={borderless}
       {...props}
     >
-      <Logo href={href || 'https://triple.guide'}>TRIPLE</Logo>
+      <Logo href={href}>TRIPLE</Logo>
       <MarketLinksContainer>
         {playStoreUrl ? (
           <MarketLink marketType={MarketType.playStore} href={playStoreUrl} />


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`PublicHeader`에 `children`이 없는 경우, 내 예약 목록으로 이동하는 링크를 보여주도록 합니다.

This fixes #1395 

## 변경 내역 및 배경

호텔 웹 구매동선 지원과 스카이스캐너 입점을 위해 필요한 변경입니다.

## 사용 및 테스트 방법

Canary, Storybook

## 스크린샷

<img width="1185" alt="Screen Shot 2021-06-02 at 3 29 21 PM" src="https://user-images.githubusercontent.com/712260/120434709-c4049c00-c3b7-11eb-9b2a-a9acdc390e68.png">


## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
