### PR TITLE
[poi-detail] 추천 아티클 '더 알아보기' 영역에 onClick을 추가합니다

### DIFF
--- a/packages/poi-detail/src/recommended-articles/recommended-articles.tsx
+++ b/packages/poi-detail/src/recommended-articles/recommended-articles.tsx
@@ -18,6 +18,7 @@ export default function RecommendedArticles({
   regionId,
   zoneId,
   onArticleClick,
+  onMoreClick,
   appInstallationCta,
 }: {
   regionId?: string
@@ -26,6 +27,7 @@ export default function RecommendedArticles({
     e: React.SyntheticEvent,
     clickedArticle: ArticleListingData,
   ) => void
+  onMoreClick?: () => void
   appInstallationCta?: {
     href: string
     inventoryId: string
@@ -80,8 +82,8 @@ export default function RecommendedArticles({
   )
 
   const handleShowMoreClick = useCallback(() => {
-    show(TransitionType.Article)
-  }, [show])
+    onMoreClick ? onMoreClick() : show(TransitionType.Article)
+  }, [onMoreClick, show])
 
   if (!recommendedArticles || recommendedArticles.length === 0) {
     return null


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

- '더 알아보기' 영역에 커스텀 가능한 onClick을 props로 추가합니다
- 공유 일정 페이지 내에서 TransitionModal action에 제한이 걸리는 이슈가 발생
  => 각 컴포넌트별로 deeplink가 달라져 커스텀 가능한 onClick 추가
  
<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법


<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<img width="615" alt="스크린샷 2021-09-29 오후 6 09 54" src="https://user-images.githubusercontent.com/43316372/135238994-005c1379-b8d5-450a-83fd-268dfb051996.png">
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
