### PR TITLE
[modals] 웹에서 모달 버튼이 1개 이상일때 깨지는 현상을 수정합니다

### DIFF
--- a/packages/modals/src/modal-base.tsx
+++ b/packages/modals/src/modal-base.tsx
@@ -42,9 +42,8 @@ const Actions = styled.div<{ children?: any }>`
   a {
     ${({ children }) => {
       const childrenCount = React.Children.count(children)
-      // 모달의 width를 기준 -1을 기준로 해당 작업을 진행합니다.
-      const width = 294 / childrenCount - (childrenCount - 1) / childrenCount
-
+      // Modal Box 의 width - 내부 Children 개수 - 1 / Children 개수
+      const width = (295 - childrenCount - 1) / childrenCount
       return css`
         width: ${width}px;
       `


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

- [modals] 웹에서 모달 버튼이 1개 이상일때 깨지는 현상을 수정합니다.

### 원인
- modal 내부의 actions 의 영역에서 `a` 태그의 css가 `width: calc((100% - ${childrenCount -1}px)/ 2)` 와 같은 로직을 취하고 있는데 
해당 로직이 width 비율을  보장하지 못합니다. 해당 버튼의 border-left로 인해 width 의 범위를 넘어서는 현상이 발생해 디자인이 꺠지는 현사이 있었습니다.

  
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
![image](https://user-images.githubusercontent.com/35159082/130969413-58a8f16f-c5b8-4708-80ae-39eef1028b6f.png)

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
