### PR TITLE
패키지별 package.json을 표준화합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40922,7 +40922,7 @@
     "packages/ab-experiments": {
       "name": "@titicaca/ab-experiments",
       "version": "5.2.1",
-      "license": "UNLICENSED",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/react-contexts": "^5.2.1"
       },
@@ -40933,6 +40933,7 @@
     "packages/action-sheet": {
       "name": "@titicaca/action-sheet",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "react-transition-group": "^4.4.1"
@@ -40945,7 +40946,7 @@
     "packages/ad-banners": {
       "name": "@titicaca/ad-banners",
       "version": "5.2.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@egjs/flicking": "^3.8.1",
         "@egjs/react-flicking": "^3.7.0",
@@ -40962,6 +40963,7 @@
     "packages/app-banner": {
       "name": "@titicaca/app-banner",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1"
       }
@@ -40969,7 +40971,7 @@
     "packages/app-installation-cta": {
       "name": "@titicaca/app-installation-cta",
       "version": "5.2.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^5.2.1",
         "@titicaca/core-elements": "^5.2.1",
@@ -40982,6 +40984,7 @@
     "packages/author": {
       "name": "@titicaca/author",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^5.2.1",
         "@titicaca/core-elements": "^5.2.1"
@@ -40990,6 +40993,7 @@
     "packages/booking-completion": {
       "name": "@titicaca/booking-completion",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/router": "^5.2.1",
@@ -41004,7 +41008,7 @@
     "packages/carousel": {
       "name": "@titicaca/carousel",
       "version": "5.2.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@egjs/flicking": "^3.8.1",
         "@egjs/react-flicking": "^3.7.0",
@@ -41019,16 +41023,18 @@
     },
     "packages/color-palette": {
       "name": "@titicaca/color-palette",
-      "version": "5.2.1"
+      "version": "5.2.1",
+      "license": "MIT"
     },
     "packages/constants": {
       "name": "@titicaca/constants",
-      "version": "5.2.1"
+      "version": "5.2.1",
+      "license": "MIT"
     },
     "packages/content-sharing": {
       "name": "@titicaca/content-sharing",
       "version": "5.2.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1"
       }
@@ -41036,7 +41042,7 @@
     "packages/core-elements": {
       "name": "@titicaca/core-elements",
       "version": "5.2.1",
-      "license": "UNLICENSED",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^5.2.1",
         "@titicaca/content-utilities": "4.11.0",
@@ -41054,6 +41060,7 @@
     "packages/date-picker": {
       "name": "@titicaca/date-picker",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^5.2.1",
         "@titicaca/fetcher": "^5.2.1",
@@ -41064,6 +41071,7 @@
     "packages/directions-finder": {
       "name": "@titicaca/directions-finder",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/i18n": "^5.2.1",
@@ -41076,7 +41084,7 @@
     "packages/drawer-button": {
       "name": "@titicaca/drawer-button",
       "version": "5.2.1",
-      "license": "UNLICENSED",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1"
       }
@@ -41084,6 +41092,7 @@
     "packages/fetcher": {
       "name": "@titicaca/fetcher",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "ts-custom-error": "^3.2.0",
         "universal-cookie": "^4.0.3"
@@ -41099,6 +41108,7 @@
     "packages/footer": {
       "name": "@titicaca/footer",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/router": "^5.2.1",
@@ -41112,6 +41122,7 @@
     "packages/form": {
       "name": "@titicaca/form",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/action-sheet": "^5.2.1",
         "@titicaca/color-palette": "^5.2.1",
@@ -41123,6 +41134,7 @@
     "packages/hub-form": {
       "name": "@titicaca/hub-form",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^5.2.1",
         "@titicaca/core-elements": "^5.2.1"
@@ -41131,6 +41143,7 @@
     "packages/i18n": {
       "name": "@titicaca/i18n",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "i18next": "^19.3.3",
         "isomorphic-fetch": "^2.2.1",
@@ -41143,6 +41156,7 @@
     "packages/icons": {
       "name": "@titicaca/icons",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^5.2.1"
       }
@@ -41150,6 +41164,7 @@
     "packages/image-carousel": {
       "name": "@titicaca/image-carousel",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@egjs/flicking": "^3.8.1",
         "@egjs/react-flicking": "^3.7.0",
@@ -41160,7 +41175,7 @@
     "packages/intersection-observer": {
       "name": "@titicaca/intersection-observer",
       "version": "5.2.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/react-intersection-observer": "1.6.0",
         "intersection-observer": "^0.7.0"
@@ -41172,6 +41187,7 @@
     "packages/listing-filter": {
       "name": "@titicaca/listing-filter",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^5.2.1"
       },
@@ -41183,6 +41199,7 @@
     "packages/location-properties": {
       "name": "@titicaca/location-properties",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/action-sheet": "^5.2.1",
         "@titicaca/core-elements": "^5.2.1",
@@ -41196,6 +41213,7 @@
     "packages/map": {
       "name": "@titicaca/map",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@react-google-maps/api": "~2.2.0",
         "@titicaca/color-palette": "^5.2.1",
@@ -41208,6 +41226,7 @@
     "packages/meta-tags": {
       "name": "@titicaca/meta-tags",
       "version": "5.2.1",
+      "license": "MIT",
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
         "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
@@ -41216,6 +41235,7 @@
     "packages/modals": {
       "name": "@titicaca/modals",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "semver": "^7.3.5"
@@ -41243,6 +41263,7 @@
     "packages/nearby-pois": {
       "name": "@titicaca/nearby-pois",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/i18n": "^5.2.1",
@@ -41263,6 +41284,7 @@
     "packages/poi-detail": {
       "name": "@titicaca/poi-detail",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/action-sheet": "^5.2.1",
         "@titicaca/carousel": "^5.2.1",
@@ -41286,6 +41308,7 @@
     "packages/poi-list-elements": {
       "name": "@titicaca/poi-list-elements",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/resource-list-element": "^5.2.1",
@@ -41300,7 +41323,7 @@
     "packages/popup": {
       "name": "@titicaca/popup",
       "version": "5.2.1",
-      "license": "UNLICENSED",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "react-transition-group": "^4.4.1"
@@ -41309,6 +41332,7 @@
     "packages/pricing": {
       "name": "@titicaca/pricing",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/type-definitions": "^5.2.1",
@@ -41318,6 +41342,7 @@
     "packages/public-header": {
       "name": "@titicaca/public-header",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^5.2.1",
         "@titicaca/view-utilities": "^5.2.1"
@@ -41331,7 +41356,7 @@
     "packages/react-contexts": {
       "name": "@titicaca/react-contexts",
       "version": "5.2.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/constants": "^5.2.1",
         "@titicaca/fetcher": "^5.2.1",
@@ -41356,7 +41381,7 @@
     "packages/react-hooks": {
       "name": "@titicaca/react-hooks",
       "version": "5.2.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1",
         "lottie-web": "^5.7.4",
@@ -41407,6 +41432,7 @@
     "packages/recommended-contents": {
       "name": "@titicaca/recommended-contents",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/intersection-observer": "^5.2.1"
@@ -41415,6 +41441,7 @@
     "packages/replies": {
       "name": "@titicaca/replies",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/action-sheet": "^5.2.1",
         "@titicaca/core-elements": "^5.2.1",
@@ -41427,6 +41454,7 @@
     "packages/resource-list-element": {
       "name": "@titicaca/resource-list-element",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/pricing": "^5.2.1",
@@ -41438,6 +41466,7 @@
     "packages/review": {
       "name": "@titicaca/review",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/action-sheet": "^5.2.1",
         "@titicaca/core-elements": "^5.2.1",
@@ -41482,6 +41511,7 @@
     "packages/router": {
       "name": "@titicaca/router",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/modals": "^5.2.1",
         "@titicaca/view-utilities": "^5.2.1",
@@ -41499,6 +41529,7 @@
     "packages/scrap-button": {
       "name": "@titicaca/scrap-button",
       "version": "5.2.1",
+      "license": "MIT",
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
         "react": "*",
@@ -41508,6 +41539,7 @@
     "packages/scroll-spy": {
       "name": "@titicaca/scroll-spy",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/intersection-observer": "^5.2.1",
         "@titicaca/react-hooks": "^5.2.1",
@@ -41520,7 +41552,7 @@
     "packages/search": {
       "name": "@titicaca/search",
       "version": "5.2.1",
-      "license": "UNLICENSED",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/react-hooks": "^5.2.1",
@@ -41534,6 +41566,7 @@
     "packages/slider": {
       "name": "@titicaca/slider",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/view-utilities": "^5.2.1",
@@ -41543,6 +41576,7 @@
     "packages/social-reviews": {
       "name": "@titicaca/social-reviews",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/i18n": "^5.2.1",
@@ -41561,7 +41595,7 @@
     "packages/standard-action-handler": {
       "name": "@titicaca/standard-action-handler",
       "version": "5.2.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/view-utilities": "^5.2.1",
         "qs": "^6.9.4"
@@ -41578,6 +41612,7 @@
     "packages/static-map": {
       "name": "@titicaca/static-map",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1"
       }
@@ -41585,6 +41620,7 @@
     "packages/static-page-contents": {
       "name": "@titicaca/static-page-contents",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^5.2.1",
         "isomorphic-fetch": "^2.2.1"
@@ -41596,6 +41632,7 @@
     "packages/style-box": {
       "name": "@titicaca/style-box",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.3",
         "styled-components": ">=4.4.1 < 6"
@@ -41604,6 +41641,7 @@
     "packages/triple-document": {
       "name": "@titicaca/triple-document",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^5.2.1",
         "@titicaca/content-type-definitions": "4.11.0",
@@ -41646,6 +41684,7 @@
     "packages/triple-media": {
       "name": "@titicaca/triple-media",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/type-definitions": "^5.2.1"
@@ -41653,11 +41692,13 @@
     },
     "packages/type-definitions": {
       "name": "@titicaca/type-definitions",
-      "version": "5.2.1"
+      "version": "5.2.1",
+      "license": "MIT"
     },
     "packages/ui-flow": {
       "name": "@titicaca/ui-flow",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/modals": "^5.2.1",
         "qs": "^6.9.0"
@@ -41671,6 +41712,7 @@
     "packages/user-verification": {
       "name": "@titicaca/user-verification",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^5.2.1",
         "@titicaca/modals": "^5.2.1",
@@ -41689,6 +41731,7 @@
     "packages/view-utilities": {
       "name": "@titicaca/view-utilities",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "@titicaca/type-definitions": "^5.2.1",
         "@types/qs": "^6.9.0",
@@ -41705,6 +41748,7 @@
     "packages/web-storage": {
       "name": "@titicaca/web-storage",
       "version": "5.2.1",
+      "license": "MIT",
       "dependencies": {
         "ts-custom-error": "^3.2.0",
         "universal-cookie": "^4.0.4"

--- a/packages/ab-experiments/package.json
+++ b/packages/ab-experiments/package.json
@@ -2,15 +2,8 @@
   "name": "@titicaca/ab-experiments",
   "version": "5.2.1",
   "description": "a/b experiments package",
-  "homepage": "https:/github.com/titicacadev/triple-frontend#readme",
-  "license": "UNLICENSED",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/ab-experiments",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -18,10 +11,14 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "peerDependencies": {
-    "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
-  },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/react-contexts": "^5.2.1"
+  },
+  "peerDependencies": {
+    "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
   }
 }

--- a/packages/action-sheet/package.json
+++ b/packages/action-sheet/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/action-sheet",
   "version": "5.2.1",
   "description": "Action sheet component",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/action-sheet",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,12 +11,16 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "peerDependencies": {
-    "react": ">=16.3.0",
-    "styled-components": ">=4.4.1 < 6"
-  },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "react-transition-group": "^4.4.1"
+  },
+  "peerDependencies": {
+    "react": ">=16.3.0",
+    "styled-components": ">=4.4.1 < 6"
   }
 }

--- a/packages/ad-banners/package.json
+++ b/packages/ad-banners/package.json
@@ -2,23 +2,19 @@
   "name": "@titicaca/ad-banners",
   "version": "5.2.1",
   "description": "Image banner list section for POI, hotel, article",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "license": "ISC",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/ad-banners",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
-  "scripts": {},
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@egjs/flicking": "^3.8.1",
     "@egjs/react-flicking": "^3.7.0",

--- a/packages/app-banner/package.json
+++ b/packages/app-banner/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/app-banner",
   "version": "5.2.1",
   "description": "Common App Banner for Public Pages",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/app-banner",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1"
   }

--- a/packages/app-installation-cta/package.json
+++ b/packages/app-installation-cta/package.json
@@ -9,23 +9,19 @@
     "triple",
     "frontend"
   ],
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "license": "ISC",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/app-installation-cta",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
-  "scripts": {},
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/color-palette": "^5.2.1",
     "@titicaca/core-elements": "^5.2.1",

--- a/packages/author/package.json
+++ b/packages/author/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/author",
   "version": "5.2.1",
   "description": "Triple Author UI elements",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/author",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/color-palette": "^5.2.1",
     "@titicaca/core-elements": "^5.2.1"

--- a/packages/booking-completion/package.json
+++ b/packages/booking-completion/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/booking-completion",
   "version": "5.2.1",
   "description": "Triple Booking completion Page",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/booking-completion",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/router": "^5.2.1",

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -2,16 +2,8 @@
   "name": "@titicaca/carousel",
   "version": "5.2.1",
   "description": "Triple Carousel",
-  "author": "torres-triple <torres@triple-corp.com>",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "license": "ISC",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/carousel",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -19,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@egjs/flicking": "^3.8.1",
     "@egjs/react-flicking": "^3.7.0",
@@ -29,5 +25,6 @@
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*"
-  }
+  },
+  "author": "torres-triple <torres@triple-corp.com>"
 }

--- a/packages/color-palette/package.json
+++ b/packages/color-palette/package.json
@@ -2,16 +2,17 @@
   "name": "@titicaca/color-palette",
   "version": "5.2.1",
   "description": "Triple Color Palette",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/color-palette",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
-  }
+  },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ]
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -7,20 +7,17 @@
     "frontend",
     "typescript"
   ],
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/constants",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
-  "scripts": {},
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
-  }
+  },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ]
 }

--- a/packages/content-sharing/package.json
+++ b/packages/content-sharing/package.json
@@ -2,15 +2,8 @@
   "name": "@titicaca/content-sharing",
   "version": "5.2.1",
   "description": "Content Sharing",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "license": "ISC",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/content-sharing",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -18,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1"
   }

--- a/packages/core-elements/package.json
+++ b/packages/core-elements/package.json
@@ -2,26 +2,25 @@
   "name": "@titicaca/core-elements",
   "version": "5.2.1",
   "description": "Core elements of Triple Design System",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "files": [
-    "lib/"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/titicacadev/triple-frontend.git"
-  },
   "keywords": [
     "triple",
     "design",
     "system",
     "library"
   ],
-  "license": "UNLICENSED",
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/core-elements",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/titicacadev/triple-frontend.git"
+  },
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/color-palette": "^5.2.1",
     "@titicaca/content-utilities": "4.11.0",

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/date-picker",
   "version": "5.2.1",
   "description": "Triple - Date Picker",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/date-picker",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/color-palette": "^5.2.1",
     "@titicaca/fetcher": "^5.2.1",

--- a/packages/directions-finder/package.json
+++ b/packages/directions-finder/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/directions-finder",
   "version": "5.2.1",
   "description": "POI directions finder",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/directions-finder",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/i18n": "^5.2.1",

--- a/packages/drawer-button/package.json
+++ b/packages/drawer-button/package.json
@@ -6,26 +6,19 @@
     "button",
     "drawer"
   ],
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "license": "UNLICENSED",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/drawer-button",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
-  "scripts": {
-    "test": "echo \"No test is included in this package.\""
-  },
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1"
   }

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -2,10 +2,8 @@
   "name": "@titicaca/fetcher",
   "version": "5.2.1",
   "description": "Utilities for Triple view libraries and applications",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/fetcher",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -13,7 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "ts-custom-error": "^3.2.0",
     "universal-cookie": "^4.0.3"

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/footer",
   "version": "5.2.1",
   "description": "Common Footer for Public Pages",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/footer",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,13 +11,17 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "peerDependencies": {
-    "@titicaca/react-contexts": "*"
-  },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/router": "^5.2.1",
     "@types/qs": "^6.9.0",
     "qs": "^6.9.0"
+  },
+  "peerDependencies": {
+    "@titicaca/react-contexts": "*"
   }
 }

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -2,24 +2,19 @@
   "name": "@titicaca/form",
   "version": "5.2.1",
   "description": "Triple Form Components",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/form",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
-  "scripts": {
-    "test": "echo \"Error: run tests from root\" && exit 1"
-  },
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/action-sheet": "^5.2.1",
     "@titicaca/color-palette": "^5.2.1",

--- a/packages/hub-form/package.json
+++ b/packages/hub-form/package.json
@@ -2,24 +2,19 @@
   "name": "@titicaca/hub-form",
   "version": "5.2.1",
   "description": "Form for hub-like pages",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/hub-form",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
-  "scripts": {
-    "test": "echo \"Error: run tests from root\" && exit 1"
-  },
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/color-palette": "^5.2.1",
     "@titicaca/core-elements": "^5.2.1"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/i18n",
   "version": "5.2.1",
   "description": "Triple-frontend Internalization",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/i18n",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "i18next": "^19.3.3",
     "isomorphic-fetch": "^2.2.1",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/icons",
   "version": "5.2.1",
   "description": "Triple Icons",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/icons",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/color-palette": "^5.2.1"
   }

--- a/packages/image-carousel/package.json
+++ b/packages/image-carousel/package.json
@@ -2,10 +2,8 @@
   "name": "@titicaca/image-carousel",
   "version": "5.2.1",
   "description": "Triple Image Carousel",
-  "main": "lib/index.js",
-  "files": [
-    "lib/"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/image-carousel",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -13,7 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@egjs/flicking": "^3.8.1",
     "@egjs/react-flicking": "^3.7.0",

--- a/packages/intersection-observer/package.json
+++ b/packages/intersection-observer/package.json
@@ -2,11 +2,19 @@
   "name": "@titicaca/intersection-observer",
   "version": "5.2.1",
   "description": "Shared IntersecionObserver component",
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/intersection-observer",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/titicacadev/triple-frontend.git"
+  },
+  "bugs": {
+    "url": "https://github.com/titicacadev/triple-frontend/issues"
+  },
   "main": "lib/index.js",
   "files": [
-    "lib/*"
+    "lib"
   ],
-  "license": "ISC",
   "dependencies": {
     "@titicaca/react-intersection-observer": "1.6.0",
     "intersection-observer": "^0.7.0"

--- a/packages/listing-filter/package.json
+++ b/packages/listing-filter/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/listing-filter",
   "version": "5.2.1",
   "description": "Listing filter UI",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/listing-filter",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/color-palette": "^5.2.1"
   },

--- a/packages/location-properties/package.json
+++ b/packages/location-properties/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/location-properties",
   "version": "5.2.1",
   "description": "Location properties: addresses, contact, URL, ...",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/location-properties",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/action-sheet": "^5.2.1",
     "@titicaca/core-elements": "^5.2.1",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/map",
   "version": "5.2.1",
   "description": "Map component",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/map",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@react-google-maps/api": "~2.2.0",
     "@titicaca/color-palette": "^5.2.1",

--- a/packages/meta-tags/package.json
+++ b/packages/meta-tags/package.json
@@ -2,15 +2,19 @@
   "name": "@titicaca/meta-tags",
   "version": "5.2.1",
   "description": "Triple Web Application Meta tag modules",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/meta-tags",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
+  "bugs": {
+    "url": "https://github.com/titicacadev/triple-frontend/issues"
+  },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
     "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/modals",
   "version": "5.2.1",
   "description": "Triple modal dialog components",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/modals",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,14 +11,18 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "semver": "^7.3.5"
   },
-  "peerDependencies": {
-    "@titicaca/react-contexts": "*"
-  },
   "devDependencies": {
     "@types/semver": "^7.3.6"
+  },
+  "peerDependencies": {
+    "@titicaca/react-contexts": "*"
   }
 }

--- a/packages/nearby-pois/package.json
+++ b/packages/nearby-pois/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/nearby-pois",
   "version": "5.2.1",
   "description": "Nearby POIs list",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/nearby-pois",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/i18n": "^5.2.1",

--- a/packages/poi-detail/package.json
+++ b/packages/poi-detail/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/poi-detail",
   "version": "5.2.1",
   "description": "Components for POI detail page",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/poi-detail",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/action-sheet": "^5.2.1",
     "@titicaca/carousel": "^5.2.1",

--- a/packages/poi-list-elements/package.json
+++ b/packages/poi-list-elements/package.json
@@ -2,10 +2,8 @@
   "name": "@titicaca/poi-list-elements",
   "version": "5.2.1",
   "description": "Triple POI UI Elements",
-  "main": "lib/index.js",
-  "files": [
-    "lib/"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/poi-list-elements",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -13,7 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/resource-list-element": "^5.2.1",

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -2,24 +2,23 @@
   "name": "@titicaca/popup",
   "version": "5.2.1",
   "description": "Triple Popup",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "files": [
-    "lib/"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/titicacadev/triple-frontend.git"
-  },
   "keywords": [
     "triple",
     "popup"
   ],
-  "license": "UNLICENSED",
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/popup",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/titicacadev/triple-frontend.git"
+  },
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "react-transition-group": "^4.4.1"

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/pricing",
   "version": "5.2.1",
   "description": "Triple - pricing",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/pricing",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/type-definitions": "^5.2.1",

--- a/packages/public-header/package.json
+++ b/packages/public-header/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/public-header",
   "version": "5.2.1",
   "description": "Common Header for Public Pages",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/public-header",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/color-palette": "^5.2.1",
     "@titicaca/view-utilities": "^5.2.1"

--- a/packages/react-contexts/package.json
+++ b/packages/react-contexts/package.json
@@ -2,12 +2,19 @@
   "name": "@titicaca/react-contexts",
   "version": "5.2.1",
   "description": "React context modules for triple web applications",
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/react-contexts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/titicacadev/triple-frontend.git"
+  },
+  "bugs": {
+    "url": "https://github.com/titicacadev/triple-frontend/issues"
+  },
   "main": "lib/index.js",
   "files": [
-    "lib/*"
+    "lib"
   ],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "@titicaca/constants": "^5.2.1",
     "@titicaca/fetcher": "^5.2.1",
@@ -18,14 +25,15 @@
     "ua-parser-js": "^0.7.20",
     "universal-cookie": "^4.0.4"
   },
+  "devDependencies": {
+    "@types/isomorphic-fetch": "^0.0.35",
+    "@types/qs": "^6.9.2",
+    "@types/ua-parser-js": "^0.7.33"
+  },
   "peerDependencies": {
     "@titicaca/triple-web-to-native-interfaces": "*",
     "firebase": "^7.24.0",
     "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
   },
-  "devDependencies": {
-    "@types/isomorphic-fetch": "^0.0.35",
-    "@types/qs": "^6.9.2",
-    "@types/ua-parser-js": "^0.7.33"
-  }
+  "author": ""
 }

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -2,22 +2,19 @@
   "name": "@titicaca/react-hooks",
   "version": "5.2.1",
   "description": "triple frontend custom hooks",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "license": "ISC",
-  "main": "lib/index.js",
-  "files": [
-    "lib/*"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/react-hooks",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
-  "scripts": {
-    "test": "echo \"Error: run tests from root\" && exit 1"
-  },
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "isomorphic-fetch": "^2.2.1",
     "lottie-web": "^5.7.4",

--- a/packages/recommended-contents/package.json
+++ b/packages/recommended-contents/package.json
@@ -2,10 +2,8 @@
   "name": "@titicaca/recommended-contents",
   "version": "5.2.1",
   "description": "Recommended contents list",
-  "main": "lib/index.js",
-  "files": [
-    "lib/"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/recommended-contents",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -13,7 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/intersection-observer": "^5.2.1"

--- a/packages/replies/package.json
+++ b/packages/replies/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/replies",
   "version": "5.2.1",
   "description": "Replies Component",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/replies",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/action-sheet": "^5.2.1",
     "@titicaca/core-elements": "^5.2.1",

--- a/packages/resource-list-element/package.json
+++ b/packages/resource-list-element/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/resource-list-element",
   "version": "5.2.1",
   "description": "Triple - resource-list-element",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/resource-list-element",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/pricing": "^5.2.1",

--- a/packages/review/package.json
+++ b/packages/review/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/review",
   "version": "5.2.1",
   "description": "UI Components for User Reviews from Triple Service",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/review",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/action-sheet": "^5.2.1",
     "@titicaca/core-elements": "^5.2.1",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -2,14 +2,8 @@
   "name": "@titicaca/router",
   "version": "5.2.1",
   "description": "Triple Universal Router Component and Functions",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/router",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -17,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/modals": "^5.2.1",
     "@titicaca/view-utilities": "^5.2.1",

--- a/packages/scrap-button/package.json
+++ b/packages/scrap-button/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/scrap-button",
   "version": "5.2.1",
   "description": "Listing filter UI",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/scrap-button",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
     "react": "*",

--- a/packages/scroll-spy/package.json
+++ b/packages/scroll-spy/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/scroll-spy",
   "version": "5.2.1",
   "description": "Scroll Spy Component",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/scroll-spy",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/intersection-observer": "^5.2.1",
     "@titicaca/react-hooks": "^5.2.1",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -2,19 +2,22 @@
   "name": "@titicaca/search",
   "version": "5.2.1",
   "description": "search",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  "files": [
-    "lib/"
+  "keywords": [
+    "search"
   ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/search",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
-  "keywords": [
-    "search"
+  "bugs": {
+    "url": "https://github.com/titicacadev/triple-frontend/issues"
+  },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
   ],
-  "license": "UNLICENSED",
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/react-hooks": "^5.2.1",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -2,14 +2,8 @@
   "name": "@titicaca/slider",
   "version": "5.2.1",
   "description": "Slider component",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/slider",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -17,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/view-utilities": "^5.2.1",

--- a/packages/social-reviews/package.json
+++ b/packages/social-reviews/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/social-reviews",
   "version": "5.2.1",
   "description": "Social reviews section for Triple contents",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/social-reviews",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/i18n": "^5.2.1",

--- a/packages/standard-action-handler/package.json
+++ b/packages/standard-action-handler/package.json
@@ -2,11 +2,19 @@
   "name": "@titicaca/standard-action-handler",
   "version": "5.2.1",
   "description": "Standard action handler for Triple service applications",
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/standard-action-handler",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/titicacadev/triple-frontend.git"
+  },
+  "bugs": {
+    "url": "https://github.com/titicacadev/triple-frontend/issues"
+  },
   "main": "lib/index.js",
   "files": [
-    "lib/*"
+    "lib"
   ],
-  "license": "ISC",
   "dependencies": {
     "@titicaca/view-utilities": "^5.2.1",
     "qs": "^6.9.4"

--- a/packages/static-map/package.json
+++ b/packages/static-map/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/static-map",
   "version": "5.2.1",
   "description": "Static map component",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/static-map",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1"
   }

--- a/packages/static-page-contents/package.json
+++ b/packages/static-page-contents/package.json
@@ -2,10 +2,8 @@
   "name": "@titicaca/static-page-contents",
   "version": "5.2.1",
   "description": "Static page pomponent",
-  "main": "lib/index.js",
-  "files": [
-    "lib/"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/static-page-contents",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -13,7 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/color-palette": "^5.2.1",
     "isomorphic-fetch": "^2.2.1"

--- a/packages/style-box/package.json
+++ b/packages/style-box/package.json
@@ -2,14 +2,8 @@
   "name": "@titicaca/style-box",
   "version": "5.2.1",
   "description": "Triple Style Box",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/style-box",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -17,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "csstype": "^3.0.3",
     "styled-components": ">=4.4.1 < 6"

--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -2,10 +2,8 @@
   "name": "@titicaca/triple-document",
   "version": "5.2.1",
   "description": "TripleDocument: Formatted Content System",
-  "main": "lib/index.js",
-  "files": [
-    "lib/"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/triple-document",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -13,7 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/color-palette": "^5.2.1",
     "@titicaca/content-type-definitions": "4.11.0",
@@ -33,10 +34,10 @@
     "@titicaca/view-utilities": "^5.2.1",
     "semver": "^7.3.5"
   },
-  "peerDependencies": {
-    "@titicaca/react-contexts": "*"
-  },
   "devDependencies": {
     "@types/semver": "^7.3.6"
+  },
+  "peerDependencies": {
+    "@titicaca/react-contexts": "*"
   }
 }

--- a/packages/triple-media/package.json
+++ b/packages/triple-media/package.json
@@ -2,10 +2,8 @@
   "name": "@titicaca/triple-media",
   "version": "5.2.1",
   "description": "Media object of Triple",
-  "main": "lib/index.js",
-  "files": [
-    "lib/"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/triple-media",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -13,7 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/type-definitions": "^5.2.1"

--- a/packages/type-definitions/package.json
+++ b/packages/type-definitions/package.json
@@ -7,20 +7,17 @@
     "frontend",
     "typescript"
   ],
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/type-definitions",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
-  "scripts": {},
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
-  }
+  },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ]
 }

--- a/packages/ui-flow/package.json
+++ b/packages/ui-flow/package.json
@@ -8,22 +8,19 @@
     "react",
     "hooks"
   ],
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/ui-flow",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
   },
-  "scripts": {},
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/modals": "^5.2.1",
     "qs": "^6.9.0"

--- a/packages/user-verification/package.json
+++ b/packages/user-verification/package.json
@@ -8,14 +8,8 @@
     "user",
     "verification"
   ],
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "directories": {
-    "lib": "lib"
-  },
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/user-verification",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -23,6 +17,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/core-elements": "^5.2.1",
     "@titicaca/modals": "^5.2.1",

--- a/packages/view-utilities/package.json
+++ b/packages/view-utilities/package.json
@@ -2,10 +2,8 @@
   "name": "@titicaca/view-utilities",
   "version": "5.2.1",
   "description": "Utilities for Triple view libraries and applications",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/view-utilities",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -13,7 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "@titicaca/type-definitions": "^5.2.1",
     "@types/qs": "^6.9.0",

--- a/packages/web-storage/package.json
+++ b/packages/web-storage/package.json
@@ -2,11 +2,8 @@
   "name": "@titicaca/web-storage",
   "version": "5.2.1",
   "description": "WebStorage API wrapper for Triple services",
-  "homepage": "https://github.com/titicacadev/triple-frontend#readme",
-  "main": "lib/index.js",
-  "files": [
-    "lib"
-  ],
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/web-storage",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/titicacadev/triple-frontend.git"
@@ -14,6 +11,10 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
   "dependencies": {
     "ts-custom-error": "^3.2.0",
     "universal-cookie": "^4.0.4"

--- a/scripts/normalize-package-metadata.js
+++ b/scripts/normalize-package-metadata.js
@@ -1,0 +1,71 @@
+/**
+ * 아래 명령어로 이 스크립트를 실행하세요.
+ * node ./node_modules/lerna/cli.js exec --ignore @titicaca/triple-frontend-docs --ignore=@titicaca/frontend-integration-test --parallel -- node "\$LERNA_ROOT_PATH/scripts/normalize-package-metadata.js"
+ */
+const fs = require('fs/promises')
+const path = require('path')
+
+normalizePackageMetadata()
+
+async function normalizePackageMetadata() {
+  const transformer = ({
+    name,
+    version,
+    description,
+    keywords,
+    license,
+    homepage,
+    repository,
+    bugs,
+    scripts,
+    main,
+    types,
+    files,
+    directories,
+    dependencies,
+    devDependencies,
+    peerDependencies,
+    ...rest
+  }) => ({
+    name,
+    version,
+    description,
+    keywords,
+    license: 'MIT',
+    homepage: makeHomepageUrl(name),
+    repository: {
+      type: 'git',
+      url: 'git+https://github.com/titicacadev/triple-frontend.git',
+    },
+    bugs: {
+      url: 'https://github.com/titicacadev/triple-frontend/issues',
+    },
+    main: 'lib/index.js',
+    files: ['lib'],
+    dependencies,
+    devDependencies,
+    peerDependencies,
+    ...rest,
+  })
+
+  await writePackageJson(transformer)
+}
+
+function makeHomepageUrl(name) {
+  return `https://github.com/titicacadev/triple-frontend/tree/main/packages/${name.replace(
+    '@titicaca/',
+    '',
+  )}`
+}
+
+async function writePackageJson(transformer) {
+  const packageJsonPath = path.resolve(process.cwd(), './package.json')
+
+  const packageJson = JSON.parse(
+    (await fs.readFile(packageJsonPath)).toString(),
+  )
+
+  const newPackageJson = JSON.stringify(transformer(packageJson), null, '  ')
+
+  await fs.writeFile(packageJsonPath, newPackageJson)
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

패키지별 package.json의 속성 순서, 속성 내용을 표준화하는 스크립트를 구현하고 해당 스크립트로 표준화합니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- license 속성을 "MIT"로 통일
- 불필요한 속성 제거: `types`, `scripts`, `directories`
- homepage 속성을 GitHub의 각 디렉토리 주소로 수정
- files 속성을 `["lib"]`으로 통일
- repository, bugs 속성 통일
- 속성 순서 표준화