### PR TITLE
[replies] 비로그인 상태일 때, 로그인 유도 모달 노출

### DIFF
--- a/packages/replies/src/auto-resizing-textarea.tsx
+++ b/packages/replies/src/auto-resizing-textarea.tsx
@@ -31,6 +31,7 @@ interface TextareaProps {
   value: string
   minRows: number
   maxRows: number
+  readOnly: boolean
   placeholder?: string
   onChange: (message: string) => void
 }
@@ -40,7 +41,7 @@ export interface TextAreaHandle {
 }
 
 function AutoResizingTextarea(
-  { value, minRows, maxRows, placeholder, onChange }: TextareaProps,
+  { value, minRows, maxRows, readOnly, placeholder, onChange }: TextareaProps,
   ref: ForwardedRef<TextAreaHandle>,
 ) {
   const [rows, setRows] = useState(minRows)
@@ -79,6 +80,7 @@ function AutoResizingTextarea(
       onChange={handleChange}
       lineHeight={TEXTAREA_LINE_HEIGHT}
       ref={textareaRef}
+      readOnly={readOnly}
     />
   )
 }

--- a/packages/replies/src/list/reply.tsx
+++ b/packages/replies/src/list/reply.tsx
@@ -9,12 +9,13 @@ import {
 } from '@titicaca/core-elements'
 import { formatTimestamp, findFoldedPosition } from '@titicaca/view-utilities'
 import { useAppCallback } from '@titicaca/ui-flow'
-import { TransitionType } from '@titicaca/modals'
+import { TransitionType, useLoginCtaModal } from '@titicaca/modals'
 import { ExternalLink, useNavigate } from '@titicaca/router'
 import {
   useUriHash,
   useHistoryFunctions,
   useIsomorphicNavigation,
+  useSessionAvailability,
 } from '@titicaca/react-contexts'
 import ActionSheet from '@titicaca/action-sheet'
 
