### PR TITLE
v6 마이그레이션 가이드에 react-triple-client-interfaces에 대응하는 내용을 추가합니다.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -75,6 +75,15 @@ const StyledLocalLink = styled(LocalLink)`
 - withLoginCTAModal -> withLoginCtaModal
 - LoginCTAModalProvider -> LoginCtaModalProvider
 
+### `@titicaca/react-triple-client-interfaces` 사용
+
+트리플 네이티브 클라이언트를 이용하거나 클라이언트 종류에 따른 동작 분기가 필요한 경우
+`@titicaca/react-triple-client-interfaces` 패키지가 제공하는 기능을 사용해야 합니다.
+이 패키지 동작에 필요한 `TripleClientMetadataProvider`를 마운트해주세요.
+
+자세한 설명은 [패키지 README](https://github.com/titicacadev/triple-frontend/tree/main/packages/react-triple-client-interfaces)를
+참고 바랍니다.
+
 ## v4 to v5
 
 ### deprecated props 제거 및 사용 방법


### PR DESCRIPTION
`@titicaca/react-triple-client-interfaces`는 `@titicaca/user-verification` 패키지에서만 이용하고 있지만, `triple-document`등 간접 의존성을 가진 패키지들이 있으므로 미리 가이드를 하는 편이 안전하다고 보았습니다. 마이그레이션의 혼란을 줄이기 위해 `TripleClientMetadataProvider`를 마운트하는 내용을 추가합니다.