### PR TITLE
태그 삭제 API를 GitHub Actions로 대체

### DIFF
--- a/.github/workflows/pr-closed.yaml
+++ b/.github/workflows/pr-closed.yaml
@@ -30,12 +30,10 @@ jobs:
           echo "::set-output name=status::$(cat status)"
 
       - name: Delete release tag of this pull request
-        if: ${{ steps.check-tag-ref.outputs.status == '200' }}
-        # https://docs.github.com/en/rest/reference/git#delete-a-reference
-        run: |
-          curl --url $GITHUB_API_URL_BASE/git/refs/tags/$TAG_NAME \
-            -X DELETE \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization token ${{ secrets.TRIPLE_BOT_GITHUB_TOKEN }}" \
-            -sI \
-            -o /dev/null \
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true
+          tag_name: ${{ env.TAG_NAME }}
+          repo: ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

REST API를 직접 호출하는 대신 https://github.com/dev-drprasad/delete-tag-and-release 를 사용합니다.
