### PR TITLE
docs의 자체 eslint 규칙을 root로 통합합니다.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,5 +5,11 @@
   },
   "globals": {
     "google": true
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.mdx"],
+      "extends": "plugin:mdx/recommended"
+    }
+  ]
 }

--- a/docs/.eslintrc
+++ b/docs/.eslintrc
@@ -1,9 +1,0 @@
-{
-  "extends": ["../.eslintrc"],
-  "overrides": [
-    {
-      "files": ["*.mdx"],
-      "extends": "plugin:mdx/recommended"
-    }
-  ]
-}


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

docs에서 mdx때문에 자체 eslint 규칙을 관리하고 있었습니다.
overrides 속성을 사용하면 mdx 파일에만 mdx 플러그인을 사용할 수 있기 때문에 docs만 별도의 eslint 규칙을 관리할 필요 없습니다.
root의 eslint 관리 파일로 합칩니다.

## 사용 및 테스트 방법

`npm run eslint:es`

## 이 PR의 유형

소스 코드 간소화