### PR TITLE
[triple-document] Text의 중복 줄바꿈을 제거하는 함수 추가

### DIFF
--- a/packages/triple-document/src/elements/text/fix-line-break.test.ts
+++ b/packages/triple-document/src/elements/text/fix-line-break.test.ts
@@ -1,0 +1,9 @@
+import { fixLineBreak } from './fix-line-break'
+
+it('removes duplicated line break', () => {
+  const rawHTML = 'line1<br>\nline2<br>\nline3'
+
+  const result = fixLineBreak(rawHTML)
+
+  expect(result).toBe('line1<br>line2<br>line3')
+})

--- a/packages/triple-document/src/elements/text/fix-line-break.ts
+++ b/packages/triple-document/src/elements/text/fix-line-break.ts
@@ -1,0 +1,7 @@
+export function fixLineBreak(rawHTML: any) {
+  if (typeof rawHTML === 'string') {
+    return rawHTML.replace(/<br>\n/g, '<br>')
+  }
+
+  return rawHTML
+}

--- a/packages/triple-document/src/elements/text/plain.tsx
+++ b/packages/triple-document/src/elements/text/plain.tsx
@@ -3,6 +3,8 @@ import { Text, Paragraph } from '@titicaca/core-elements'
 
 import { useLinkClickHandler } from '../../prop-context/link-click-handler'
 
+import { fixLineBreak } from './fix-line-break'
+
 export default function TextElement({
   value: { text, rawHTML },
   compact,
@@ -37,7 +39,7 @@ export default function TextElement({
       <Text.Html
         margin={compact ? { top: 4 } : { top: 10, left: 30, right: 30 }}
         alpha={0.9}
-        dangerouslySetInnerHTML={{ __html: rawHTML }}
+        dangerouslySetInnerHTML={{ __html: fixLineBreak(rawHTML) }}
         onClick={handleClick}
         {...props}
       />


### PR DESCRIPTION
<!--- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## 설명

<!--- 이 PR 내용에 대한 요약입니다. 최대 3줄을 넘지 않도록 해주세요. -->

[triple-document] Text의 중복 줄바꿈을 제거하는 함수 추가

## 변경 내역 및 배경

<!--- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!--- 그 문제와 관련 있는 이슈가 열려 있다면, 여기 링크를 붙여 주세요. -->

https://titicaca.slack.com/archives/C01CHRQBP1U/p1639967846231500

TripleDocument Text rawHTML의 값에 줄바꿈이 예상한 값보다 한 줄 더 중복되는 경우가 있습니다. 어드민 툴의 input 컴포넌트가 원인이지만 기존에 생성된 아티클, 기획전 등이 많아 기존 형태를 유지하기 위해 TripleDocument에서 중복 개행을 제거하는 로직을 추가합니다.

## 사용 및 테스트 방법

<!--- 이 기능(혹은 수정)을 어떻게 사용하거나 테스트할 수 있는지 적어주세요. -->
<!--- 컴포넌트 및 함수의 호출 예제, 테스팅 환경과 다른 영역에 미치는 영향 등을 설명해주시면 좋습니다. -->

테스트 통과

## 스크린샷

<!--- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!--- 반드시 필요한 게 아니라면 생략 가능합니다. -->

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] 버그 또는 사소한 수정

