### PR TITLE
History Context에서 hash url 이동을 간소화합니다.

### DIFF
--- a/packages/react-contexts/src/history-context/history-context.tsx
+++ b/packages/react-contexts/src/history-context/history-context.tsx
@@ -202,8 +202,6 @@ export function HistoryProvider({
 
       if (useRouter) {
         window.location.replace(`#${hash}`)
-      } else {
-        return new Promise((resolve) => resolve(true))
       }
     },
     [isAndroid],
@@ -220,8 +218,6 @@ export function HistoryProvider({
 
       if (useRouter) {
         window.location.hash = hash
-      } else {
-        return new Promise((resolve) => resolve(true))
       }
     },
     [isAndroid],


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

History Context에서 URL의 hash 값을 바꿀 때 최대한 간단한 API를 사용합니다. push할 때는 `window.location.hash`를 사용하고, replace할 때는 `window.location.replace()`를 사용합니다.

## 왜 이 변경이 필요한가요?

해시를 넣을 때 `generateUrl` 함수를 사용하여 URL을 만든 다음 라우팅하는 코드 때문에 url이 바뀌어서 Next.js의 `hashChangeComplete` 이벤트가 발생하지 않는 [문제](https://titicaca.slack.com/archives/CMPS2LZK5/p1623829162117800?thread_ts=1623826626.112300&cid=CMPS2LZK5)가 있었습니다.
해시만 바꾸는 방법으로 다른 URL의 변경을 최소화하면 문제를 해결할 수 있지 않을까 하는 희망을 품었습니다.

## 이 PR의 유형

사소한 수정