### PR TITLE
[modals] navigate() 후 true를 반환합니다.

### DIFF
--- a/packages/modals/src/login-cta-modal.tsx
+++ b/packages/modals/src/login-cta-modal.tsx
@@ -76,6 +76,8 @@ export function LoginCTAModalProvider({ children }: PropsWithChildren<{}>) {
                 returnUrl || document.location.href,
               )}`,
             )
+
+            return true
           }}
         >
           로그인하고 트리플을


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`navigate()` 후 `false`가 리턴되어 `onConfirm`에 등록된 `back` 핸들러가 불리고 있었던 것 같습니다. https://docs.google.com/spreadsheets/d/1J6wDXPM1VePqqpMWd4_gT4zOkEcazXFTi3DUYqTZ_Vw/edit#gid=0 에서 @noasax 가 리포트한 이슈의 원인으로 추정됩니다.

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
