### PR TITLE
Text.Html/Text.WithRef 삭제

### DIFF
--- a/packages/core-elements/src/elements/text.tsx
+++ b/packages/core-elements/src/elements/text.tsx
@@ -105,12 +105,7 @@ function TextTitle({ css, children, margin }: TextTitleProps) {
 
 type CompoundedText = typeof Text & {
   Title: typeof TextTitle
-  /**
-   * @deprecated
-   */
-  WithRef: typeof Text
 }
 ;(Text as CompoundedText).Title = TextTitle
-;(Text as CompoundedText).WithRef = Text
 
 export default Text as CompoundedText


### PR DESCRIPTION
## 설명

core-elements 패키지에서 `Text.Html`/`Text.WithRef` 컴포넌트를 더이상 지원하지 않습니다.

`Text.Html` 컴포넌트를 사용하던 곳에서는 직접 `styled(Text)`를 만들어서 필요한 css를 선언하면 됩니다.
`Text.WithRef` 컴포넌트는 `Text` 컴포넌트와 동일합니다.

## 변경 내역 및 배경

[Text.Html 관련 슬랙 링크](https://titicaca.slack.com/archives/CEEPB4TDY/p1639991166110900)
[Text.Html deprecated 되었던 PR 링크](https://github.com/titicacadev/triple-frontend/pull/1739)

## 이 PR의 유형

<!--- 어떤 유형의 변경인가요? 해당하는 모든 유형에 체크해주세요. [x]로 체크할 수 있습니다: -->

- [x] Breaking change (관련 컴포넌트를 기존에 사용하던 곳들에 코드 수정이 필요합니다.)
