### PR TITLE
DetailHeader V2 리뷰 섹션의 로직을 수정합니다

### DIFF
--- a/packages/poi-detail/src/detail-header-v2/index.tsx
+++ b/packages/poi-detail/src/detail-header-v2/index.tsx
@@ -89,7 +89,7 @@ export default function DetailHeaderV2({
         <Text size="tiny" alpha={0.5}>
           {names.local || names.en}
         </Text>
-        {(reviewsCount > 0 || scrapsCount > 0) && (
+        {(reviewsRating || scrapsCount > 0) && (
           <Container margin={{ top: 14 }}>
             {scrapsCount > 0 && (
               <Text inline bold size="mini" alpha={1} margin={{ right: 10 }}>
@@ -97,7 +97,7 @@ export default function DetailHeaderV2({
                 {` ${formatNumber(scrapsCount)}`}
               </Text>
             )}
-            {(reviewsCount || reviewsRating) && (
+            {reviewsRating && (
               <Text inline bold size="mini" alpha={1}>
                 <Rating score={reviewsRating} />
                 {reviewsCount > 0 && `${formatNumber(reviewsCount)}`}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

- DetailHeader V2 리뷰 섹션의 로직을 수정합니다
- 트리플 리뷰가 존재 하지 않고, 야놀자 리뷰만 존재할 때 카운트를 보여주지 않지만, 
- 리뷰 보기(타사) 버튼에 대한 기능을 사용하는 케이스가 필요합니다.

야놀자 리뷰 연동 리뷰수 노출관련 PR - https://github.com/titicacadev/triple-hotels-web/pull/2321

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
