### PR TITLE
Triple Fallback Action 패키지 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43588,6 +43588,7 @@
         "@titicaca/color-palette": "^6.2.1",
         "@titicaca/content-utilities": "4.12.0",
         "@titicaca/intersection-observer": "^6.2.1",
+        "@titicaca/triple-fallback-action": "^6.2.1",
         "@titicaca/view-utilities": "^6.2.1",
         "react-input-mask": "^2.0.4",
         "react-transition-group": "^4.4.1"
@@ -58058,6 +58059,7 @@
         "@titicaca/color-palette": "^6.2.1",
         "@titicaca/content-utilities": "4.12.0",
         "@titicaca/intersection-observer": "^6.2.1",
+        "@titicaca/triple-fallback-action": "^6.2.1",
         "@titicaca/view-utilities": "^6.2.1",
         "react-input-mask": "^2.0.4",
         "react-transition-group": "^4.4.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20033,6 +20033,10 @@
       "resolved": "packages/triple-email-document",
       "link": true
     },
+    "node_modules/@titicaca/triple-fallback-action": {
+      "resolved": "packages/triple-fallback-action",
+      "link": true
+    },
     "node_modules/@titicaca/triple-frontend-docs": {
       "resolved": "docs",
       "link": true
@@ -44243,6 +44247,11 @@
         "@titicaca/type-definitions": "^6.2.1"
       }
     },
+    "packages/triple-fallback-action": {
+      "name": "@titicaca/triple-fallback-action",
+      "version": "6.2.1",
+      "license": "MIT"
+    },
     "packages/triple-media": {
       "name": "@titicaca/triple-media",
       "version": "6.2.1",
@@ -58529,6 +58538,9 @@
         "@titicaca/core-elements": "^6.2.1",
         "@titicaca/type-definitions": "^6.2.1"
       }
