### PR TITLE
[core-elements] sticky-header의 zTier, zIndex 기본 값 수정

### DIFF
--- a/packages/core-elements/src/elements/sticky-header.tsx
+++ b/packages/core-elements/src/elements/sticky-header.tsx
@@ -6,12 +6,12 @@ import { layeringMixin, LayeringMixinProps } from '../mixins'
 const StyledHeader = styled.header<LayeringMixinProps>`
   position: sticky;
   top: 0;
-  ${layeringMixin(10)}
+  ${layeringMixin(0)}
 `
 
 export type StickyHeaderProps = React.PropsWithChildren<LayeringMixinProps>
 
-function StickyHeader({ children, zIndex, zTier }: StickyHeaderProps) {
+function StickyHeader({ children, zIndex = 3, zTier }: StickyHeaderProps) {
   return (
     <StyledHeader zIndex={zIndex} zTier={zTier}>
       {children}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

[core-elements] sticky-header의 zTier, zIndex 기본 값 수정

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

기존 PublicHeader의 z-index는 2 또는 3이었는데 zTier를 너무 높은 값으로 설정해서 레이아웃이 많이 깨지고 있습니다.
zTier 기본 값은 0으로 변경하고
PublicHeader 외의 다른 컴포넌트가 z-index: 2를 많이 사용 하고 있어서 zIndex 값은 3을 기본값으로 변경합니다.

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

- air
- content
- hotels
- tna
- trips

에서 문제가 없는지 확인해야 함


## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정

