### PR TITLE
[triple-document] Custom element 사용 시 warning을 제거합니다.

### DIFF
--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -77,14 +77,17 @@ export function TripleDocument({
                 optimized={optimized}
               >
                 {children.map(({ type, value }, i) => {
-                  const Element = { ...ELEMENTS, ...customElements }[type]
+                  const RegularElement = ELEMENTS[type]
+                  const CustomElement = customElements[type]
+
+                  const Element = CustomElement || RegularElement
 
                   return (
                     Element && (
                       <Element
                         key={i}
                         value={value}
-                        {...(customElements
+                        {...(CustomElement
                           ? {
                               onResourceClick: resourceClickHandler,
                               onImageClick,


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`TripleDocument` 컴포넌트에 Custom element를 전달하는 경우 발생하는 warning을 제거합니다.

## 변경 내역 및 배경

기존의 warning은 #1318 을 통해 제거되었으나, custom element가 추가되었을 경우 #1318 이전과 같이 모든 Event handler가 element에 공급되고 있었습니다. Custom element 호환성을 위해 해주었던 처리인데, custom element에만 handler props가 공급되도록 수정해봅니다.

## 사용 및 테스트 방법

Canary

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