+    },
+    "@titicaca/triple-fallback-action": {
+      "version": "file:packages/triple-fallback-action"
     },
     "@titicaca/triple-frontend-docs": {
       "version": "file:docs",

--- a/packages/core-elements/package.json
+++ b/packages/core-elements/package.json
@@ -25,6 +25,7 @@
     "@titicaca/color-palette": "^6.2.1",
     "@titicaca/content-utilities": "4.12.0",
     "@titicaca/intersection-observer": "^6.2.1",
+    "@titicaca/triple-fallback-action": "^6.2.1",
     "@titicaca/view-utilities": "^6.2.1",
     "react-input-mask": "^2.0.4",
     "react-transition-group": "^4.4.1"

--- a/packages/core-elements/src/constants.ts
+++ b/packages/core-elements/src/constants.ts
@@ -1,1 +1,0 @@
-export const FALLBACK_ACTION_CLASS_NAME = '-triple-fallback-action'

--- a/packages/core-elements/src/elements/navbar.tsx
+++ b/packages/core-elements/src/elements/navbar.tsx
@@ -9,8 +9,8 @@ import {
   ReactNode,
   HTMLAttributes,
 } from 'react'
+import { TRIPLE_FALLBACK_ACTION_CLASS_NAME } from '@titicaca/triple-fallback-action'
 
-import { FALLBACK_ACTION_CLASS_NAME } from '../constants'
 import { layeringMixin, LayeringMixinProps, paddingMixin } from '../mixins'
 import { unit } from '../utils/unit'
 import { MarginPadding } from '../commons'
@@ -132,7 +132,7 @@ interface NavbarItemProps {
 
 const NavbarItem = styled.div.attrs<NavbarItemProps>(({ icon }) => ({
   className: ['back', 'close'].includes(icon || '')
-    ? FALLBACK_ACTION_CLASS_NAME
+    ? TRIPLE_FALLBACK_ACTION_CLASS_NAME
     : '',
 }))<NavbarItemProps>`
   ${({ position }) => position && `position: ${position};`}

--- a/packages/core-elements/src/elements/spinner/rolling-spinner.tsx
+++ b/packages/core-elements/src/elements/spinner/rolling-spinner.tsx
@@ -1,7 +1,7 @@
+import { TRIPLE_FALLBACK_ACTION_CLASS_NAME } from '@titicaca/triple-fallback-action'
 import { useMemo, PropsWithChildren } from 'react'
 import styled, { keyframes } from 'styled-components'
 
-import { FALLBACK_ACTION_CLASS_NAME } from '../../constants'
 import { layeringMixin, LayeringMixinProps } from '../../mixins'
 import Container from '../container'
 
@@ -148,7 +148,7 @@ export default function RollingSpinner({
 
   return (
     <RollingSpinnerFrame
-      className={FALLBACK_ACTION_CLASS_NAME}
+      className={TRIPLE_FALLBACK_ACTION_CLASS_NAME}
       zTier={zTier}
       zIndex={zIndex}
     >

--- a/packages/core-elements/src/elements/spinner/spinner.tsx
+++ b/packages/core-elements/src/elements/spinner/spinner.tsx
@@ -1,6 +1,6 @@
+import { TRIPLE_FALLBACK_ACTION_CLASS_NAME } from '@titicaca/triple-fallback-action'
 import styled, { css, keyframes } from 'styled-components'
 
-import { FALLBACK_ACTION_CLASS_NAME } from '../../constants'
 import { layeringMixin, LayeringMixinProps } from '../../mixins'
 
 const loadingAnimation = keyframes`
@@ -52,7 +52,7 @@ export default function Spinner({
 } & LayeringMixinProps) {
   return (
     <Container full={full} zTier={zTier} zIndex={zIndex}>
-      <Wrapper className={FALLBACK_ACTION_CLASS_NAME}>
+      <Wrapper className={TRIPLE_FALLBACK_ACTION_CLASS_NAME}>
         <Icon />
         {children}
       </Wrapper>

--- a/packages/core-elements/tsconfig.build.json
+++ b/packages/core-elements/tsconfig.build.json
@@ -9,6 +9,9 @@
       "path": "../intersection-observer/tsconfig.build.json"
     },
     {
+      "path": "../triple-fallback-action/tsconfig.build.json"
+    },
+    {
       "path": "../view-utilities/tsconfig.build.json"
     }
   ]

--- a/packages/core-elements/tsconfig.json
+++ b/packages/core-elements/tsconfig.json
@@ -7,6 +7,7 @@
     "paths": {
       "@titicaca/color-palette": ["../color-palette/src"],
       "@titicaca/intersection-observer": ["../intersection-observer/src"],
+      "@titicaca/triple-fallback-action": ["../triple-fallback-action/src"],
       "@titicaca/view-utilities": ["../view-utilities/src"]
     }
   },
@@ -17,6 +18,9 @@
     },
     {
       "path": "../intersection-observer"
+    },
+    {
+      "path": "../triple-fallback-action"
     },
     {
       "path": "../view-utilities"

--- a/packages/triple-fallback-action/README.md
+++ b/packages/triple-fallback-action/README.md
@@ -1,0 +1,64 @@
+# `@titicaca/triple-fallback-action`
+
+HTML 페이지는 로드했으나 Javascript 파일을 로드하지 못했을 때 페이지를 벗어나는 기능을 제공합니다.
+
+## 작동 원리
+
+특정 클래스의 엘리먼트를 클릭했을 때 페이지를 닫거나 뒤로 가기하는 스크립트가 있습니다.
+이 스크립트를 서버에서 페이지를 만들 때 HTML 문서에 인라인 시킵니다.
+따라서, JS 애셋을 로드하지 못했더라도 특정 클래스의 엘리먼트를 클릭하면 페이지를 닫거나 뒤로 갈 수 있습니다.
+이 특정 클래스는 뒤로 가기 버튼이나, 화면 전체를 덮는 요소에 추가합니다.
+
+## 적용 방법
+
+`pages/_document.tsx`에 다음 코드를 추가하세요.
+
+<!-- prettier-ignore-start -->
+```tsx
+import { TripleFallbackActionScript } from '@titicaca/triple-fallback-action'
+
+// class MyDocument extends Document {
+  // public render() {
+    // return (
+      // <body>
+        // ...
+        <TripleFallbackActionScript />
+      // </body>
+    // )
+  // }
+// }
+```
+<!-- prettier-ignore-end -->
+
+`pages/_app.tsx`에 다음 코드를 추가하세요.
+
+<!-- prettier-ignore-start -->
+```ts
+import { useTripleFallbackActionRemover } from '@titicaca/triple-fallback-action'
+
+// function MyApp() {
+  // ...
+
+  useTripleFallbackActionRemover()
+
+  // ...
+// }
+```
+<!-- prettier-ignore-end -->
+
+`MyApp`이 클래스 컴포넌트라면 컴포넌트를 추가하세요.
+
+<!-- prettier-ignore-start -->
+```tsx
+import { TripleFallbackActionRemover } from '@titicaca/triple-fallback-action'
+
+// class MyApp extends App {
+  // public render() {
+    // return (
+      // ...
+      <TripleFallbackActionRemover />
+    // )
+  // }
+// }
+```
+<!-- prettier-ignore-end -->

--- a/packages/triple-fallback-action/package.json
+++ b/packages/triple-fallback-action/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@titicaca/triple-fallback-action",
+  "version": "6.2.1",
+  "description": "Escape hatch for Javascript file loading failure in web pages",
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/triple-fallback-action",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/titicacadev/triple-frontend.git"
+  },
+  "bugs": {
+    "url": "https://github.com/titicacadev/triple-frontend/issues"
+  },
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ]
+}

