### PR TITLE
[public-header] react-triple-client-interfaces를 이용해 렌더링 여부를 분기합니다.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,7 +6,6 @@ packages/*/lib/**
 docs/storybook-static
 
 packages/i18n
-packages/public-header
 packages/ab-experiments
 packages/action-sheet
 packages/app-installation-cta

--- a/docs/stories/public-header/public-header.stories.tsx
+++ b/docs/stories/public-header/public-header.stories.tsx
@@ -1,10 +1,7 @@
-import PublicHeader, { PublicHeaderProps } from '@titicaca/public-header'
+import { PublicHeader, PublicHeaderProps } from '@titicaca/public-header'
 import { Meta, Story } from '@storybook/react'
-import {
-  EnvProvider,
-  generateUserAgentValues,
-  UserAgentProvider,
-} from '@titicaca/react-contexts'
+import { EnvProvider } from '@titicaca/react-contexts'
+import { TripleClientMetadataProvider } from '@titicaca/react-triple-client-interfaces'
 
 export default {
   title: 'public-header / PublicHeader',
@@ -29,9 +26,11 @@ const Template: Story<PublicHeaderProps> = (args) => {
       facebookAppId=""
       webUrlBase=""
     >
-      <UserAgentProvider value={generateUserAgentValues(navigator.userAgent)}>
+      <TripleClientMetadataProvider
+        {...TripleClientMetadataProvider.getInitialProps({})}
+      >
         <PublicHeader {...args} />
-      </UserAgentProvider>
+      </TripleClientMetadataProvider>
     </EnvProvider>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43890,6 +43890,7 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^6.4.0",
+        "@titicaca/react-triple-client-interfaces": "^6.4.0",
         "@titicaca/view-utilities": "^6.4.0"
       },
       "peerDependencies": {
@@ -58249,6 +58250,7 @@
       "version": "file:packages/public-header",
       "requires": {
         "@titicaca/color-palette": "^6.4.0",
+        "@titicaca/react-triple-client-interfaces": "^6.4.0",
         "@titicaca/view-utilities": "^6.4.0"
       }
     },

--- a/packages/public-header/package.json
+++ b/packages/public-header/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "@titicaca/color-palette": "^6.4.0",
+    "@titicaca/react-triple-client-interfaces": "^6.4.0",
     "@titicaca/view-utilities": "^6.4.0"
   },
   "peerDependencies": {

--- a/packages/public-header/src/public-header.spec.tsx
+++ b/packages/public-header/src/public-header.spec.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { render } from '@testing-library/react'
 import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 

--- a/packages/public-header/src/public-header.spec.tsx
+++ b/packages/public-header/src/public-header.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
+
+import { PublicHeader } from './public-header'
+
+jest.mock('@titicaca/react-triple-client-interfaces')
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+it('renders nothing inside triple client', () => {
+  ;(
+    useTripleClientMetadata as jest.MockedFunction<
+      typeof useTripleClientMetadata
+    >
+  ).mockReturnValue({
+    appVersion: '5.11.0',
+    appName: 'Triple-iOS',
+  })
+
+  const { container } = render(<PublicHeader />)
+
+  expect(container.childNodes.length).toBe(0)
+})
+
+it('renders header outside triple client', () => {
+  ;(
+    useTripleClientMetadata as jest.MockedFunction<
+      typeof useTripleClientMetadata
+    >
+  ).mockReturnValue(null)
+
+  const { container } = render(<PublicHeader />)
+
+  expect(container.childNodes.length).toBe(1)
+})

--- a/packages/public-header/src/public-header.tsx
+++ b/packages/public-header/src/public-header.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import { white, brightGray } from '@titicaca/color-palette'
-import { useUserAgentContext } from '@titicaca/react-contexts'
+import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 
 import {
   HEADER_DESKTOP_HEIGHT,
@@ -97,7 +97,7 @@ export function PublicHeader({
   deeplinkPath,
   disableAutoHide,
 }: PublicHeaderProps) {
-  const { app } = useUserAgentContext()
+  const app = useTripleClientMetadata()
   const visible = useAutoHide(disableAutoHide)
 
   if (app) {

--- a/packages/public-header/tsconfig.build.json
+++ b/packages/public-header/tsconfig.build.json
@@ -6,6 +6,9 @@
       "path": "../color-palette/tsconfig.build.json"
     },
     {
+      "path": "../react-triple-client-interfaces/tsconfig.build.json"
+    },
+    {
       "path": "../view-utilities/tsconfig.build.json"
     },
     {

--- a/packages/public-header/tsconfig.json
+++ b/packages/public-header/tsconfig.json
@@ -7,6 +7,9 @@
     "paths": {
       "@titicaca/color-palette": ["../color-palette/src"],
       "@titicaca/react-contexts": ["../react-contexts/src"],
+      "@titicaca/react-triple-client-interfaces": [
+        "../react-triple-client-interfaces/src"
+      ],
       "@titicaca/view-utilities": ["../view-utilities/src"]
     }
   },
@@ -14,6 +17,9 @@
   "references": [
     {
       "path": "../color-palette"
+    },
+    {
+      "path": "../react-triple-client-interfaces"
     },
     {
       "path": "../view-utilities"


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

`react-contexts` 대신 `triple-react-client-interfaces` 패키지를 이용해 `PublicHeader`의 렌더링 여부를 분기합니다.

## 변경 내역

- `PublicHeader` 내부에서 `useTripleClientMetadata` 훅의 리턴 값이 있을 경우 렌더링을 생략합니다.
- `.eslintignore` 목록에서 `public-header` 패키지를 제거합니다. 

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
