### PR TITLE
[map] `PoiDotMarker`의 props, type 및 `CircleMarker`의 type 등을 export 합니다.

### DIFF
--- a/packages/map/src/map-view.tsx
+++ b/packages/map/src/map-view.tsx
@@ -114,7 +114,7 @@ export function MapView({
   )
 
   useEffect(() => {
-    if (!bounds) {
+    if (!bounds || coordinates.length === 0) {
       return
     }
     map?.fitBounds(bounds, padding)

--- a/packages/map/src/overlay/markers/poi-dot-marker.tsx
+++ b/packages/map/src/overlay/markers/poi-dot-marker.tsx
@@ -8,11 +8,13 @@ import React, {
 } from 'react'
 import { OverlayView, OverlayViewProps } from '@react-google-maps/api'
 
-import { BubbleMarker, CIRCLE_MARKER, DotMarker } from './primary-marker'
 import {
+  BubbleMarker,
+  CIRCLE_MARKER,
   CircleType,
-  MarkerBaseProps,
-} from './primary-marker/circle-marker/circle-marker-base'
+  DotMarker,
+} from './primary-marker'
+import { MarkerBaseProps } from './primary-marker/circle-marker/circle-marker-base'
 
 export interface DotWithPopOverMarkerProps
   extends Pick<MarkerBaseProps, 'zIndex'>,

--- a/packages/map/src/overlay/markers/poi-dot-marker.tsx
+++ b/packages/map/src/overlay/markers/poi-dot-marker.tsx
@@ -8,9 +8,8 @@ import React, {
 } from 'react'
 import { OverlayView, OverlayViewProps } from '@react-google-maps/api'
 
-import { BubbleMarker, DotMarker } from './primary-marker'
+import { BubbleMarker, CIRCLE_MARKER, DotMarker } from './primary-marker'
 import {
-  CIRCLE_MARKER,
   CircleType,
   MarkerBaseProps,
 } from './primary-marker/circle-marker/circle-marker-base'
@@ -20,6 +19,7 @@ export interface DotWithPopOverMarkerProps
     Omit<OverlayViewProps, 'mapPaneName'> {
   type: CircleType
   active: boolean
+  dotSize?: { width: number; height: number }
   bubbleContent: React.ReactNode
   activeContent?: React.ReactNode
   inActiveContent?: React.ReactNode
@@ -41,6 +41,7 @@ export function PoiDotMarker({
 function DotWithPopOverMarker({
   type,
   active,
+  dotSize,
   withDot,
   activeContent,
   inActiveContent,
@@ -109,7 +110,12 @@ function DotWithPopOverMarker({
         ) : null}
 
         {withDot ? (
-          <DotMarker active={active} color={color} onClick={handleClick}>
+          <DotMarker
+            active={active}
+            size={dotSize}
+            color={color}
+            onClick={handleClick}
+          >
             {children}
           </DotMarker>
         ) : null}

--- a/packages/map/src/overlay/markers/poi-dot-marker.tsx
+++ b/packages/map/src/overlay/markers/poi-dot-marker.tsx
@@ -24,7 +24,7 @@ export interface DotWithPopOverMarkerProps
   dotSize?: { width: number; height: number }
   bubbleContent: React.ReactNode
   activeContent?: React.ReactNode
-  inActiveContent?: React.ReactNode
+  inactiveContent?: React.ReactNode
   withDot?: boolean
   onClick?: (e: MouseEvent) => void
   onBubbleClick?: (e: MouseEvent) => void
@@ -46,7 +46,7 @@ function DotWithPopOverMarker({
   dotSize,
   withDot,
   activeContent,
-  inActiveContent,
+  inactiveContent,
   bubbleContent,
   zIndex,
   onClick,
@@ -124,7 +124,7 @@ function DotWithPopOverMarker({
 
         {active && activeContent ? activeContent : null}
 
-        {!active && inActiveContent ? inActiveContent : null}
+        {!active && inactiveContent ? inactiveContent : null}
       </>
     </OverlayView>
   )

--- a/packages/map/src/overlay/markers/poi-dot-marker.tsx
+++ b/packages/map/src/overlay/markers/poi-dot-marker.tsx
@@ -20,8 +20,10 @@ export interface DotWithPopOverMarkerProps
     Omit<OverlayViewProps, 'mapPaneName'> {
   type: CircleType
   active: boolean
-  bubbleContent: React.ComponentType
-  activeWithDot?: boolean
+  bubbleContent: React.ReactNode
+  activeContent?: React.ReactNode
+  inActiveContent?: React.ReactNode
+  withDot?: boolean
   onClick?: (e: MouseEvent) => void
   onBubbleClick?: (e: MouseEvent) => void
 }
@@ -29,15 +31,19 @@ export interface DotWithPopOverMarkerProps
 /**
  * 말풍선 텍스트 및 poi dot marker를 렌더링하기 위한 컴포넌트
  */
-
-export function PoiDotMarker({ ...props }: DotWithPopOverMarkerProps) {
-  return <DotWithPopOverMarker {...props} />
+export function PoiDotMarker({
+  children,
+  ...props
+}: PropsWithChildren<DotWithPopOverMarkerProps>) {
+  return <DotWithPopOverMarker {...props}>{children}</DotWithPopOverMarker>
 }
 
 function DotWithPopOverMarker({
   type,
   active,
-  activeWithDot,
+  withDot,
+  activeContent,
+  inActiveContent,
   bubbleContent,
   zIndex,
   onClick,
@@ -95,22 +101,23 @@ function DotWithPopOverMarker({
       ref={overlayViewRef}
       onLoad={handleLoad}
     >
-      {active ? (
-        <>
+      <>
+        {active ? (
           <BubbleMarker onClick={handleBubbleClick}>
             {bubbleContent}
           </BubbleMarker>
-          {activeWithDot && (
-            <DotMarker active={active} color={color} onClick={handleClick} />
-          )}
-        </>
-      ) : (
-        <>{children}</>
-      )}
+        ) : null}
 
-      {!active && !activeWithDot && (
-        <DotMarker active={active} color={color} onClick={handleClick} />
-      )}
+        {withDot ? (
+          <DotMarker active={active} color={color} onClick={handleClick}>
+            {children}
+          </DotMarker>
+        ) : null}
+
+        {active && activeContent ? activeContent : null}
+
+        {!active && inActiveContent ? inActiveContent : null}
+      </>
     </OverlayView>
   )
 }

--- a/packages/map/src/overlay/markers/primary-marker/circle-marker/circle-marker-base.tsx
+++ b/packages/map/src/overlay/markers/primary-marker/circle-marker/circle-marker-base.tsx
@@ -1,9 +1,6 @@
 import styled, { css, keyframes } from 'styled-components'
 import { Required } from 'utility-types'
 
-// tna 추가예정
-export type CircleType = 'attraction' | 'restaurant' | 'hotel'
-
 export interface MarkerBaseProps {
   /** 마커 사이즈, 단위 px */
   width?: number

--- a/packages/map/src/overlay/markers/primary-marker/circle-marker/circle-marker-base.tsx
+++ b/packages/map/src/overlay/markers/primary-marker/circle-marker/circle-marker-base.tsx
@@ -4,29 +4,6 @@ import { Required } from 'utility-types'
 // tna 추가예정
 export type CircleType = 'attraction' | 'restaurant' | 'hotel'
 
-/** 마커 종류의 따른 css 값 */
-export const CIRCLE_MARKER: {
-  [key in CircleType]: {
-    color: string
-    imageUrl: string
-  }
-} = {
-  attraction: {
-    color: 'var(--color-purple)',
-    imageUrl:
-      'https://assets.triple.guide/images/img-map-pin-attraction-on@3x.png',
-  },
-  restaurant: {
-    color: 'var(--color-vermilion)',
-    imageUrl:
-      'https://assets.triple.guide/images/img-map-pin-restaurant-on@3x.png',
-  },
-  hotel: {
-    color: 'var(--color-purple)',
-    imageUrl: 'https://assets.triple.guide/images/img-map-pin-hotel-on@3x.png',
-  },
-}
-
 export interface MarkerBaseProps {
   /** 마커 사이즈, 단위 px */
   width?: number

--- a/packages/map/src/overlay/markers/primary-marker/circle-marker/index.tsx
+++ b/packages/map/src/overlay/markers/primary-marker/circle-marker/index.tsx
@@ -1,12 +1,40 @@
 import React, { MouseEvent, PropsWithChildren, useCallback } from 'react'
 import { OverlayViewProps, OverlayView } from '@react-google-maps/api'
 
-import { Circle, CirclePin, MarkerBaseProps } from './circle-marker-base'
+import {
+  Circle,
+  CirclePin,
+  CircleType,
+  MarkerBaseProps,
+} from './circle-marker-base'
 
 export interface CircleMarkerProps
   extends MarkerBaseProps,
     Omit<OverlayViewProps, 'mapPaneName'> {
   onClick?: (e: MouseEvent) => void
+}
+
+/** 마커 종류의 따른 css 값 */
+export const CIRCLE_MARKER: {
+  [key in CircleType]: {
+    color: string
+    imageUrl: string
+  }
+} = {
+  attraction: {
+    color: 'var(--color-purple)',
+    imageUrl:
+      'https://assets.triple.guide/images/img-map-pin-attraction-on@3x.png',
+  },
+  restaurant: {
+    color: 'var(--color-vermilion)',
+    imageUrl:
+      'https://assets.triple.guide/images/img-map-pin-restaurant-on@3x.png',
+  },
+  hotel: {
+    color: 'var(--color-purple)',
+    imageUrl: 'https://assets.triple.guide/images/img-map-pin-hotel-on@3x.png',
+  },
 }
 
 export function CircleMarker({

--- a/packages/map/src/overlay/markers/primary-marker/circle-marker/index.tsx
+++ b/packages/map/src/overlay/markers/primary-marker/circle-marker/index.tsx
@@ -1,12 +1,10 @@
 import React, { MouseEvent, PropsWithChildren, useCallback } from 'react'
 import { OverlayViewProps, OverlayView } from '@react-google-maps/api'
 
-import {
-  Circle,
-  CirclePin,
-  CircleType,
-  MarkerBaseProps,
-} from './circle-marker-base'
+import { Circle, CirclePin, MarkerBaseProps } from './circle-marker-base'
+
+// tna 추가예정
+export type CircleType = 'attraction' | 'restaurant' | 'hotel'
 
 export interface CircleMarkerProps
   extends MarkerBaseProps,

--- a/packages/map/src/overlay/markers/primary-marker/dot-marker.tsx
+++ b/packages/map/src/overlay/markers/primary-marker/dot-marker.tsx
@@ -1,10 +1,10 @@
 import styled, { css } from 'styled-components'
-import React, { MouseEventHandler } from 'react'
+import React, { MouseEventHandler, PropsWithChildren } from 'react'
 
 interface DotMarkerProps {
   active: boolean
   color: string
-  onClick: MouseEventHandler<HTMLDivElement>
+  onClick?: MouseEventHandler<HTMLDivElement>
 }
 
 const BUBBLE_HEIGHT = 32
@@ -37,13 +37,19 @@ const DotCircle = styled.div<{ color?: string }>`
     padding-top: 4px;
   }
 `
+
 /**
  * Poi를 나타내는 작은 점 마커 컴포넌트
  */
-export function DotMarker({ active, color, onClick }: DotMarkerProps) {
+export function DotMarker({
+  active,
+  color,
+  onClick,
+  children,
+}: PropsWithChildren<DotMarkerProps>) {
   return (
     <DotMarkerContainer onClick={onClick} active={active}>
-      <DotCircle color={color} />
+      <DotCircle color={color}>{children}</DotCircle>
     </DotMarkerContainer>
   )
 }

--- a/packages/map/src/overlay/markers/primary-marker/dot-marker.tsx
+++ b/packages/map/src/overlay/markers/primary-marker/dot-marker.tsx
@@ -12,12 +12,12 @@ const BUBBLE_HEIGHT = 32
 
 const DotMarkerContainer = styled.div<Pick<DotMarkerProps, 'size' | 'active'>>`
   position: relative;
-  ${({ size: { width = 13, height = 13 } = {}, active }) =>
+  ${({ size: { width = 16, height = 16 } = {}, active }) =>
     css`
       left: -8px;
       top: -${8 + (active ? BUBBLE_HEIGHT : 0)}px;
-      width: ${width + 3 * 2}px;
-      height: ${height + 3 * 2}px;
+      width: ${width * 2}px;
+      height: ${height * 2}px;
       pointer-events: ${active ? 'none' : 'auto'};
     `}
 `
@@ -32,12 +32,15 @@ const DotCircle = styled.div<Pick<DotMarkerProps, 'size' | 'color'>>`
   left: 3px;
   top: 3px;
 
-  ${({ size: { width = 13, height = 13 } = {} }) =>
+  ${({ size: { width = 13, height = 13 } = {}, color }) =>
     css`
       width: ${width}px;
       height: ${height}px;
+      background-color: ${color};
     `}
-  background-color: ${({ color }) => color};
+  > svg {
+    padding-top: 4px;
+  }
 `
 
 /**

--- a/packages/map/src/overlay/markers/primary-marker/dot-marker.tsx
+++ b/packages/map/src/overlay/markers/primary-marker/dot-marker.tsx
@@ -4,24 +4,25 @@ import React, { MouseEventHandler, PropsWithChildren } from 'react'
 interface DotMarkerProps {
   active: boolean
   color: string
+  size?: { width: number; height: number }
   onClick?: MouseEventHandler<HTMLDivElement>
 }
 
 const BUBBLE_HEIGHT = 32
 
-const DotMarkerContainer = styled.div<{ active: boolean }>`
+const DotMarkerContainer = styled.div<Pick<DotMarkerProps, 'size' | 'active'>>`
   position: relative;
-  ${({ active }) =>
+  ${({ size: { width = 13, height = 13 } = {}, active }) =>
     css`
       left: -8px;
       top: -${8 + (active ? BUBBLE_HEIGHT : 0)}px;
-      width: 32px;
-      height: 32px;
+      width: ${width + 3 * 2}px;
+      height: ${height + 3 * 2}px;
       pointer-events: ${active ? 'none' : 'auto'};
     `}
 `
 
-const DotCircle = styled.div<{ color?: string }>`
+const DotCircle = styled.div<Pick<DotMarkerProps, 'size' | 'color'>>`
   position: absolute;
   z-index: 1;
   color: #fff;
@@ -30,12 +31,13 @@ const DotCircle = styled.div<{ color?: string }>`
   box-shadow: 0 2px 1px 0 rgba(0, 0, 0, 0.15);
   left: 3px;
   top: 3px;
-  width: 13px;
-  height: 13px;
+
+  ${({ size: { width = 13, height = 13 } = {} }) =>
+    css`
+      width: ${width}px;
+      height: ${height}px;
+    `}
   background-color: ${({ color }) => color};
-  > svg {
-    padding-top: 4px;
-  }
 `
 
 /**
@@ -43,13 +45,16 @@ const DotCircle = styled.div<{ color?: string }>`
  */
 export function DotMarker({
   active,
+  size,
   color,
   onClick,
   children,
 }: PropsWithChildren<DotMarkerProps>) {
   return (
-    <DotMarkerContainer onClick={onClick} active={active}>
-      <DotCircle color={color}>{children}</DotCircle>
+    <DotMarkerContainer size={size} onClick={onClick} active={active}>
+      <DotCircle size={size} color={color}>
+        {children}
+      </DotCircle>
     </DotMarkerContainer>
   )
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- 각 플젝에서 사용되는 `CircleMarkerType`, `CIRCLE_MARKER`를 export하여 사용가능하게 수정합니다.
-  `PoiDotMarker`에 props을 추가합니다 (dotSize, active/inActive Content, withDot)
- `coordinates`의 length가 0일때 bounds skip
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