--- a/packages/triple-fallback-action/src/index.test.tsx
+++ b/packages/triple-fallback-action/src/index.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { ReactElement } from 'react'
+
+import {
+  TripleFallbackActionRemover,
+  TripleFallbackActionScript,
+  TRIPLE_FALLBACK_ACTION_CLASS_NAME,
+} from '.'
+
+const back = jest.spyOn(history, 'back')
+
+afterEach(() => {
+  back.mockClear()
+})
+
+test('Fallback Action 클래스를 가진 요소를 클릭하면 페이지를 닫습니다.', () => {
+  renderScriptTag(<TripleFallbackActionScript />)
+
+  const { getByText } = render(
+    <button className={TRIPLE_FALLBACK_ACTION_CLASS_NAME}>클릭</button>,
+  )
+
+  const button = getByText('클릭')
+
+  fireEvent.click(button)
+
+  expect(back).toBeCalled()
+})
+
+test('핸들러를 제거하는 컴포넌트를 함께 렌더링하면 페이지를 닫지 않습니다.', async () => {
+  renderScriptTag(<TripleFallbackActionScript />)
+
+  const { getByText } = render(
+    <>
+      <button className={TRIPLE_FALLBACK_ACTION_CLASS_NAME}>클릭</button>
+      <TripleFallbackActionRemover />
+    </>,
+  )
+
+  const button = getByText('클릭')
+
+  await waitFor(() => expect(window.__DISASTER_FALLBACK_HANDLER__).toBe(null))
+
+  fireEvent.click(button)
+
+  expect(back).not.toBeCalled()
+})
+
+function renderScriptTag(el: ReactElement) {
+  const scriptContainer = document.createElement('div')
+  scriptContainer.innerHTML = renderToStaticMarkup(el)
+  const script = document.createElement('script')
+  script.innerHTML = scriptContainer.getElementsByTagName('script')[0].innerHTML
+  document.body.appendChild(script)
+}

--- a/packages/triple-fallback-action/src/index.tsx
+++ b/packages/triple-fallback-action/src/index.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect } from 'react'
 
