### PR TITLE
[react-triple-client-interfaces] useTripleClientFeatureFlag 훅을 추가합니다.

### DIFF
--- a/packages/react-triple-client-interfaces/README.md
+++ b/packages/react-triple-client-interfaces/README.md
@@ -72,3 +72,25 @@ function YourComponent() {
   }
 }
 ```
+
+### `useTripleClientFeatureFlag`
+
+특정 기능이나 뷰를 트리플 클라이언트 버전에 따라 노출하거나 숨겨야 할 때
+이용할 수 있는 Hook 함수입니다.
+
+```jsx
+function YourComponent() {
+  const isFeatureVisible = useTripleClientFeatureFlag({
+    appName: 'Triple-iOS',
+    appVersion: '5.10.0',
+    operator: 'gt',
+    availableOnPublic: true,
+  })
+
+  if (isFeatureVisible) {
+    /* 기능을 지원하는 클라이언트 */
+  } else {
+    return null
+  }
+}
+```

--- a/packages/react-triple-client-interfaces/src/index.ts
+++ b/packages/react-triple-client-interfaces/src/index.ts
@@ -1,3 +1,4 @@
 export * from './triple-client-metadata-context'
 export * from './use-triple-client-actions'
 export * from './triple-client-user-agent'
+export * from './use-triple-client-feature-flag'

--- a/packages/react-triple-client-interfaces/src/use-triple-client-feature-flag.spec.tsx
+++ b/packages/react-triple-client-interfaces/src/use-triple-client-feature-flag.spec.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import type { PropsWithChildren } from 'react'
+import { renderHook } from '@testing-library/react-hooks'
+
+import { TripleClientMetadataProvider } from './triple-client-metadata-context'
+import { useTripleClientFeatureFlag } from './use-triple-client-feature-flag'
+
+it('returns true if app version meets the version operator requirements', () => {
+  const wrapper = ({ children }: PropsWithChildren<Record<string, never>>) => (
+    <TripleClientMetadataProvider appName="Triple-iOS" appVersion="5.11.0">
+      {children}
+    </TripleClientMetadataProvider>
+  )
+
+  const { result } = renderHook(
+    () =>
+      useTripleClientFeatureFlag({
+        operator: 'gte',
+        appVersion: '5.11.0',
+        availableOnPublic: true,
+      }),
+    { wrapper },
+  )
+
+  expect(result.current).toBeTruthy()
+})
+
+it('returns false if app version does not meet the version operator requirements', () => {
+  const wrapper = ({ children }: PropsWithChildren<Record<string, never>>) => (
+    <TripleClientMetadataProvider appName="Triple-iOS" appVersion="5.11.0">
+      {children}
+    </TripleClientMetadataProvider>
+  )
+
+  const { result } = renderHook(
+    () =>
+      useTripleClientFeatureFlag({
+        operator: 'gte',
+        appVersion: '5.12.0',
+        availableOnPublic: true,
+      }),
+    { wrapper },
+  )
+
+  expect(result.current).toBeFalsy()
+})
+
+it('returns false if app name does not meet the requirements', () => {
+  const wrapper = ({ children }: PropsWithChildren<Record<string, never>>) => (
+    <TripleClientMetadataProvider appName="Triple-iOS" appVersion="5.11.0">
+      {children}
+    </TripleClientMetadataProvider>
+  )
+
+  const { result } = renderHook(
+    () =>
+      useTripleClientFeatureFlag({
+        operator: 'gte',
+        appName: 'Triple-Android',
+        appVersion: '5.12.0',
+        availableOnPublic: true,
+      }),
+    { wrapper },
+  )
+
+  expect(result.current).toBeFalsy()
+})
+
+it('returns false if app does not exist and is not avilable on public', () => {
+  const wrapper = ({ children }: PropsWithChildren<Record<string, never>>) => (
+    <TripleClientMetadataProvider>{children}</TripleClientMetadataProvider>
+  )
+
+  const { result } = renderHook(
+    () =>
+      useTripleClientFeatureFlag({
+        operator: 'gte',
+        appName: 'Triple-Android',
+        appVersion: '5.12.0',
+        availableOnPublic: false,
+      }),
+    { wrapper },
+  )
+
+  expect(result.current).toBeFalsy()
+})
+
+it('returns true if app does not exist and is avilable on public', () => {
+  const wrapper = ({ children }: PropsWithChildren<Record<string, never>>) => (
+    <TripleClientMetadataProvider>{children}</TripleClientMetadataProvider>
+  )
+
+  const { result } = renderHook(
+    () =>
+      useTripleClientFeatureFlag({
+        operator: 'gte',
+        appName: 'Triple-Android',
+        appVersion: '5.12.0',
+        availableOnPublic: true,
+      }),
+    { wrapper },
+  )
+
+  expect(result.current).toBeTruthy()
+})

--- a/packages/react-triple-client-interfaces/src/use-triple-client-feature-flag.ts
+++ b/packages/react-triple-client-interfaces/src/use-triple-client-feature-flag.ts
@@ -1,0 +1,62 @@
+import * as semver from 'semver'
+
+import { useTripleClientMetadata } from './triple-client-metadata-context'
+import type { AppName } from './types'
+
+type Operator = 'lt' | 'lte' | 'gt' | 'gte'
+
+const VERSION_OPERATIONS: Record<
+  Operator,
+  typeof semver.lt | typeof semver.lte | typeof semver.gt | typeof semver.gte
+> = {
+  lt: semver.lt,
+  lte: semver.lte,
+  gt: semver.gt,
+  gte: semver.gte,
+}
+
+export function useTripleClientFeatureFlag({
+  operator,
+  appVersion,
+  availableOnPublic,
+  appName,
+}: {
+  /**
+   * 버전 비교에 사용할 operator를 결정합니다. 아래 4개 operator가 지원됩니다.
+   *
+   *   - 'gt'
+   *   - 'gte'
+   *   - 'lt'
+   *   - 'lte'
+   */
+  operator: Operator
+  /**
+   * 비교의 기준이 될 버전입니다.
+   */
+  appVersion: string
+  /**
+   * 트리플 클라이언트 사용 중이 아닐 경우(= 외부 브라우저일 경우) 노출 여부를
+   * 결정합니다.
+   */
+  availableOnPublic: boolean
+  /**
+   * 특정 플랫폼의 트리플 클라이언트에서만 노출이 필요할 경우 설정합니다.
+   */
+  appName?: AppName[keyof AppName]
+}) {
+  const app = useTripleClientMetadata()
+
+  if (!app) {
+    return availableOnPublic
+  } else {
+    const tripleClientAppVersion = semver.coerce(app.appVersion)
+    const operation = VERSION_OPERATIONS[operator]
+    const hasMatchingOs = appName !== undefined ? app.appName === appName : true
+
+    return Boolean(
+      tripleClientAppVersion &&
+        operation(tripleClientAppVersion, appVersion) &&
+        hasMatchingOs,
+    )
+  }
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

#1728 에서 구현하던 Feature flag 훅을 재구현합니다.

## 변경 내역

- `useTripleClientFeatureFlag` 훅과 테스트를 작성합니다.

