### PR TITLE
쿠폰 그룹 다운로드할 때 인증에 실패하면 인증 프로세스 시작

### DIFF
--- a/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
+++ b/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
@@ -213,6 +213,9 @@ async function downloadCoupons(coupons: CouponData[]) {
     if (results[0].errorCode === MAX_COUPONS_PER_USER_ERROR_CODE) {
       return { type: 'NO_DOWNLOADABLE_COUPONS' } as const
     }
+    if (results[0].errorCode === 'NO_CI_AUTHENTICATION') {
+      return { type: 'NEED_USER_VERIFICATION' } as const
+    }
   }
 
   return {
@@ -292,6 +295,9 @@ export function InAppCouponGroupDownloadButton({
             },
             NO_DOWNLOADABLE_COUPONS: () => {
               raiseDownloadedAlert()
+            },
+            NEED_USER_VERIFICATION: () => {
+              initiateVerification()
             },
             UNKNOWN_ERROR: ({ message }: { message?: string }) => {
               setErrorMessage(message)


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

쿠폰 그룹을 다운로드할 때 인증에 실패한 응답이 오면 인증 프로세스를 시작합니다.

## 변경 내역 및 배경

- 불필요한 조건 식 제거
- 쿠폰 다운로드 에러 코드 타이핑
- 인증 실패한 경우 대응 추가

## 이 PR의 유형

버그 수정