### PR TITLE
DatePicker 컴포넌트에서 노출 시작일과 노출 종료일을 설정 가능하도록 기능을 추가합니다.

### DIFF
--- a/docs/stories/date-picker/date-picker.stories.tsx
+++ b/docs/stories/date-picker/date-picker.stories.tsx
@@ -150,8 +150,8 @@ export function DayPickerStory() {
         .map((date) => new Date(date))}
       numberOfMonths={number('표시할 개월 수', 3)}
       renderDayInfo={object('커스텀 day 컴포넌트', initialRenderDayInfo, '\n')}
-      fromMonth={new Date(date('시작 노출일', new Date()))}
-      toMonth={new Date(date('마지막 노출일', new Date()))}
+      fromMonth={new Date(date('시작 노출일', new Date())).toDateString()}
+      toMonth={new Date(date('마지막 노출일', new Date())).toDateString()}
     />
   )
 }

--- a/packages/date-picker/src/day-picker.tsx
+++ b/packages/date-picker/src/day-picker.tsx
@@ -50,8 +50,8 @@ function DatePicker({
   hideTodayLabel?: boolean
   height?: string
   canChangeMonth?: boolean
-  fromMonth?: Date
-  toMonth?: Date
+  fromMonth?: string
+  toMonth?: string
   /**
    * @deprecated TF에서 공휴일을 Fetch하고 있습니다.
    */
@@ -71,6 +71,17 @@ function DatePicker({
     () => (day ? moment(day).toDate() : undefined),
     [day],
   )
+
+  const formattedFromMonth = React.useMemo(
+    () => (fromMonth ? moment(fromMonth).toDate() : undefined),
+    [fromMonth],
+  )
+
+  const formattedToMonth = React.useMemo(
+    () => (toMonth ? moment(toMonth).toDate() : undefined),
+    [toMonth],
+  )
+
   const modifiers: Partial<Modifiers> = React.useMemo(
     () => ({
       publicHolidays: publicHolidaysFromProps || publicHolidays,
@@ -124,8 +135,8 @@ function DatePicker({
         modifiers={modifiers}
         disabledDays={disabledDays}
         canChangeMonth={canChangeMonth}
-        fromMonth={fromMonth}
-        toMonth={toMonth}
+        fromMonth={formattedFromMonth}
+        toMonth={formattedToMonth}
         renderDay={renderDay}
       />
     </DayContainer>


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->
DatePicker 컴포넌트에서 노출 시작일과 노출 종료일을 설정 가능하도록 기능을 추가합니다.

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
- 파트너 센터에서 파트너가 등록이 불가능한 날짜를 접근하려고 할 때, 차단하는 용도로 사용합니다.
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷
<img width="751" alt="스크린샷 2021-11-29 오전 9 57 22" src="https://user-images.githubusercontent.com/3426196/143793830-3640e57c-04d2-4304-a983-b82a0da66bf1.png">
<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->
- [V] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [V] docs의 스토리를 변경했습니다.
