### PR TITLE
`useNavigate` 훅으로 특정 URL을 라우팅하지 못하는 문제를 수정합니다.

### DIFF
--- a/packages/router/src/common/app-bridge.test.ts
+++ b/packages/router/src/common/app-bridge.test.ts
@@ -191,22 +191,6 @@ describe('openNativeLink', () => {
 
     expect(changeLocation).toBeCalledWith(`${MOCK_APP_SCHEME}://${href}`)
   })
-
-  describe('절대 경로를 넣으면 오류를 냅니다.', () => {
-    test.each([['https://www.google.com', 'triple.guide/hotels']])(
-      '%p',
-      (href: string) => {
-        const changeLocation = jest.fn()
-        const {
-          result: {
-            current: { openNativeLink },
-          },
-        } = renderHook(useAppBridge, { initialProps: { changeLocation } })
-
-        expect(() => openNativeLink(href)).toThrowError()
-      },
-    )
-  })
 })
 
 function mockUserAgentContext(isPublic = true) {

--- a/packages/router/src/common/app-bridge.ts
+++ b/packages/router/src/common/app-bridge.ts
@@ -54,10 +54,6 @@ export function useAppBridge({
       openNativeLink: (rawHref: string) => {
         const { scheme, host, ...rest } = parseUrl(rawHref)
 
-        if (!!scheme || !!host) {
-          throw new Error('네이티브 라우팅은 상대 경로만 가능합니다.')
-        }
-
         changeLocation(generateUrl({ scheme: appUrlScheme, ...rest }))
       },
     }),


### PR DESCRIPTION


<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

[`useNavigate`로 대체한 곳에서 URL을 라우팅하지 못하는 문제](https://sentry.io/organizations/titicaca-corp/issues/2924374234/?project=1319418)가 있었습니다.
기존에는 받았던 URL을 무조건 `location.href`에 할당했는데 새로운 코드에서 검증하는 로직이 추가되어 생기는 문제입니다.
검증 로직을 제거하여 기존과 같은 방식으로 작동하도록 수정합니다.