### PR TITLE
릴리즈된 버전을 PR 댓글로 추가

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -43,13 +43,6 @@ jobs:
           PR_SHA=$(cat ./pr.json | jq -r '.head.sha')
           PR_REF=$(cat ./pr.json | jq -r '.head.ref')
 
-          echo "PR_NUMBER=${{ github.event.issue.number }}"
-          echo "PR_SHA=$PR_SHA"
-          echo "PR_REF=$PR_REF"
-          echo "SLACK_GITHUB_REF=$PR_REF"
-          echo "PR_SHORT_SHA=${PR_SHA:0:7}"
-          echo "PR_TITLE=$(cat ./pr.json | jq -r '.title')"
-
           echo "PR_NUMBER=${{ github.event.issue.number }}" >> $GITHUB_ENV
           echo "PR_SHA=$PR_SHA" >> $GITHUB_ENV
           echo "PR_REF=$PR_REF" >> $GITHUB_ENV
@@ -132,8 +125,6 @@ jobs:
           REF_COUNT=$(node -p -e "Math.max(0, parseInt((\"$(git describe --always --long --dirty --match "v*.*.*")\".match(/^(?:.*@)?.*-(\d+)-.*?$/) || ['0', '0'])[1], 10) - 1)")
 
           echo "CANARY_VERSION=$NEXT_VERSION-pr-${{ env.PR_NUMBER }}.$REF_COUNT" >> GITHUB_ENV
-
-          echo ${{ env.CANARY_VERSION }}
 
       - name: Notify canary publish start to slack
         env:


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

canary workflow에 canary release 이후 릴리즈된 버전을 Pull Request에 댓글로 작성하는 단계를 추가합니다.

## 배경

canary workflow가 PR에 링크가 붙지 않고, 배포 이후 PR에는 어떤 흔적도 남기지 않아서 설치할 버전을 찾으려면 매번 actions 탭을 들어가서 해당하는 canary workflow를 찾아야했습니다.

PR에서 바로 릴리즈된 버전을 찾고 싶었습니다.

## 변경 내역

- `CANARY_RELEASE` 환경 변수를 PR 댓글로 작성합니다.
- 전역 환경 변수의 위치를 최상위 단계로 옮깁니다.
- Node.js의 버전과 npm registry를 환경 변수로 관리합니다.
- "release-canary"를 태깅하는 과정을 슬랙 알림 단계와 분리합니다.
- workflow에 기록하던 값을 참고할 일이 적으므로 제거합니다.

## 논의할 점

### canary workflow를 PR에 연결하기

서비스 레포들처럼 PR에서 canary workflow가 도는 것을 볼 수 있으면 좋겠습니다. PR 댓글로 git 태깅 작업을 하고 새로운 git 태그에 canary workflow가 돌도록 변경하면 가능해집니다.

### npm dist-tag를 사용하기

npm에 publish할 때 dist-tag를 지정하면 아예 버전을 알아낼 필요가 없어집니다. 예를 들어 `pr-1462`를 dist-tag로 설정하면, `@titicaca/action-sheet@pr-1462`를 설치하여 가장 최근에 배포한 canary 버전을 사용할 수 있습니다.

[참고: tag가 숫자로 시작하거나, v로 시작하면 버전과 충돌이 생길 수 있습니다.](https://docs.npmjs.com/cli/v7/commands/npm-dist-tag#caveats)

