### PR TITLE
👷 CI에서 빌드와 테스트 순서 변경

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,11 +104,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Build
-        run: npm run build
-
       - name: Test
         run: npm run test:ci
+
+      - name: Build
+        run: npm run build
 
       - name: Notify build success to slack
         if: success()


### PR DESCRIPTION
빌드 없이 테스트를 수행할 수 있습니다. 오래 걸리는 빌드 이후에 테스트를 하는 것보다 더 빠르게 테스트 결과를 확인할 수 있습니다. 둘의 순서를 변경하여 빌드 단계에 의존성이 없다는 것을 표현하는 한 편, 테스트 결과를 더 빠르게 확인할 수 있게 만듭니다.