@@ -93,14 +94,13 @@ export default function Reply({
   fetchMoreReplies: (reply?: ReplyType) => void
 }) {
   const [likeReaction, setLikeReactions] = useState(reactions.like)
-
   const { setEditingMessage } = useRepliesContext()
-
   const { push, back } = useHistoryFunctions()
-
   const { asyncBack } = useIsomorphicNavigation()
-
   const navigate = useNavigate()
+
+  const sessionAvailable = useSessionAvailability()
+  const { show: showLoginCta } = useLoginCtaModal()
 
   const handleMoreClick = useCallback(
     (id) => {
@@ -114,6 +114,11 @@ export default function Reply({
     mentioningUserUid,
     mentioningUserName,
   }: ReplyType['actionSpecifications']['reply']) => {
+    if (!sessionAvailable) {
+      showLoginCta()
+      return
+    }
+
     setEditingMessage({
       parentMessageId: toMessageId,
       content: {
@@ -174,6 +179,11 @@ export default function Reply({
   )
 
   const handleLikeReplyClick = async ({ messageId }: { messageId: string }) => {
+    if (!sessionAvailable) {
+      showLoginCta()
+      return
+    }
+
     await likeReply({ messageId })
 
     setLikeReactions((prev) => ({
@@ -187,6 +197,11 @@ export default function Reply({
   }: {
     messageId: string
   }) => {
+    if (!sessionAvailable) {
+      showLoginCta()
+      return
+    }
+
     await unlikeReply({ messageId })
 
     setLikeReactions((prev) => ({

--- a/packages/replies/src/register.test.tsx
+++ b/packages/replies/src/register.test.tsx
@@ -1,0 +1,59 @@
+import React, { PropsWithChildren } from 'react'
+import '@testing-library/jest-dom'
+import 'jest-styled-components'
+import { render } from '@testing-library/react'
+import { EnvProvider, SessionContextProvider } from '@titicaca/react-contexts'
+
+import { RepliesProvider } from './context'
+import Register from './register'
+
+describe('Reply 등록 버튼을 테스트합니다.', () => {
+  test('입력 창에 입력된 값이 없으면 버튼의 색상은 blue500 입니다.', () => {
+    const mockedOnReplyAdd = jest.fn()
+    const mockedOnReplyEdit = jest.fn()
+
+    const { getByRole } = render(
+      <Register
+        resourceId=""
+        resourceType="article"
+        onReplyAdd={mockedOnReplyAdd}
+        onReplyEdit={mockedOnReplyEdit}
+      />,
+      { wrapper: ReplyWithLoginWrapper },
+    )
+
+    const registerButtonElement = getByRole('button', { name: /등록/ })
+
+    expect(registerButtonElement).toHaveStyleRule(
+      'color',
+      'var(--color-blue500)',
+    )
+  })
+})
+
+function ReplyWithLoginWrapper({ children }: PropsWithChildren<unknown>) {
+  return (
+    <EnvProvider
+      appUrlScheme=""
+      webUrlBase=""
+      authBasePath="/"
+      facebookAppId=""
+      defaultPageTitle=""
+      defaultPageDescription=""
+      googleMapsApiKey=""
+      afOnelinkId=""
+      afOnelinkPid=""
+      afOnelinkSubdomain=""
+    >
+      <SessionContextProvider
+        type="browser"
+        props={{
+          initialUser: undefined,
+          initialSessionAvailability: true,
+        }}
+      >
+        <RepliesProvider>{children}</RepliesProvider>
+      </SessionContextProvider>
+    </EnvProvider>
+  )
+}

--- a/packages/replies/src/register.test.tsx
+++ b/packages/replies/src/register.test.tsx
@@ -8,7 +8,7 @@ import { RepliesProvider } from './context'
 import Register from './register'
 
 describe('Reply 등록 버튼을 테스트합니다.', () => {
-  test('입력 창에 입력된 값이 없으면 버튼의 색상은 blue500 입니다.', () => {
+  test('입력 창에 입력된 값이 없으면 버튼의 글자 색상은 blue500 입니다.', () => {
     const mockedOnReplyAdd = jest.fn()
     const mockedOnReplyEdit = jest.fn()
 
@@ -30,7 +30,7 @@ describe('Reply 등록 버튼을 테스트합니다.', () => {
     )
   })
 
-  test('입력 창에 입력된 값이 있으면 버튼의 색상은 blue 입니다.', async () => {
+  test('입력 창에 입력된 값이 있으면 버튼의 글자 색상은 blue 입니다.', async () => {
     const mockedOnReplyAdd = jest.fn()
     const mockedOnReplyEdit = jest.fn()
 

--- a/packages/replies/src/register.test.tsx
+++ b/packages/replies/src/register.test.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react'
+import { PropsWithChildren } from 'react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'
 import { render } from '@testing-library/react'

--- a/packages/replies/src/register.test.tsx
+++ b/packages/replies/src/register.test.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from 'react'
 import '@testing-library/jest-dom'
 import 'jest-styled-components'
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { EnvProvider, SessionContextProvider } from '@titicaca/react-contexts'
 
 import { RepliesProvider } from './context'
@@ -28,6 +28,29 @@ describe('Reply 등록 버튼을 테스트합니다.', () => {
       'color',
       'var(--color-blue500)',
     )
+  })
+
+  test('입력 창에 입력된 값이 있으면 버튼의 색상은 blue 입니다.', async () => {
+    const mockedOnReplyAdd = jest.fn()
+    const mockedOnReplyEdit = jest.fn()
+
+    const { getByRole } = render(
+      <Register
+        resourceId=""
+        resourceType="article"
+        onReplyAdd={mockedOnReplyAdd}
+        onReplyEdit={mockedOnReplyEdit}
+      />,
+      { wrapper: ReplyWithLoginWrapper },
+    )
+
+    const textareaElement = getByRole('textbox')
+
+    fireEvent.change(textareaElement, { target: { value: 'Hi' } })
+
+    const registerButtonElement = getByRole('button', { name: /등록/ })
+
+    expect(registerButtonElement).toHaveStyleRule('color', 'var(--color-blue)')
   })
 })
 

--- a/packages/replies/src/register.tsx
+++ b/packages/replies/src/register.tsx
@@ -9,7 +9,7 @@ import AutoResizingTextarea, { TextAreaHandle } from './auto-resizing-textarea'
 import { useRepliesContext } from './context'
 import { ResourceType, Reply } from './types'
 
-const RegisterButton = styled.button`
+const RegisterButton = styled.button<{ active: boolean }>`
   width: 26px;
   padding: 0;
   margin-left: 20px;
@@ -17,7 +17,7 @@ const RegisterButton = styled.button`
   font-size: 15px;
   font-weight: bold;
   color: ${(props) =>
-    props.disabled ? 'var(--color-blue500)' : 'var(--color-blue)'};
+    props.active ? 'var(--color-blue500)' : 'var(--color-blue)'};
   background: inherit;
   border: none;
   outline: none;
@@ -49,7 +49,6 @@ function Register(
   } = useRepliesContext()
 
   const sessionAvailable = useSessionAvailability()
-
   const { show: showLoginCta } = useLoginCtaModal()
 
   const handleRegister = async () => {
@@ -110,7 +109,7 @@ function Register(
           onClick={() => {
             handleRegister()
           }}
-          disabled={!plaintext}
+          active={!plaintext}
         >
           등록
         </RegisterButton>

--- a/packages/replies/src/register.tsx
+++ b/packages/replies/src/register.tsx
@@ -3,13 +3,14 @@ import styled from 'styled-components'
 import { Container, FlexBox, HR1 } from '@titicaca/core-elements'
 import { useLoginCtaModal } from '@titicaca/modals'
 import { useSessionAvailability } from '@titicaca/react-contexts'
+import { useSessionCallback } from '@titicaca/ui-flow'
 
 import { authorMessage } from './replies-api-clients'
 import AutoResizingTextarea, { TextAreaHandle } from './auto-resizing-textarea'
 import { useRepliesContext } from './context'
 import { ResourceType, Reply } from './types'
 
-const RegisterButton = styled.button<{ active: boolean }>`
+const RegisterButton = styled.button<{ disabled: boolean }>`
   width: 26px;
   padding: 0;
   margin-left: 20px;
@@ -17,7 +18,7 @@ const RegisterButton = styled.button<{ active: boolean }>`
   font-size: 15px;
   font-weight: bold;
   color: ${(props) =>
-    props.active ? 'var(--color-blue500)' : 'var(--color-blue)'};
+    props.disabled ? 'var(--color-blue500)' : 'var(--color-blue)'};
   background: inherit;
   border: none;
   outline: none;
@@ -51,12 +52,7 @@ function Register(
   const sessionAvailable = useSessionAvailability()
   const { show: showLoginCta } = useLoginCtaModal()
 
-  const handleRegister = async () => {
-    if (!sessionAvailable) {
-      showLoginCta()
-      return
-    }
-
+  const handleRegister = useSessionCallback(async () => {
     if (!plaintext) {
       return
     }
@@ -79,7 +75,7 @@ function Register(
     initializeEditingMessage()
 
     handleContentChange('')
-  }
+  })
 
   return (
     <Container
@@ -109,7 +105,7 @@ function Register(
           onClick={() => {
             handleRegister()
           }}
-          active={!plaintext}
+          disabled={!plaintext}
         >
           등록
         </RegisterButton>

--- a/packages/replies/src/register.tsx
+++ b/packages/replies/src/register.tsx
@@ -1,6 +1,8 @@
 import { ForwardedRef, forwardRef } from 'react'
 import styled from 'styled-components'
 import { Container, FlexBox, HR1 } from '@titicaca/core-elements'
+import { useLoginCtaModal } from '@titicaca/modals'
+import { useSessionAvailability } from '@titicaca/react-contexts'
 
 import { authorMessage } from './replies-api-clients'
 import AutoResizingTextarea, { TextAreaHandle } from './auto-resizing-textarea'
@@ -46,7 +48,16 @@ function Register(
     handleContentChange,
   } = useRepliesContext()
 
+  const sessionAvailable = useSessionAvailability()
+
+  const { show: showLoginCta } = useLoginCtaModal()
+
   const handleRegister = async () => {
+    if (!sessionAvailable) {
+      showLoginCta()
+      return
+    }
+
     if (!plaintext) {
       return
     }
@@ -72,7 +83,10 @@ function Register(
   }
 
   return (
-    <Container cursor="pointer">
+    <Container
+      cursor="pointer"
+      onClick={!sessionAvailable ? () => showLoginCta() : undefined}
+    >
       <HR1 margin={{ top: 0 }} />
 
       <FlexBox
@@ -89,6 +103,7 @@ function Register(
           value={plaintext || ''}
           onChange={handleContentChange}
           ref={ref}
+          readOnly={!sessionAvailable}
         />
 
         <RegisterButton

--- a/packages/replies/src/register.tsx
+++ b/packages/replies/src/register.tsx
@@ -10,7 +10,7 @@ import AutoResizingTextarea, { TextAreaHandle } from './auto-resizing-textarea'
 import { useRepliesContext } from './context'
 import { ResourceType, Reply } from './types'
 
-const RegisterButton = styled.button<{ disabled: boolean }>`
+const RegisterButton = styled.button<{ active: boolean }>`
   width: 26px;
   padding: 0;
   margin-left: 20px;
@@ -18,7 +18,7 @@ const RegisterButton = styled.button<{ disabled: boolean }>`
   font-size: 15px;
   font-weight: bold;
   color: ${(props) =>
-    props.disabled ? 'var(--color-blue500)' : 'var(--color-blue)'};
+    props.active ? 'var(--color-blue)' : 'var(--color-blue500)'};
   background: inherit;
   border: none;
   outline: none;
@@ -105,7 +105,7 @@ function Register(
           onClick={() => {
             handleRegister()
           }}
-          disabled={!plaintext}
+          active={!!plaintext}
         >
           등록
         </RegisterButton>

--- a/packages/replies/src/reply.test.tsx
+++ b/packages/replies/src/reply.test.tsx
@@ -65,7 +65,7 @@ describe('리액션 관련 기능을 테스트합니다.', () => {
           focusInput={onFocusInput}
           fetchMoreReplies={fetchMoreReplies}
         />,
-        { wrapper: ReplyWrapper },
+        { wrapper: ReplyWithLoginWrapper },
       )
 
       const likeCountElement = queryByText(/좋아요/)
@@ -91,7 +91,7 @@ describe('리액션 관련 기능을 테스트합니다.', () => {
           focusInput={onFocusInput}
           fetchMoreReplies={fetchMoreReplies}
         />,
-        { wrapper: ReplyWrapper },
+        { wrapper: ReplyWithLoginWrapper },
       )
 
       const likeCountElement = queryByText(/좋아요/)
@@ -117,7 +117,7 @@ describe('리액션 관련 기능을 테스트합니다.', () => {
           focusInput={onFocusInput}
           fetchMoreReplies={fetchMoreReplies}
         />,
-        { wrapper: ReplyWrapper },
+        { wrapper: ReplyWithLoginWrapper },
       )
 
       const likeCountElement = queryByText(/좋아요/)
@@ -128,7 +128,7 @@ describe('리액션 관련 기능을 테스트합니다.', () => {
     })
   })
 
-  describe('사용자의 좋아요 클릭 액션을 테스트합니다.', () => {
+  describe('로그인한 사용자의 좋아요 클릭 액션을 테스트합니다.', () => {
     test('좋아요를 클릭했던 사용자가 다시 클릭하면, 좋아요 갯수를 -1 합니다.', async () => {
       const reply = generateMockReply({
         reactions: {
@@ -145,7 +145,7 @@ describe('리액션 관련 기능을 테스트합니다.', () => {
           focusInput={onFocusInput}
           fetchMoreReplies={fetchMoreReplies}
         />,
-        { wrapper: ReplyWrapper },
+        { wrapper: ReplyWithLoginWrapper },
       )
 
       const unlikeButtonElement = getByRole('button', {
@@ -179,7 +179,7 @@ describe('리액션 관련 기능을 테스트합니다.', () => {
           focusInput={onFocusInput}
           fetchMoreReplies={fetchMoreReplies}
         />,
-        { wrapper: ReplyWrapper },
+        { wrapper: ReplyWithLoginWrapper },
       )
 
       const likeButtonElement = getByRole('button', {
@@ -203,7 +203,7 @@ function generateMockReply(reactions: Pick<ReplyType, 'reactions'>) {
   return { ...MOCKED_REPLY, ...reactions }
 }
 
-function ReplyWrapper({ children }: PropsWithChildren<unknown>) {
+function ReplyWithLoginWrapper({ children }: PropsWithChildren<unknown>) {
   return (
     <EnvProvider
       appUrlScheme=""
@@ -221,7 +221,7 @@ function ReplyWrapper({ children }: PropsWithChildren<unknown>) {
         type="browser"
         props={{
           initialUser: undefined,
-          initialSessionAvailability: false,
+          initialSessionAvailability: true,
         }}
       >
         <RepliesProvider>{children}</RepliesProvider>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
비로그인 상태일 때 처리하는 로직이 없어서, 사용자가 등록을 눌러도 아무 반응이 없는 오류가 있습니다.
비로그인 상태일 때에는 로그인 유도 모달을 노출하도록 합니다.

로그인 유도 모달이 들어가는 기능
- 좋아요 반응
- 댓글 달기
- 답글 달기

[매거진에 댓글달기 테스트 시트 9번](https://docs.google.com/spreadsheets/d/1kzWfbAFQookK-sqi4OnpiAUHx0jKgQyR5X99y2DWPgU/edit#gid=195797161)

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->


## 스크린샷 & URL
![image](https://user-images.githubusercontent.com/38130934/154008967-5e829165-a63e-426a-86be-baecc59ec31a.png)

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