-const FALLBACK_HANDLER_KEY = '__DISTASTER_FALLBACK_HANDLER__'
+const FALLBACK_HANDLER_KEY = '__DISASTER_FALLBACK_HANDLER__'
 
 declare global {
   interface Window {

--- a/packages/triple-fallback-action/src/index.tsx
+++ b/packages/triple-fallback-action/src/index.tsx
@@ -16,7 +16,7 @@ export function TripleFallbackActionScript() {
       dangerouslySetInnerHTML={{
         __html: `
           if (!window.${FALLBACK_HANDLER_KEY}) {
-            window.__DISASTER_FALLBACK_HANDLER__ = function (e) {
+            window.${FALLBACK_HANDLER_KEY} = function (e) {
               if (e.target.className.indexOf('${TRIPLE_FALLBACK_ACTION_CLASS_NAME}') > -1) {
                 try {
                   if (typeof Soto !== 'undefined' && Soto !== null) {

--- a/packages/triple-fallback-action/src/index.tsx
+++ b/packages/triple-fallback-action/src/index.tsx
@@ -1,0 +1,74 @@
+import { useLayoutEffect } from 'react'
+
+const FALLBACK_HANDLER_KEY = '__DISTASTER_FALLBACK_HANDLER__'
+
+declare global {
+  interface Window {
+    [FALLBACK_HANDLER_KEY]: ((e: MouseEvent) => void) | null
+  }
+}
+
+export const TRIPLE_FALLBACK_ACTION_CLASS_NAME = '-triple-fallback-action'
+
+export function TripleFallbackActionScript() {
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `
+          if (!window.${FALLBACK_HANDLER_KEY}) {
+            window.__DISASTER_FALLBACK_HANDLER__ = function (e) {
+              if (e.target.className.indexOf('${TRIPLE_FALLBACK_ACTION_CLASS_NAME}') > -1) {
+                try {
+                  if (typeof Soto !== 'undefined' && Soto !== null) {
+                    Soto.postMessage(JSON.stringify({ command: 'backOrClose' }))
+                  } else if (typeof window !== 'undefined' &&
+                    typeof window.webkit !== 'undefined' &&
+                    window.webkit !== null &&
+                    window.webkit.messageHandlers &&
+                    window.webkit.messageHandlers.Soto) {
+
+                    window.webkit.messageHandlers.Soto.postMessage({ command: 'backOrClose' })
+                  } else {
+                    history.back()
+                  }
+                } catch (e) {
+                  /* do nothing */
+                }
+              }
+            }
+
+            document.body.addEventListener('click', window.${FALLBACK_HANDLER_KEY})
+          }
+        `,
+      }}
+    />
+  )
+}
+
+export function useTripleFallbackActionRemover() {
+  useLayoutEffect(() => {
+    removeDisasterFallback()
+  }, [])
+}
+
+export function TripleFallbackActionRemover() {
+  useTripleFallbackActionRemover()
+
+  return null
+}
+
+function removeDisasterFallback() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const fallbackHandler = window[FALLBACK_HANDLER_KEY]
+
+  if (!fallbackHandler) {
+    return
+  }
+
+  document.body.removeEventListener('click', fallbackHandler)
+
+  window[FALLBACK_HANDLER_KEY] = null
+}

--- a/packages/triple-fallback-action/tsconfig.build.json
+++ b/packages/triple-fallback-action/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "lib", "**/*.test.*", "**/*.spec.*"]
+}

--- a/packages/triple-fallback-action/tsconfig.json
+++ b/packages/triple-fallback-action/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {}
+  },
+  "include": ["./src"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -58,6 +58,7 @@
       "@titicaca/style-box": ["style-box/src"],
       "@titicaca/triple-document": ["triple-document/src"],
       "@titicaca/triple-email-document": ["triple-email-document/src"],
+      "@titicaca/triple-fallback-action": ["triple-fallback-action/src"],
       "@titicaca/triple-media": ["triple-media/src"],
       "@titicaca/type-definitions": ["type-definitions/src"],
       "@titicaca/ui-flow": ["ui-flow/src"],


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

[애셋 로드에 실패했을 때 페이지를 벗어날 수 있는 기능](https://github.com/titicacadev/triple-content-web/pull/498)을 공통 모듈로 추출합니다.

클릭 대상의 클래스 이름, 스크립트를 추가하는 컴포넌트, 핸들러를 제거하는 훅과 컴포넌트를 제공합니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- `@titicaca/triple-fallback-action` 패키지 추가
- `@tititcaca/core-elements`에 `@titicaca/triple-fallback-action`을 의존성으로 추가