### PR TITLE
Date-Picker 컴포넌트 내에 Date 컴포넌트를 커스텀할 수 있도록 기능 추가

### DIFF
--- a/docs/stories/date-picker/date-picker.stories.tsx
+++ b/docs/stories/date-picker/date-picker.stories.tsx
@@ -85,7 +85,7 @@ const initialHolidays = [
   .map((offset) => new Date(offset))
   .map((date) => formatDate(date))
 
-const initialRenderDays = {
+const initialRenderDayInfo = {
   [new Date().toISOString().split('T')[0]]: 'Hello',
 }
 
@@ -148,7 +148,7 @@ export function DayPickerStory() {
         .filter(checkValidDate)
         .map((date) => new Date(date))}
       numberOfMonths={number('표시할 개월 수', 3)}
-      renderDays={object('커스텀 day 컴포넌트', initialRenderDays, '\n')}
+      renderDayInfo={object('커스텀 day 컴포넌트', initialRenderDayInfo, '\n')}
     />
   )
 }

--- a/packages/date-picker/src/day-picker.tsx
+++ b/packages/date-picker/src/day-picker.tsx
@@ -18,7 +18,7 @@ const DateContainer = styled.div`
   position: relative;
 `
 
-const ContentContainer = styled.div`
+const DayInfoContainer = styled.div`
   position: absolute;
   top: 25px;
   width: 100%;
@@ -39,11 +39,11 @@ function DatePicker({
   publicHolidays: publicHolidaysFromProps,
   hideTodayLabel = false,
   canChangeMonth = false,
-  renderDays,
+  renderDayInfo,
 }: DislableDaysProps & {
   day: string | null
   onDateChange: (date: Date) => void
-  renderDays?: Record<string, React.ReactNode>
+  renderDayInfo?: Record<string, React.ReactNode>
   numberOfMonths?: number
   hideTodayLabel?: boolean
   height?: string
@@ -83,13 +83,13 @@ function DatePicker({
       return (
         <DateContainer>
           <div>{convertedDay}</div>
-          {renderDays?.[date] && (
-            <ContentContainer>{renderDays?.[date]}</ContentContainer>
+          {renderDayInfo?.[date] && (
+            <DayInfoContainer>{renderDayInfo?.[date]}</DayInfoContainer>
           )}
         </DateContainer>
       )
     },
-    [renderDays],
+    [renderDayInfo],
   )
 
   const handleDayClick = React.useCallback(


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경
- DatePicker에 renderDays Props를 추가
- storybook에서 해당 변경사항 볼 수 있도록 추가 

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<img width="516" alt="스크린샷 2021-11-24 오후 6 25 52" src="https://user-images.githubusercontent.com/3426196/143211006-26e174bf-434c-463d-9922-cfbaf64e657f.png">

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형
- [ ] 버그 또는 사소한 수정
- [V] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트
- [V] docs의 스토리를 변경했습니다.
