### PR TITLE
[triple-document] 쿠폰 다운로드 시도 시, API 호출 전 verification state 체크하는 부분을 제거합니다.

### DIFF
--- a/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
+++ b/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
@@ -82,14 +82,13 @@ export function CouponDownloadButton({
     undefined,
   )
   const { push } = useHistoryFunctions()
-  const { verificationState, initiateVerification } = useUserVerification({
+  const { initiateVerification } = useUserVerification({
     verificationType,
     forceVerification: false,
   })
   const { login } = useSessionContext()
   const [needLogin, setNeedLogin] = useState(false)
 
-  const isUnverifiedUser = verificationType && !verificationState.verified
   const buttonDisabled = couponFetched === false && needLogin === false
 
   useEffect(() => {
@@ -126,30 +125,26 @@ export function CouponDownloadButton({
       } else if (downloaded === true) {
         raiseDownloadedAlert()
       } else {
-        if (isUnverifiedUser === true) {
-          initiateVerification()
-        } else {
-          const response = await downloadCoupon(slugId)
+        const response = await downloadCoupon(slugId)
 
-          const responseHandlers = {
-            /* eslint-disable @typescript-eslint/naming-convention */
-            SUCCESS: () => {
-              push(`${slugId}.${HASH_COMPLETE_DOWNLOAD_COUPON}`)
-              setDownloaded(true)
-            },
-            NEED_LOGIN: () => {
-              login()
-            },
-            NEED_USER_VERIFICATION: () => initiateVerification(),
-            UNKNOWN_ERROR: ({ message }: { message?: string }) => {
-              setErrorMessage(message)
-              push(`${slugId}.${HASH_ERROR_COUPON}`)
-            },
-            /* eslint-enable @typescript-eslint/naming-convention */
-          }
-          const handleResponse = responseHandlers[response.type]
-          handleResponse(response)
+        const responseHandlers = {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          SUCCESS: () => {
+            push(`${slugId}.${HASH_COMPLETE_DOWNLOAD_COUPON}`)
+            setDownloaded(true)
+          },
+          NEED_LOGIN: () => {
+            login()
+          },
+          NEED_USER_VERIFICATION: () => initiateVerification(),
+          UNKNOWN_ERROR: ({ message }: { message?: string }) => {
+            setErrorMessage(message)
+            push(`${slugId}.${HASH_ERROR_COUPON}`)
+          },
+          /* eslint-enable @typescript-eslint/naming-convention */
         }
+        const handleResponse = responseHandlers[response.type]
+        handleResponse(response)
       }
     }
 
@@ -234,7 +229,7 @@ export function CouponGroupDownloadButton({
     undefined,
   )
   const { push } = useHistoryFunctions()
-  const { verificationState, initiateVerification } = useUserVerification({
+  const { initiateVerification } = useUserVerification({
     verificationType,
     forceVerification: false,
   })
@@ -243,7 +238,6 @@ export function CouponGroupDownloadButton({
 
   const downloaded =
     coupons.length === 0 || coupons.every(({ downloaded }) => downloaded)
-  const isUnverifiedUser = verificationType && !verificationState.verified
   const buttonDisabled = coupons.length === 0 && needLogin === false
 
   const raiseDownloadedAlert = () =>
@@ -279,38 +273,34 @@ export function CouponGroupDownloadButton({
       } else if (downloaded === true) {
         raiseDownloadedAlert()
       } else {
-        if (isUnverifiedUser === true) {
-          initiateVerification()
-        } else {
-          const response = await downloadCoupons(coupons)
+        const response = await downloadCoupons(coupons)
 
-          const responseHandlers = {
-            /* eslint-disable @typescript-eslint/naming-convention */
-            NEED_LOGIN: () => {
-              login()
-            },
-            EVERY_COUPONS_DOWNLOADED: () => {
-              push(`${groupId}.${HASH_COMPLETE_DOWNLOAD_COUPON_GROUP}`)
-            },
-            SOME_COUPONS_DOWNLOADED: () => {
-              push(`${groupId}.${HASH_COMPLETE_DOWNLOAD_PART_OF_COUPON_GROUP}`)
-            },
-            NO_DOWNLOADABLE_COUPONS: () => {
-              raiseDownloadedAlert()
-            },
-            NEED_USER_VERIFICATION: () => {
-              initiateVerification()
-            },
-            UNKNOWN_ERROR: ({ message }: { message?: string }) => {
-              setErrorMessage(message)
-              push(`${groupId}.${HASH_ERROR_COUPON}`)
-            },
-            /* eslint-enable @typescript-eslint/naming-convention */
-          }
-
-          const handleResponse = responseHandlers[response.type]
-          handleResponse(response)
+        const responseHandlers = {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          NEED_LOGIN: () => {
+            login()
+          },
+          EVERY_COUPONS_DOWNLOADED: () => {
+            push(`${groupId}.${HASH_COMPLETE_DOWNLOAD_COUPON_GROUP}`)
+          },
+          SOME_COUPONS_DOWNLOADED: () => {
+            push(`${groupId}.${HASH_COMPLETE_DOWNLOAD_PART_OF_COUPON_GROUP}`)
+          },
+          NO_DOWNLOADABLE_COUPONS: () => {
+            raiseDownloadedAlert()
+          },
+          NEED_USER_VERIFICATION: () => {
+            initiateVerification()
+          },
+          UNKNOWN_ERROR: ({ message }: { message?: string }) => {
+            setErrorMessage(message)
+            push(`${groupId}.${HASH_ERROR_COUPON}`)
+          },
+          /* eslint-enable @typescript-eslint/naming-convention */
         }
+
+        const handleResponse = responseHandlers[response.type]
+        handleResponse(response)
       }
     }
     onClick && onClick()


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

카카오톡 인앱브라우저가 `visibilitychange` 이벤트를 발생시키지 않는 것으로 보입니다. 이 이벤트에 의존하는 verification state 체크를 제거하고, 서버사이드의 에러 응답에 의존하도록 로직을 수정해봅니다.

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
