### PR TITLE
[react-contexts] viewItem의 파라미터 타입 수정

### DIFF
--- a/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
@@ -294,15 +294,12 @@ export function EventTrackingProvider({
 
   useEffect(() => {
     if (item?.id) {
-      const { type, id, name, regionId, zoneId, referrer } = item
+      const { type, id, name } = item
 
       nativeViewItem({
         contentType: type,
         itemId: id,
         itemName: name,
-        regionId,
-        zoneId,
-        referrer,
       })
     }
   }, [item?.id]) // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

[react-contexts] viewItem의 파라미터 타입 수정

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

react-contexts에서 사용하는 triple-web-to-native-interfaces 의 viewItem 함수의 파라미터 타입이 잘못되어 있습니다.
https://github.com/titicacadev/triple-web-to-native-interfaces/blob/master/src/index.ts#L98-L102

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
- [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? 

