### PR TITLE
[booking-completion] 리전을 가지고 도시메인으로 넘길때 useAppCallback으로 감싸줍니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31351,6 +31351,7 @@
         "@titicaca/ui-flow": "^2.29.1"
       },
       "peerDependencies": {
+        "@titicaca/modals": "*",
         "@titicaca/react-contexts": "*"
       }
     },

--- a/packages/booking-completion/package.json
+++ b/packages/booking-completion/package.json
@@ -20,6 +20,7 @@
     "@titicaca/ui-flow": "^2.29.1"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "@titicaca/modals": "*"
   }
 }

--- a/packages/booking-completion/src/index.tsx
+++ b/packages/booking-completion/src/index.tsx
@@ -4,6 +4,7 @@ import { useHistoryFunctions } from '@titicaca/react-contexts'
 import styled from 'styled-components'
 import { TranslatedProperty } from '@titicaca/type-definitions'
 import { useAppCallback } from '@titicaca/ui-flow'
+import { TransitionType } from '@titicaca/modals'
 
 interface Region {
   id: string
@@ -55,11 +56,9 @@ function BookingCompletion({
   region,
 }: BookingCompletionProps) {
   const { navigate } = useHistoryFunctions()
-  const defaultModalType = 'general'
-  const TransitionType = defaultModalType as any
 
   const handleMoveToRegion = useAppCallback(
-    TransitionType,
+    TransitionType.General,
     useCallback(() => {
       onMoveToRegion()
       navigate(`/regions/${region?.id}`)

--- a/packages/booking-completion/tsconfig.build.json
+++ b/packages/booking-completion/tsconfig.build.json
@@ -13,6 +13,9 @@
     },
     {
       "path": "../react-contexts/tsconfig.build.json"
+    },
+    {
+      "path": "../modals/tsconfig.build.json"
     }
   ]
 }

--- a/packages/booking-completion/tsconfig.json
+++ b/packages/booking-completion/tsconfig.json
@@ -17,6 +17,9 @@
     },
     {
       "path": "../react-contexts"
+    },
+    {
+      "path": "../modals"
     }
   ]
 }


### PR DESCRIPTION

<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
close #1480 
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경
- booking-completion에 ui-flow 의존성 추가
- <del>booking-completion 컴포넌트가 deepLink도 받을수 있도록 추가</del>
- 도시메인으로 넘길때 useAppCallback감싸는 로직 추가 
<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법
canary
<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
