### PR TITLE
[date-picker] range-picker test에서 query 함수로 getAllBy 사용

### DIFF
--- a/packages/date-picker/src/range-picker.test.tsx
+++ b/packages/date-picker/src/range-picker.test.tsx
@@ -9,9 +9,9 @@ jest.mock('./use-public-holidays', () => ({
 }))
 
 describe('RangePicker', () => {
-  it('should select today when enableSameDay is false', async () => {
+  it('should select today when enableSameDay is false', () => {
     const handleDatesChange = jest.fn()
-    const { findAllByRole } = render(
+    const { getAllByRole } = render(
       <RangePicker
         startDate={null}
         endDate={null}
@@ -20,7 +20,7 @@ describe('RangePicker', () => {
       />,
     )
 
-    const dateCells = await findAllByRole('gridcell')
+    const dateCells = getAllByRole('gridcell')
     const todayCell = dateCells.find((el) =>
       el.classList.contains('DayPicker-Day--today'),
     )
@@ -36,13 +36,13 @@ describe('RangePicker', () => {
     })
   })
 
-  it('should not select same day without enableSameDay', async () => {
+  it('should not select same day without enableSameDay', () => {
     let startDate = null
     const handleDatesChange = jest.fn(({ startDate: newStartDate }) => {
       startDate = newStartDate
     })
 
-    const { queryAllByRole, rerender } = render(
+    const { getAllByRole, rerender } = render(
       <RangePicker
         startDate={null}
         endDate={null}
@@ -51,7 +51,7 @@ describe('RangePicker', () => {
       />,
     )
 
-    const dateCells = queryAllByRole('gridcell')
+    const dateCells = getAllByRole('gridcell')
     const targetCell = dateCells[0]
     if (!targetCell) {
       throw new Error('Cannot find target cell')


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

https://github.com/titicacadev/triple-frontend/runs/4066551170?check_suite_focus=true

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

jest 26 -> 27 로 업데이트 했더니 테스트에서 타임아웃 에러가 발생합니다.
testing-library 쿼리를 사용하는 곳에서 `getAllBy` 으로 변경해서 타임아웃 발생하지 않도록 해봅니다.

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

CI 패스 

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정

