### PR TITLE
[docs] 댓글 컴포넌트의 스토리북에 control 기능을 추가합니다.

### DIFF
--- a/docs/stories/replies/replies.stories.tsx
+++ b/docs/stories/replies/replies.stories.tsx
@@ -1,19 +1,47 @@
 import React from 'react'
-import { action } from '@storybook/addon-actions'
-import Replies from '@titicaca/replies'
+import Replies, { ResourceType } from '@titicaca/replies'
+import { Story } from '@storybook/react'
 
 export default {
   title: 'Replies',
+  component: Replies,
+  argTypes: {
+    resourceId: {
+      type: 'string',
+      required: true,
+    },
+    resourceType: {
+      options: ['itinerary', 'review', 'article'],
+      control: {
+        type: 'select',
+        required: true,
+      },
+    },
+    registerPlaceholder: {
+      type: 'string',
+      required: false,
+    },
+    size: {
+      type: 'number',
+      required: false,
+      defaultValue: 10,
+    },
+  },
 }
 
-export function RepliesStory() {
-  return (
-    <Replies
-      resourceId="14a66dcf-b170-4edf-967b-b830d2362109"
-      resourceType="itinerary"
-      onClick={action('onClick 적용된 아이콘, 버튼 클릭')}
-    />
-  )
+const RepliesTemplate: Story<{
+  resourceId: string
+  resourceType: ResourceType
+  registerPlaceholder?: string
+  size?: number
+  onClick: () => void
+}> = (args) => <Replies {...args} />
+
+export const BaseReplies = RepliesTemplate.bind({})
+
+BaseReplies.args = {
+  resourceId: '14a66dcf-b170-4edf-967b-b830d2362109',
+  resourceType: 'itinerary',
 }
 
-RepliesStory.storyName = '기본 댓글'
+BaseReplies.storyName = '기본 댓글'

--- a/packages/replies/src/types.ts
+++ b/packages/replies/src/types.ts
@@ -1,4 +1,4 @@
-export type ResourceType = 'review' | 'itinerary'
+export type ResourceType = 'review' | 'itinerary' | 'article'
 
 export interface Reply {
   id: string


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명
`@storybook/controls`를 이용해 댓글 컴포넌트의 `props`를 설정할 수 있도록 합니다.

<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
![image](https://user-images.githubusercontent.com/38130934/139385136-ff9b5973-47aa-4535-af51-4e8760e245f6.png)

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [X] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
