### PR TITLE
🐛 Response 객체에서 사용할 속성만 뽑아내도록 변경

### DIFF
--- a/packages/fetcher/src/fetcher.ts
+++ b/packages/fetcher/src/fetcher.ts
@@ -18,7 +18,7 @@ export async function fetcher<SuccessBody, FailureBody = unknown>(
 
   const response = await fetchFunction(...makeRequestParams(url, options))
   const body = await readResponseBody(response)
-  const restResponse = removeBodyRelatedProperties(response)
+  const restResponse = pickUsableProperties(response)
 
   if (response.ok === true) {
     return {
@@ -89,16 +89,6 @@ function readResponseBody(response: Response) {
   return response.text()
 }
 
-function removeBodyRelatedProperties({
-  clone,
-  body,
-  bodyUsed,
-  arrayBuffer,
-  blob,
-  formData,
-  json,
-  text,
-  ...restResponse
-}: Response) {
-  return restResponse
+function pickUsableProperties({ headers, ok, status, url }: Response) {
+  return { headers, ok, status, url }
 }

--- a/packages/fetcher/src/types.ts
+++ b/packages/fetcher/src/types.ts
@@ -47,8 +47,8 @@ export type SuccessOrFailureBody<SuccessBody, FailureBody> =
   | { ok: true; parsedBody: SuccessBody }
   | { ok: false; parsedBody: FailureBody }
 
-export type HttpResponse<SuccessBody, FailureBody = unknown> = Omit<
+export type HttpResponse<SuccessBody, FailureBody = unknown> = Pick<
   Response,
-  keyof Body | 'clone'
+  'headers' | 'ok' | 'status' | 'url'
 > &
   SuccessOrFailureBody<SuccessBody, FailureBody>


### PR DESCRIPTION
기존에는 rest destructuring을 사용하여 body 관련 속성만 제외했습니다.
하지만 Response가 객체가 아니라 클래스 인스턴스여서 status, url 등의 값이 복사되지 않는 문제가 있었습니다.

이를 해결하기 위해 사용하는 값만 명시적으로 참조합니다.

https://titicaca.slack.com/archives/CEEPB4TDY/p1639467493019900