### PR TITLE
쿠폰 다운로드 버튼에서 사용하는 API 요청에 새로운 fetcher 인터페이스 사용

### DIFF
--- a/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
+++ b/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
@@ -6,7 +6,7 @@ import {
   useUserVerification,
   VerificationType,
 } from '@titicaca/user-verification'
-import { authGuardedFetchers, captureHttpError, post } from '@titicaca/fetcher'
+import { authGuardedFetchers, captureHttpError } from '@titicaca/fetcher'
 
 import { CouponData } from '../../types'
 
@@ -204,7 +204,7 @@ export function InAppCouponGroupDownloadButton({
       return
     }
 
-    const { result: results, ok } = await post<
+    const response = await authGuardedFetchers.post<
       {
         id: string
         success: boolean
@@ -216,6 +216,14 @@ export function InAppCouponGroupDownloadButton({
         ids: coupons.map(({ id }) => id),
       },
     })
+
+    if (response === 'NEED_LOGIN') {
+      return
+    }
+
+    captureHttpError(response)
+
+    const { result: results, ok } = response
 
     if (ok && results) {
       const succeedCoupons = results.filter(({ success }) => success)


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

한장 쿠폰 조회와 다운로드, 여러장 쿠폰 조회와 다운로드 API 요청할 때 새로운 fetcher 인터페이스를 사용하고, 인증 외의 에러를 `captureHttpError`로 기록합니다.

[쿠폰 다운로드할 때 발생하는 401 에러](https://sentry.io/organizations/titicaca-corp/issues/2702543233/?project=1423752)를 제거합니다.
## 변경 내역 및 배경

- 쿠폰 다운로드 버튼에서 API 요청할 때 새로운 fetcher인터페이스 사용
- 인증 외 에러는 `captureHttpError` 함수로 기록
- 여러장 쿠폰 버튼에서 enabled state를 없애고 coupons에서 유도


오류를 최소화할 수 있도록 모든 조건은 그대로 두고 인터페이스 변경과 오류 기록 단계만 추가했습니다.
## 사용 및 테스트 방법

canary

## 이 PR의 유형

기능 개선