### PR TITLE
[poi-detail] RecommendedArticles가 zoneId를 받을 수 있도록 합니다

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36232,13 +36232,28 @@
         "@titicaca/modals": "^2.38.1",
         "@titicaca/type-definitions": "^2.38.1",
         "@titicaca/view-utilities": "^2.38.1",
-        "isomorphic-fetch": "^2.2.1"
+        "isomorphic-fetch": "^2.2.1",
+        "qs": "^6.10.1"
       },
       "devDependencies": {
         "@types/isomorphic-fetch": "^0.0.35"
       },
       "peerDependencies": {
         "@titicaca/react-contexts": "*"
+      }
+    },
+    "packages/poi-detail/node_modules/qs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "packages/poi-list-elements": {
@@ -45345,7 +45360,18 @@
         "@titicaca/type-definitions": "^2.38.1",
         "@titicaca/view-utilities": "^2.38.1",
         "@types/isomorphic-fetch": "^0.0.35",
-        "isomorphic-fetch": "^2.2.1"
+        "isomorphic-fetch": "^2.2.1",
+        "qs": "^6.10.1"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        }
       }
     },
     "@titicaca/poi-list-elements": {

--- a/packages/poi-detail/package.json
+++ b/packages/poi-detail/package.json
@@ -24,7 +24,8 @@
     "@titicaca/modals": "^2.38.1",
     "@titicaca/type-definitions": "^2.38.1",
     "@titicaca/view-utilities": "^2.38.1",
-    "isomorphic-fetch": "^2.2.1"
+    "isomorphic-fetch": "^2.2.1",
+    "qs": "^6.10.1"
   },
   "devDependencies": {
     "@types/isomorphic-fetch": "^0.0.35"

--- a/packages/poi-detail/src/recommended-articles/api-client.ts
+++ b/packages/poi-detail/src/recommended-articles/api-client.ts
@@ -1,15 +1,26 @@
 import fetch from 'isomorphic-fetch'
 import { ImageMeta } from '@titicaca/type-definitions'
+import qs from 'qs'
 
 import { ArticleListingData } from './types'
 
 export async function fetchRecommendedArticles({
   regionId,
+  zoneId,
 }: {
-  regionId: string
+  regionId?: string
+  zoneId?: string
 }): Promise<ArticleListingData[]> {
   const response = await fetch(
-    `/api/content/articles?regionId=${regionId}&sortBy=scrap`,
+    `/api/content/articles?${qs.stringify({
+      ...((regionId || zoneId) && {
+        geotags: [
+          ...(regionId ? [{ type: 'triple-region', id: regionId }] : []),
+          ...(zoneId ? [{ type: 'triple-zone', id: zoneId }] : []),
+        ],
+      }),
+      sortBy: 'scrap',
+    })}`,
   )
 
   if (!response.ok) {

--- a/packages/poi-detail/src/recommended-articles/recommended-articles.tsx
+++ b/packages/poi-detail/src/recommended-articles/recommended-articles.tsx
@@ -16,10 +16,12 @@ import MoreButton from './more-button'
 
 export default function RecommendedArticles({
   regionId,
+  zoneId,
   onArticleClick,
   appInstallationCta,
 }: {
-  regionId: string
+  regionId?: string
+  zoneId?: string
   onArticleClick: (
     e: React.SyntheticEvent,
     clickedArticle: ArticleListingData,
@@ -43,7 +45,9 @@ export default function RecommendedArticles({
 
   useEffect(() => {
     async function fetchAndSetRecommendedArticles() {
-      setRecommendedArticles(await fetchRecommendedArticles({ regionId }))
+      setRecommendedArticles(
+        await fetchRecommendedArticles({ regionId, zoneId }),
+      )
     }
     async function fetchAndSetArticleCardCTA() {
       const items = await fetchInventoryItems({
@@ -58,7 +62,13 @@ export default function RecommendedArticles({
     if (appInstallationCta?.inventoryId) {
       fetchAndSetArticleCardCTA()
     }
-  }, [appInstallationCta, regionId, setRecommendedArticles, setArticleCardCTA])
+  }, [
+    appInstallationCta,
+    regionId,
+    zoneId,
+    setRecommendedArticles,
+    setArticleCardCTA,
+  ])
 
   const handleIntersect = useCallback(
     (intersectingArticle: ArticleListingData) => {


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

regionId 없이 zoneId만 주어져도 추천 아티클을 보여주도록 합니다.

## 변경 내역 및 배경

리전에 속하지 않은 공유일정/POI 상세 페이지 등에서 추천 아티클을 보여주고자 합니다.

## 사용 및 테스트 방법

적용 예시: https://github.com/titicacadev/triple-content-web/pull/775

## 이 PR의 유형

- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)

