### PR TITLE
[triple email document] Migration에 필요한 Type을 내보내고, Color 표현을 수정합니다.

### DIFF
--- a/packages/triple-email-document/src/components/index.ts
+++ b/packages/triple-email-document/src/components/index.ts
@@ -1,2 +1,2 @@
 export { default as EmailFooter } from './footer'
-export { default as EmailPreview } from './preview'
+export { default as EmailPreview, PreviewDocument } from './preview'

--- a/packages/triple-email-document/src/elements/heading.tsx
+++ b/packages/triple-email-document/src/elements/heading.tsx
@@ -36,7 +36,7 @@ const H1Container = styled.h1`
   margin: 0;
   font-size: 21px;
   font-weight: bold;
-  color: var(--color-gray);
+  color: rgba(58, 58, 58, 1);
 `
 
 const HeadlineContainer = styled.p`
@@ -50,14 +50,14 @@ const H2Container = styled.h2`
   margin: 0;
   font-size: 19px;
   font-weight: 500;
-  color: var(--color-gray);
+  color: rgba(58, 58, 58, 1);
 `
 
 const H3Container = styled.h3`
   margin: 0;
   font-size: 16px;
   font-weight: bold;
-  color: var(--color-gray);
+  color: rgba(58, 58, 58, 1);
 `
 
 const H4Container = styled.h4`

--- a/packages/triple-email-document/src/elements/images.tsx
+++ b/packages/triple-email-document/src/elements/images.tsx
@@ -33,7 +33,7 @@ const ImageCaption = styled.div`
   font-size: 13px;
   font-weight: 500;
   text-align: center;
-  color: var(--color-gray700);
+  color: rgba(58, 58, 58, 0.7);
   white-space: pre-wrap;
 `
 

--- a/packages/triple-email-document/src/elements/link.tsx
+++ b/packages/triple-email-document/src/elements/link.tsx
@@ -23,8 +23,8 @@ const LinkStyled = styled.a`
   outline: none;
   cursor: pointer;
   border: 0;
-  color: var(--color-white);
-  background-color: var(--color-blue);
+  color: rgba(255, 255, 255, 1);
+  background-color: rgba(54, 143, 255, 1);
   float: none;
   border-radius: 21px;
 `

--- a/packages/triple-email-document/src/elements/note.tsx
+++ b/packages/triple-email-document/src/elements/note.tsx
@@ -30,11 +30,11 @@ const NoteTextStyled = styled.div`
 
 const TitleStyled = styled(NoteTextStyled)`
   font-weight: 700;
-  color: var(--color-gray);
+  color: rgba(58, 58, 58, 1);
 `
 
 const BodyStyled = styled(NoteTextStyled)`
-  color: var(--color-gray800);
+  color: rgba(58, 58, 58, 0.8);
 `
 
 export default function NoteView({

--- a/packages/triple-email-document/src/index.ts
+++ b/packages/triple-email-document/src/index.ts
@@ -3,6 +3,6 @@ import { TripleEmailDocument } from './triple-email-document'
 export { default as ELEMENTS } from './elements'
 export { TripleEmailElementData as TripleEmailDocumentElement } from './elements'
 export { ExtendedImageMeta, ImageDocument } from './elements/images'
-export { EmailFooter, EmailPreview } from './components'
+export { EmailFooter, EmailPreview, PreviewDocument } from './components'
 
 export default TripleEmailDocument

--- a/packages/triple-email-document/src/index.ts
+++ b/packages/triple-email-document/src/index.ts
@@ -2,6 +2,7 @@ import { TripleEmailDocument } from './triple-email-document'
 
 export { default as ELEMENTS } from './elements'
 export { TripleEmailElementData as TripleEmailDocumentElement } from './elements'
+export { ExtendedImageMeta, ImageDocument } from './elements/images'
 export { EmailFooter, EmailPreview } from './components'
 
 export default TripleEmailDocument


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

Type
- export PreviewDocument Type
- export Images Types

Color
- var(--color-gray) => rgba(58, 58, 58, 1)
  - email-admin은 @titicaca/core-elements의 GlobalStyle이 적용되어 있지 않으므로 rgba로 color를 표현합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
