### PR TITLE
[react-contexts] pageview event에 path를 명시하도록 합니다.

### DIFF
--- a/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
@@ -54,8 +54,8 @@ interface EventTrackingProviderProps {
 declare global {
   interface Window {
     ga?: (
-      method: 'send',
-      type: 'pageview' | 'event',
+      method: 'send' | 'set',
+      type: 'pageview' | 'event' | 'page',
       ...data: (string | undefined)[]
     ) => void
     fbq?: (
@@ -88,7 +88,8 @@ export class EventTrackingProvider extends React.PureComponent<
   ) => {
     try {
       if (window.ga) {
-        window.ga('send', 'pageview', path)
+        window.ga('set', 'page', path)
+        window.ga('send', 'pageview')
       }
 
       if (window.fbq && label) {


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

GA에 보내는 `pageview` 이벤트에 `path`를 명시하도록 합니다.

See: https://developers.google.com/analytics/devguides/collection/analyticsjs/pages

## 변경 내역 및 배경

GA Debugger를 통해 보니, CSR로 이동하는 페이지의 pageview 이벤트 수집이 원활하게 안 되고 있는 현상이 보입니다. `path` 명시가 없으면 최초에 SSR로 랜딩하는 페이지 주소가 들어가고 있는 것으로 보여요. 호텔 웹으로 테스트해보겠습니다.

## 사용 및 테스트 방법

Canary

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
