### PR TITLE
fetcher request의 body의 타입을 unknown으로 완화

### DIFF
--- a/packages/fetcher/src/make-request-params.ts
+++ b/packages/fetcher/src/make-request-params.ts
@@ -33,7 +33,7 @@ export function makeRequestParams(
 
   const headers = {
     ...customHeaders,
-    ...(body && !useBodyAsRaw && { 'content-type': 'application/json' }),
+    ...(!!body && !useBodyAsRaw && { 'content-type': 'application/json' }),
     ...(sessionId && { 'x-soto-session': sessionId }),
     ...(cookie && { cookie }),
   }

--- a/packages/fetcher/src/types.ts
+++ b/packages/fetcher/src/types.ts
@@ -1,13 +1,5 @@
 import { IncomingMessage } from 'http'
 
-type JsonWithUndefined =
-  | string
-  | number
-  | boolean
-  | { [key: string]: JsonWithUndefined }
-  | JsonWithUndefined[]
-  | undefined
-
 export type RequestOptions = Omit<RequestInit, 'body'> & {
   /**
    * @deprecated req보다는 cookie, withApiUriBase 사용을 권장합니다!
@@ -18,11 +10,7 @@ export type RequestOptions = Omit<RequestInit, 'body'> & {
   /** don't stringfy body */
   useBodyAsRaw?: boolean
   retryable?: boolean
-
-  /**
-   * RequestInit.body의 타입 오버라이드
-   */
-  body?: BodyInit | JsonWithUndefined
+  body?: unknown
   /**
    * cookie를 인자로 받을 시 해당 cookie를 헤더에 삽입
    * 브라우저의 fetch는 쿠키를 보내거나 받지 않기 때문에 SSR시에만 유효합니다.


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

fetcher 함수를 호출할 때 `body`의 타입을 unknown으로 완화합니다.

Json 타입을 정의해서 사용하려 했지만 인덱스 시그니쳐가 없는 인터페이스를 할당할 수 없는 문제로 실패했습니다.
그냥 unknown으로 완화하여 모든 종류의 값을 넣을 수 있도록합니다.
