### PR TITLE
✨ session-context logout 함수에서 logout API 호출

### DIFF
--- a/packages/react-contexts/src/session-context/session-context.tsx
+++ b/packages/react-contexts/src/session-context/session-context.tsx
@@ -86,9 +86,10 @@ export function SessionContextProvider({
 
   const logout = useCallback(async () => {
     unsetSessionID()
-    window.location.href = '/'
     setUser(null)
     await put('/api/users/logout')
+
+    window.location.href = '/'
   }, [])
 
   const value = useMemo(


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

footer에서 호출하는 session-context의 `logout` 함수에 로그아웃 API 요청을 추가합니다.

## 사용 및 테스트 방법

canary

titicacadev/triple-auth-web#69

## 이 PR의 유형

기능 추가