### PR TITLE
[react-contexts] user-agent-context의 isPublic과 app 속성에 deprecation notice를 추가합니다.

### DIFF
--- a/packages/react-contexts/src/user-agent-context/utils.ts
+++ b/packages/react-contexts/src/user-agent-context/utils.ts
@@ -34,9 +34,17 @@ export function parseApp(userAgent: string): App | null {
 }
 
 export interface UserAgentValue {
+  /**
+   * @deprecated react-triple-client-interfaces의 TripleClientMetadataContext
+   * 를 이용해주세요.
+   */
   isPublic: boolean
   isMobile: boolean
   os: Os
+  /**
+   * @deprecated react-triple-client-interfaces의 TripleClientMetadataContext
+   * 를 이용해주세요.
+   */
   app: App | null
 }
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

react-triple-client-interfaces 패키지가 담당할 트리플 클라이언트 정보 관리 역할을 user-agent-context에서 deprecate합니다.

Related: #1832 

## 변경 내역

user-agent-context가 사용하는 `UserAgentValue` 타입에서 `isPublic`과 `app`에 deprecation notice를 추가합니다.