### PR TITLE
[RFC] viewItem을 EventTrackingProvider에서 기록합니다.

### DIFF
--- a/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
@@ -116,7 +116,8 @@ interface EventTrackingProviderProps {
     type: string
     name: string
     regionId?: string
-    [key: string]: string | undefined
+    zoneId?: string
+    referrer?: string
   }
   onError?: (error: Error) => void
 }
@@ -272,17 +273,18 @@ export function EventTrackingProvider({
 
   useEffect(() => {
     if (item?.id) {
-      const { type, id, name, regionId, ...itemAttributes } = item
+      const { type, id, name, regionId, zoneId, referrer } = item
 
       nativeViewItem({
         contentType: type,
         itemId: id,
         itemName: name,
         regionId,
-        ...itemAttributes,
+        zoneId,
+        referrer,
       })
     }
-  }, [item?.type, item?.id, item?.name, item?.regionId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [item?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return <Context.Provider value={value}>{children}</Context.Provider>
 }


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

#1504 에서 `trackScreen`을 `EventTrackingProvider` 가 호출하도록 했는데, `viewItem`도 `trackScreen`과 비슷한 타이밍에 기록하는 양상이 있어서 `viewItem`에도 유사한 처리를 해주었습니다.

## 변경 내역 및 배경

`viewItem`이 사용자 전환 측정에 쓰이는 주요 이벤트인데, 로직에 잘 드러나지 않고 있었습니다. 이런 변화가 트래킹에 도움이 될 수 있을 것 같습니다.

## 사용 및 테스트 방법

Canary

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
