### PR TITLE
[triple-document] 아티클 추천코스에 조건 별 Poi 행정구역명 표기 추가

### DIFF
--- a/packages/triple-document/src/elements/itinerary/use-computed-itineraries.ts
+++ b/packages/triple-document/src/elements/itinerary/use-computed-itineraries.ts
@@ -71,7 +71,9 @@ export default function useItinerary({ itinerary }: Props) {
         .join(',')
 
       const areaNames =
-        regionId && areas.length > 0 ? areas.map((area) => area.name) : vicinity
+        regionId && areas.length > 0
+          ? areas.map((area) => area.name).join(',')
+          : vicinity
 
       const description = [categoryNames, areaNames]
         .filter((i) => i)


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
아티클 내 추천코스의 poi에 행정구역명 표기 추가합니다.

1.리전없는 poi : 시도 시군구
2.리전있는 poi + 거점지역 있음 : 거점지역
3.리전있는 poi + 거점지역 없음 : 시도 시군구

관련 JIRA : https://titicaca.atlassian.net/jira/software/projects/ENGDIVA/boards/57?assignee=6098828b20ad1b0070a95196&selectedIssue=ENGDIVA-497
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
