### PR TITLE
file기반 라우팅을 사용하지 않고 rewrites를 쓸 때 authGuard가 제대로 작동하지 않는 문제 수정

### DIFF
--- a/packages/ui-flow/src/auth-guard/index.test.ts
+++ b/packages/ui-flow/src/auth-guard/index.test.ts
@@ -218,3 +218,37 @@ it('/api/users/me가 401 이외의 에러로 응답했다면, 에러를 던집�
 
   await expect(newGSSP(ctx)).rejects.toThrowError()
 })
+
+it('resolveReturnUrl로 로그인 후 돌아갈 URL을 지정할 수 있습니다.', async () => {
+  const oldGSSP = jest.fn()
+  mockedGet.mockResolvedValueOnce({ status: 401 } as any)
+
+  const newGSSP = authGuard(oldGSSP, {
+    resolveReturnUrl: ({ query }) => {
+      return `/foo/${query.foo}`
+    },
+  })
+
+  const ctx = {
+    req: {
+      headers: {
+        'user-agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
+      },
+    },
+    query: { foo: '1' },
+    resolvedUrl: '/air/foo',
+    customContext: { mock: 'mock' },
+  } as any
+
+  const result = await newGSSP(ctx)
+
+  expect(oldGSSP).toBeCalledTimes(0)
+  expect(result).toEqual({
+    redirect: {
+      destination: `/login?returnUrl=${encodeURIComponent('/foo/1')}`,
+      basePath: false,
+      permanent: false,
+    },
+  })
+})

--- a/packages/ui-flow/src/auth-guard/index.ts
+++ b/packages/ui-flow/src/auth-guard/index.ts
@@ -11,6 +11,11 @@ interface UserResponse {
 type AuthGuardOptions = {
   authType?: string
   allowNonMembers?: boolean
+  resolveReturnUrl?: (
+    ctx: GetServerSidePropsContext & {
+      customContext?: { [key: string]: unknown }
+    },
+  ) => string
 }
 
 const NON_MEMBER_REGEX = /^_PH/
@@ -36,7 +41,9 @@ export function authGuard<Props>(
       resolvedUrl,
     } = ctx
 
-    const returnUrl = `${process.env.NEXT_PUBLIC_BASE_PATH || ''}${resolvedUrl}`
+    const returnUrl = options?.resolveReturnUrl
+      ? options.resolveReturnUrl(ctx)
+      : `${process.env.NEXT_PUBLIC_BASE_PATH || ''}${resolvedUrl}`
 
     if (userAgentString && !!parseApp(userAgentString)) {
       return gssp(ctx)


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

file 기반 라우팅을 사용하지 않고 rewrites를 이용해 라우팅을 하면, `getServerSideProps`의 `resolvedUrl` 값이 제대로 만들어지지 않는 문제가 있었습니다. (next.js 버그 같기도 합니다..) 그래서 옵션에 `resolveReturnUrl` 함수를 노출하고 해당 함수가 returnUrl을 계산할 수 있도록 파라미터로 `getServerSideProps`의 파라미터를 전달합니다.

### 실패한 시도

`req.url`을 사용하려 했지만 접었습니다. 이 값은 가공되지 않은 값이기 때문에 CSR할 때 json을 요청하는 URL도 그대로 들어있습니다. 이를 해석하는 로직을 자체적으로 구현하는 건 코드를 파편화할 수 있다고 판단했습니다. `resolvedUrl`을 쓸 수 없는 상황이 일반적이지 않은 것이라고 가정하고, 이를 해결하기 위해 URL 생성을 완전히 개발자에게 위임하는 `resolveReturnUrl` 인터페이스를 제공합니다.

## 사용 및 테스트 방법

```ts
const getServerSideProps = authGuard(() => {}, {
  resolveReturnUrl: ({ query }) => {
    const { orderId } = strictQuery(query).string(orderId).use()

    return `/domestic-my-orders/${orderId}`
  },
})
```

## 이 PR의 유형

기능 추가