### PR TITLE
docs에서 사용하는 google api key 변경

### DIFF
--- a/docs/decorators/index.tsx
+++ b/docs/decorators/index.tsx
@@ -17,7 +17,7 @@ export function historyProviderDecorator(storyFn: StoryFn<JSX.Element>) {
       facebookAppId=""
       defaultPageTitle=""
       defaultPageDescription=""
-      googleMapsApiKey="AIzaSyBaOSog5Kc4PkNw1JiSIcvz8WHt1Y78lNU"
+      googleMapsApiKey="AIzaSyDuSWU_yBwuQzeyRFcTqhyifqNX_8oaXI4"
     >
       <HistoryProvider
         isPublic={false}
@@ -39,7 +39,7 @@ export function sessionContextProviderDecorator(storyFn: StoryFn<JSX.Element>) {
       facebookAppId=""
       defaultPageTitle=""
       defaultPageDescription=""
-      googleMapsApiKey="AIzaSyBaOSog5Kc4PkNw1JiSIcvz8WHt1Y78lNU"
+      googleMapsApiKey="AIzaSyDuSWU_yBwuQzeyRFcTqhyifqNX_8oaXI4"
     >
       <SessionContextProvider
         sessionId={

--- a/docs/stories/map/map.stories.tsx
+++ b/docs/stories/map/map.stories.tsx
@@ -26,7 +26,7 @@ import {
  *
  * https://console.cloud.google.com/apis/credentials/key/e2f05131-1fe0-48d7-a231-f5f05336a007?folder=&organizationId=&project=titicaca-ci
  */
-const GOOGLE_MAPS_API_KEY = 'AIzaSyBaOSog5Kc4PkNw1JiSIcvz8WHt1Y78lNU'
+const GOOGLE_MAPS_API_KEY = 'AIzaSyDuSWU_yBwuQzeyRFcTqhyifqNX_8oaXI4'
 
 export default {
   title: 'Map / Map',


### PR DESCRIPTION
docs에서 사용하는 google api key를 변경합니다.

## 설명

titicaca-ci 프로젝트에 있는 API key를 soto-dev 프로젝트의 API key로 변경합니다.
localhost와 triple-corp.com으로 레퍼러 제한이 걸려있었는데, 레퍼러 제한을 풀고 Maps JavaScript API 사용으로만 제한하는 것으로 했습니다.

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [x] docs의 스토리를 변경했습니다.
