### PR TITLE
[search] Search 뷰를 렌더링한 직후 input element의 focus()를 호출할 수 있도록 합니다.

### DIFF
--- a/packages/search/src/index.tsx
+++ b/packages/search/src/index.tsx
@@ -124,7 +124,7 @@ export default function FullScreenSearchView({
   }, [inputRef])
 
   useLayoutEffect(() => {
-    focusedOnInput && setTimeout(() => handleInputFocus(), 300)
+    focusedOnInput && handleInputFocus()
   }, [handleInputFocus, focusedOnInput])
 
   const handleChange = useCallback(


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

곧 릴리즈할 ~5.10.0~ 5.11.0 클라이언트에 이 이벤트를 이용한 가상 키보드 제어 기능이 포함되었습니다. 이 PR의 구현은 클라이언트 기능 동작을 테스트해보기 위해 프로토타이핑하는 수준입니다. 리렌더링이 일어나면 의도치 않게 `focus()`를 호출하는 일이 생길 수 있습니다.

See: https://titicaca.slack.com/archives/CEEPB4TDY/p1637561647324600

## 변경 내역 및 배경

- `FullScreenSearchView`에 `focusedOnInput` 이라는 prop을 추가했습니다.
- `focusedOnInput`의 값이 `true`일 경우, 최초 입장 시 `useLayoutEffect()` 훅을 이용해 `input.focus()`를 호출합니다.

## 사용 및 테스트 방법

Canary

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [x] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
