### PR TITLE
[view-utilities]Public Routelist에 여행 가능한 해외 도시 및 항공권 허브를 추가합니다.

### DIFF
--- a/packages/view-utilities/src/routelist/routelist.ts
+++ b/packages/view-utilities/src/routelist/routelist.ts
@@ -11,11 +11,13 @@ const PUBLIC_ROUTELIST_REGEXES = [
   /^\/hotels\/[^/]+\/rate(\/.+?)?$/,
   /^\/hotels\/[^/]+\/breakdown(\/.+?)?$/,
   /^(\/hotels)?\/regions\/[^/]+\/hotel-areas$/,
+  /^\/air\/$/,
   /^\/air\/curation(\/.+)?$/,
   /^\/tna\/curation(\/.+)?$/,
   /^\/tna\/regions\/[^/]+\/products\/[^/]+$/,
   /^\/tna\/products\/[^/]+$/,
   /^\/tna\/products\/[^/]+\/display$/,
+  /^\/content\/covid19-status\$/,
 ]
 
 export function checkIfRoutable({ href }: { href: string }) {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
Public Route List에 아래의 항목을 추가합니다.
- 여행 가능한 해외 도시 (/content/covid19-status)
- 항공권 검색 (/air)

### 추가를 하게된 이유

현재 진행중인[ `못 갔던 여행 보내드립니다!` 프로모션 페이지](https://triple.guide/articles/ee3e6795-1ed6-4c78-a2fd-e01a05817ddd)의 하단에 
`여행 가능 해외 도시 확인하기`, `안전한 해외여행 기획전 보기`, `해외 항공권 검색하기` 버튼이 존재합니다.
여기서 각 버튼을 클릭해보면, `안전한 해외여행 기획전 보기`를 제외한 나머지 버튼이 트리플 앱 설치 유도 모달을 노출하고 있습니다.

현재 [여행 가능한 해외 도시를 볼 수 있는 페이지](https://triple.guide/content/covid19-status) 및 [항공권 허브 페이지](https://triple.guide/air)가 존재하니, 모달을 노출하는 것이 아니라 해당 페이지의 이동이 맞다고 생각하여 추가하게 되었습니다.


<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->


## 스크린샷 & URL

영상 첨부합니다.

https://user-images.githubusercontent.com/38130934/149146749-e36a6ceb-d6ec-44bf-9ca4-47563256b2e4.mov
<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
