### PR TITLE
✅ use-user-verification 테스트 과정에서 발생하는 워닝 제거

### DIFF
--- a/packages/user-verification/src/use-user-verification.test.ts
+++ b/packages/user-verification/src/use-user-verification.test.ts
@@ -13,7 +13,7 @@ jest.mock('isomorphic-fetch', () => () => {
 jest.mock('./verified-message')
 
 describe('인증 시작함수를 호출하면 인증 페이지를 엽니다.', () => {
-  function prepareTest({
+  async function prepareTest({
     forceVerification = false,
     verificationType,
     verificationContext,
@@ -24,6 +24,7 @@ describe('인증 시작함수를 호출하면 인증 페이지를 엽니다.', (
       result: {
         current: { initiateVerification },
       },
+      waitForNextUpdate,
     } = renderHook(useUserVerification, {
       initialProps: {
         forceVerification,
@@ -31,6 +32,8 @@ describe('인증 시작함수를 호출하면 인증 페이지를 엽니다.', (
         verificationContext,
       },
     })
+
+    await waitForNextUpdate()
 
     initiateVerification()
 
@@ -45,8 +48,8 @@ describe('인증 시작함수를 호출하면 인증 페이지를 엽니다.', (
       ['personal-id-verification', '/verifications/personal-id-verification'],
     ] as const)(
       'VerificationType: %s, path: %s',
-      (verificationType: VerificationType | undefined, href: string) => {
-        const { routeExternally } = prepareTest({ verificationType })
+      async (verificationType: VerificationType | undefined, href: string) => {
+        const { routeExternally } = await prepareTest({ verificationType })
 
         expect(routeExternally).toBeCalledWith(
           expect.objectContaining({
@@ -64,8 +67,8 @@ describe('인증 시작함수를 호출하면 인증 페이지를 엽니다.', (
       ['cash', 'context=cash'],
     ] as const)(
       'verificationContext: %s, should contain: %s',
-      (verificationContext, containingQuery) => {
-        const { routeExternally } = prepareTest({ verificationContext })
+      async (verificationContext, containingQuery) => {
+        const { routeExternally } = await prepareTest({ verificationContext })
 
         expect(routeExternally).toBeCalledWith(
           expect.objectContaining({
@@ -76,16 +79,16 @@ describe('인증 시작함수를 호출하면 인증 페이지를 엽니다.', (
     )
   })
 
-  test('인증 페이지를 새 창으로 엽니다.', () => {
-    const { routeExternally } = prepareTest()
+  test('인증 페이지를 새 창으로 엽니다.', async () => {
+    const { routeExternally } = await prepareTest()
 
     expect(routeExternally).toBeCalledWith(
       expect.objectContaining({ target: 'new' }),
     )
   })
 
-  test('noNavbar 옵션을 사용합니다.', () => {
-    const { routeExternally } = prepareTest()
+  test('noNavbar 옵션을 사용합니다.', async () => {
+    const { routeExternally } = await prepareTest()
 
     expect(routeExternally).toBeCalledWith(
       expect.objectContaining({ noNavbar: true }),


### PR DESCRIPTION


<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

`useEffect`에서 state 변경를 변경하는 코드가 있어서 테스트 환경에서 워닝이 발생하고 있었습니다.
`@testing-library/react-hooks`에서 제공하는 `waitForNextUpdate` 함수를 이용해 워닝을 제거합니다.