### PR TITLE
👷 tag-with-comment 워크플로 추가

### DIFF
--- a/.github/workflows/tag-with-comment.yaml
+++ b/.github/workflows/tag-with-comment.yaml
@@ -1,0 +1,131 @@
+name: tag-with-comment
+
+on:
+  issue_comment:
+    types:
+      - 'created'
+
+env:
+  TAG_NAME: release-canary
+  GITHUB_API_URL_BASE: https://api.github.com/repos/${{ github.repository }}
+  # Node.js
+  NODE_VERSION: '16.x'
+  NPM_REGISTRY_URL: 'https://registry.npmjs.org'
+  # Slack Notifications
+  SLACK_WEBHOOK: ${{ secrets.GHA_NOTIFICATIONS_WEBHOOK_URL }}
+  SLACK_CHANNEL: '#triple-web-dev-notifications' # 메시지 보낼 채널
+  SLACK_USERNAME: 'Triple Frontend' # 메시지를 보내는 계정 이름
+  SLACK_ICON_EMOJI: ':triple_new:'
+  SLACK_DETAIL_URL: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+  SLACK_GITHUB_REPOSITORY: ${{ github.repository }}
+  SLACK_AUTHOR_NAME: ${{ github.event.sender.login }}
+  SLACK_AUTHOR_ICON: ${{ github.event.sender.avatar_url }}
+  SLACK_FOOTER: ${{ github.repository }}
+  SLACK_GITHUB_REF: ${{ github.event.ref }} # 메시지에 ref로 표시되는 값
+  SLACK_GITHUB_EVENT_NAME: ${{ github.event_name }} # 메시지에 Event로 표시되는 값
+
+jobs:
+  tag-with-comment:
+    if: github.event.issue.state == 'open' && github.event.issue.pull_request && endsWith(github.event.comment.body, 'release-canary')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: ${{ env.NPM_REGISTRY_URL }}
+
+      - name: Recognize head SHA of pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.READ_ONLY_NPM_TOKEN }}
+        run: |
+          npx @titicaca/gha-tools fetch-github-pr ${{ github.event.issue.number }}
+          PR_SHA=$(cat ./pr.json | jq -r '.head.sha')
+          PR_REF=$(cat ./pr.json | jq -r '.head.ref')
+          echo "PR_NUMBER=${{ github.event.issue.number }}" >> $GITHUB_ENV
+          echo "PR_SHA=$PR_SHA" >> $GITHUB_ENV
+          echo "PR_REF=$PR_REF" >> $GITHUB_ENV
+          echo "SLACK_GITHUB_REF=$PR_REF" >> $GITHUB_ENV
+          echo "PR_SHORT_SHA=${PR_SHA:0:7}" >> $GITHUB_ENV
+          echo "PR_TITLE=$(cat ./pr.json | jq -r '.title')" >> $GITHUB_ENV
+
+      - name: Leave reaction to comment
+        run: |
+          curl -v \
+            --url https://api.github.com/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.squirrel-girl-preview+json" \
+            -H "Content-Type: application/json" \
+            -f --request POST \
+            -d "{\"content\":\"+1\"}"
+
+      - name: Create tag object
+        id: create-tag-object
+        # https://docs.github.com/en/free-pro-team@latest/rest/reference/git#create-a-tag-object
+        run: |
+          curl --url $GITHUB_API_URL_BASE/git/tags \
+            -f \
+            --request POST \
+            -H 'Authorization: token ${{ secrets.TRIPLE_BOT_GITHUB_TOKEN }}' \
+            -H 'Content-Type: application/json' \
+            -d "{\"tag\":\"$TAG_NAME\",\"message\":\"released at \`${{ github.event.updated_at }}\`\",\"object\":\"${PR_SHA}\",\"type\":\"commit\"}" \
+          > tag.json
+          echo "::set-output name=tag-sha::$(node -p -e 'require(`./tag.json`).sha')"
+
+      - name: Check tag ref exist
+        id: check-tag-ref
+        # https://docs.github.com/en/free-pro-team@latest/rest/reference/git#get-a-reference
+        run: |
+          curl --url $GITHUB_API_URL_BASE/git/refs/tags/$TAG_NAME \
+            -sI \
+            -o /dev/null \
+            -w "%{http_code}" \
+            -H 'Authorization: token ${{ secrets.TRIPLE_BOT_GITHUB_TOKEN }}' \
+          > status
+          echo "::set-output name=status::$(cat status)"
+
+      - name: Create new tag ref
+        if: ${{ steps.check-tag-ref.outputs.status != '200' }}
+        env:
+          TAG_SHA: ${{ steps.create-tag-object.outputs.tag-sha }}
+        # https://docs.github.com/en/free-pro-team@latest/rest/reference/git#create-a-reference
+        run: |
+          curl --url $GITHUB_API_URL_BASE/git/refs \
+            -f \
+            --request POST \
+            -H 'Authorization: token ${{ secrets.TRIPLE_BOT_GITHUB_TOKEN }}' \
+            -H 'Content-Type: application/json' \
+            -d "{\"ref\":\"refs/tags/$TAG_NAME\",\"sha\":\"$TAG_SHA\"}"
+
+      - name: Update tag ref
+        if: ${{ steps.check-tag-ref.outputs.status == '200' }}
+        env:
+          TAG_SHA: ${{ steps.create-tag-object.outputs.tag-sha }}
+        # https://docs.github.com/en/free-pro-team@latest/rest/reference/git#update-a-reference
+        run: |
+          curl --url $GITHUB_API_URL_BASE/git/refs/tags/$TAG_NAME \
+            -f \
+            --request PATCH \
+            -H 'Authorization: token ${{ secrets.TRIPLE_BOT_GITHUB_TOKEN }}' \
+            -H 'Content-Type: application/json' \
+            -d "{\"force\":true,\"sha\":\"${TAG_SHA}\"}"
+
+      - name: Notify tagging success to Slack
+        if: success()
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.READ_ONLY_NPM_TOKEN }}
+          SLACK_COLOR: success
+          SLACK_TITLE: ':label: Release tagging SUCCESS'
+          SLACK_TOPIC: '${{ github.event.sender.login }} tagged ${{ env.PR_REF }} as ${{ env.TAG_NAME }}.'
+        run: npx @titicaca/gha-tools notify
+
+      - name: Notify tagging fail to Slack
+        if: failure()
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.READ_ONLY_NPM_TOKEN }}
+          SLACK_COLOR: fail
+          SLACK_TITLE: ':pleading: Release tagging FAILURE'
+          SLACK_TOPIC: 'Fail to tag ${{ env.PR_REF }} as ${{ env.TAG_NAME }}.'
+        run: npx @titicaca/gha-tools notify


### PR DESCRIPTION
## 설명

댓글로 release-canary 태그를 달 수 있게 해주는 워크플로를 추가합니다.

## 변경 내역 및 배경

ci/cd 워크플로를 최신화하고 있습니다. 이슈에 댓글을 다는 워크플로우는 기본 브랜치에 머지되어야 작동하기 때문에 이 워크플로우 먼저 반영하고 다른 작업을 이어나갈 계획입니다.

## 이 PR의 유형

개발 경험 개선