### PR TITLE
배너 CTA 오버레이 클릭시, 해당 배너가 닫히도록 합니다

### DIFF
--- a/packages/app-installation-cta/src/banner-cta.tsx
+++ b/packages/app-installation-cta/src/banner-cta.tsx
@@ -64,7 +64,7 @@ export default function BannerCTA({
       <Overlay
         zTier={zTier}
         zIndex={zIndex}
-        onClick={(e) => {
+        onClick={() => {
           setIsImageBannerOpen(false)
           onDismiss && onDismiss(inventoryItem)
         }}

--- a/packages/app-installation-cta/src/banner-cta.tsx
+++ b/packages/app-installation-cta/src/banner-cta.tsx
@@ -61,7 +61,14 @@ export default function BannerCTA({
 
   return inventoryItem ? (
     isImageBannerOpen && image ? (
-      <Overlay zTier={zTier} zIndex={zIndex}>
+      <Overlay
+        zTier={zTier}
+        zIndex={zIndex}
+        onClick={(e) => {
+          setIsImageBannerOpen(false)
+          onDismiss && onDismiss(inventoryItem)
+        }}
+      >
         <BottomFixedContainer>
           <ImageBanner
             imgUrl={image}

--- a/packages/app-installation-cta/src/image-banner.tsx
+++ b/packages/app-installation-cta/src/image-banner.tsx
@@ -38,13 +38,21 @@ export default function ImageBanner({
     onShow && onShow(inventoryItem)
   }, [onShow, inventoryItem])
 
-  const handleClick = useCallback(() => {
-    onClick && onClick(inventoryItem)
-  }, [onClick, inventoryItem])
+  const handleClick = useCallback(
+    (e?: React.SyntheticEvent) => {
+      e?.stopPropagation()
+      onClick && onClick(inventoryItem)
+    },
+    [onClick, inventoryItem],
+  )
 
-  const handleDismiss = useCallback(() => {
-    onDismiss && onDismiss(inventoryItem)
-  }, [onDismiss, inventoryItem])
+  const handleDismiss = useCallback(
+    (e?: React.SyntheticEvent) => {
+      e?.stopPropagation()
+      onDismiss && onDismiss(inventoryItem)
+    },
+    [onDismiss, inventoryItem],
+  )
 
   return (
     <ImageBannerWrapper>

--- a/packages/app-installation-cta/src/image-banner.tsx
+++ b/packages/app-installation-cta/src/image-banner.tsx
@@ -39,16 +39,16 @@ export default function ImageBanner({
   }, [onShow, inventoryItem])
 
   const handleClick = useCallback(
-    (e?: React.SyntheticEvent) => {
-      e?.stopPropagation()
+    (e: React.SyntheticEvent) => {
+      e.stopPropagation()
       onClick && onClick(inventoryItem)
     },
     [onClick, inventoryItem],
   )
 
   const handleDismiss = useCallback(
-    (e?: React.SyntheticEvent) => {
-      e?.stopPropagation()
+    (e) => {
+      e.stopPropagation()
       onDismiss && onDismiss(inventoryItem)
     },
     [onDismiss, inventoryItem],


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

- 배너 CTA 오버레이 클릭시, 해당 배너가 닫히도록 합니다.
  - 하위 컴포넌트에 이벤트 전파가 되지 않도록 `stopPropagation` 처리를 해주는 코드를 추가합니다.
 
- 관련 지라 : https://titicaca.atlassian.net/browse/HI-2013
 
### 변경내역
- 배너 CTA의 오버레이(백그라운드) 클릭시, 해당 배너가 닫히도록 유도합니다.
- 해당 이벤트의 버블링으로 인해 내부 컴포넌트 클릭시, 해당 배너가 닫히는것을 방지합니다.

