### PR TITLE
✨ 응답이 ok일 때 result에 할당

### DIFF
--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -70,11 +70,9 @@ export async function fetcher<T = any, E = HttpErrorResponse>(
   )
   const body = await readResponseBody(response)
 
-  if (response.status === 200) {
+  if (response.ok === true) {
     response.result = body as T | undefined
-  }
-
-  if (!response.ok) {
+  } else {
     response.error = new HttpError(
       new Error(typeof body !== 'string' ? JSON.stringify(body) : body),
       response,


### PR DESCRIPTION


<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

기존엔 200일 때만 할당하고 있었습니다.
하지만, 201 등의 정상적인 응답에도 body가 존재할 수 있습니다.
이러한 경우에 body를 사용할 수 있도록 ok일 때 result를 할당하도록 완화합니다.

## 이 PR의 유형

기능 추가