### PR TITLE
[ui-flow] non-member 진입가능 여부를 제어가능하도록 합니다.

### DIFF
--- a/packages/ui-flow/src/auth-guard/index.ts
+++ b/packages/ui-flow/src/auth-guard/index.ts
@@ -10,7 +10,10 @@ interface UserResponse {
 
 type AuthGuardOptions = {
   authType?: string
+  allowNonMembers?: boolean
 }
+
+const NON_MEMBER_REGEX = /^_PH/
 
 export function authGuard<Props>(
   gssp: (
@@ -47,11 +50,16 @@ export function authGuard<Props>(
       },
     )
 
-    if (user) {
+    const isNonMember = user && user.uid.match(NON_MEMBER_REGEX)
+
+    if (
+      (options?.allowNonMembers && user) ||
+      (!options?.allowNonMembers && user && !isNonMember)
+    ) {
       return gssp({ ...ctx, customContext: { ...ctx.customContext, user } })
     }
 
-    if (status === 401) {
+    if (status === 401 || isNonMember) {
       const query = qs.stringify({
         returnUrl,
         type: options?.authType,


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`authGuard`에 `allowNonMembers`옵션을 추가합니다.

## 변경 내역 및 배경

스카이스캐너 입점을 위해 준비한 '비회원 예약' 에서는 비회원을 '휴대폰번호만을 인증수단으로 사용하는 회원' 이라는 개념으로 정의합니다. `/api/users/me` 응답을 이용해 비회원과 회원을 구분할 수 있고, 비회원들은 경우에 따라 `authGuard` 통과 여부를 제어할 필요가 있습니다.

## 사용 및 테스트 방법

Canary

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
