### PR TITLE
[replies] 자식 컴포넌트의 이벤트를 막습니다.

### DIFF
--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -18,14 +18,14 @@ import ReplyList from './list'
 import Register from './register'
 import { checkUniqueReply } from './utils'
 
-// FIXME: 개발 완료 후 onClickCapture props를 제거합니다.
-// 제공되는 댓글의 일부 기능을 노출하지 않기 위해서 추가한 임시 핸들러 props이며,
-// 개발이 완료되면 없어질 props입니다.
 export default function Replies({
   resourceId,
   resourceType,
   registerPlaceholder,
   size,
+  // FIXME: 개발 완료 후 onClickCapture props를 제거합니다.
+  // 제공되는 댓글의 일부 기능을 노출하지 않기 위해서 추가한 임시 핸들러 props이며,
+  // 개발이 완료되면 없어질 props입니다.
   onClickCapture,
 }: {
   resourceId: string


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

수정이 필요하게 된 이유는 공유 일정 페이지에서 답글 달기 등 기능을 클릭하면 모달이 나옴과 동시에 해당 기능이 활성화가 되는 오류가 있습니다. 
해당 기능(답글 달기..)을 비활성화하고 모달을 띄우는 방향으로 수정이 필요한 상태입니다.

해당 기능을 막기 위해 `onClickCapture`를 사용합니다.

- [오류 확인 경로 (스테이징)](https://triple-staging.titicaca-corp.com/trips/lounge/itineraries/797d148d-4769-4bf1-8f36-839ef2801979)
- [수정 확인 경로 (데브)](https://triple-dev.titicaca-corp.com/trips/lounge/itineraries/bb3addcf-1390-4f42-8a44-d7fc32d4a084)

<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [ ] 버그 또는 사소한 수정
- [ ] 기능 추가 (하위 호환을 유지하면서 기능을 추가합니다.)
- [ ] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)

## 체크리스트

<!--- 각 항목을 읽어 보시고, 해당하는 항목에 [x]를 표시해주세요. -->
<!--- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->

- [ ] docs의 스토리를 변경했습니다.
