### PR TITLE
[RFC][react-contexts] trackSimpleEvent 퇴장을 준비합니다.

### DIFF
--- a/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
@@ -149,31 +149,13 @@ export class EventTrackingProvider extends React.PureComponent<
     label,
     ...rest
   }) => {
-    const {
-      props: { pageLabel, onError },
-    } = this
-
-    try {
-      if (window.ga) {
-        window.ga('send', 'event', pageLabel, action, label)
-      }
-
-      if (hasAccessibleTripleNativeClients()) {
-        nativeTrackEvent({
-          ga: [pageLabel, action, label].filter((v) => v),
-          fa: {
-            category: pageLabel,
-            event_name: DEFAULT_EVENT_NAME,
-            action: action as string,
-            ...rest,
-          },
-        })
-      }
-    } catch (error) {
-      if (onError) {
-        onError(error)
-      }
-    }
+    return this.trackEvent({
+      ga: [action, label],
+      fa: {
+        action: action as string,
+        ...rest,
+      },
+    })
   }
 
   render() {


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

`trackSimpleEvent`와 `trackEvent`의 동작을 맞추고, 퇴장을 준비합니다.

## 변경 내역 및 배경

하위 호환을 유지하면서 `trackSimpleEvent`의 특이한(?) 동작을 없애나가려 합니다. `trackSimpleEvent` 호출 시, Parameter를 `trackEvent`에 맞게 변조하여 `trackEvent`를 호출합니다.

`trackEvent`의 Alias처럼 사용되도록 하고, 이전을 쉽게 하기 위함입니다.

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
