### PR TITLE
[standard-action-handler] 새창열기 기능 추가

### DIFF
--- a/packages/standard-action-handler/README.md
+++ b/packages/standard-action-handler/README.md
@@ -31,6 +31,7 @@
   - parameter
     - { path }
 - ### `/web-action/copy-to-clipboard`
+
   - 텍스트를 클립보드에 복사합니다.
   - parameter
     - { path, query }

--- a/packages/standard-action-handler/README.md
+++ b/packages/standard-action-handler/README.md
@@ -31,7 +31,6 @@
   - parameter
     - { path }
 - ### `/web-action/copy-to-clipboard`
-
   - 텍스트를 클립보드에 복사합니다.
   - parameter
     - { path, query }

--- a/packages/standard-action-handler/README.md
+++ b/packages/standard-action-handler/README.md
@@ -31,10 +31,17 @@
   - parameter
     - { path }
 - ### `/web-action/copy-to-clipboard`
+
   - 텍스트를 클립보드에 복사합니다.
   - parameter
     - { path, query }
       - query : text=[복사할 텍스트]
+
+- ### `/web-action/new-window`
+  - href를 새 창에서 엽니다.
+  - parameter
+    - {path, query}
+      - query : href=[이동할 URL]
 
 ### How to make URL
 
@@ -71,10 +78,19 @@ ContextOptions: {
       rawHref: string,
       parmas?: NavigateOptions
      ) => string | undefined | void
+    /** new-window action에서 사용할 routeExternally */
+    routeExternally?: ({
+      href, target,
+     }: {
+      href: string
+      target: TargetType
+     }) => void
   }
 ```
 
 initialize의 parameter로 사용되는 `navigate`는 실행되는 환경과 세션 등을 고려하여 전달받은 URL(rawHref)로 이동하는 역할을 합니다.
+
+ContextOptions 중 하나인 `routeExternally`는 이동하고자 하는 URL을 새 창으로 열 때 사용합니다. 새 창 열기 기능을 위한 함수이기 때문에 `target` parameter는 `'current' | 'new' | 'browser'` 중 `'new'`로 지정되어 있습니다.
 
 ### execute(url, params)
 
@@ -102,10 +118,12 @@ initialize 메소드에서 return된 execute 함수를 사용합니다.
 ```
 import { useHistoryFunctions } from '@titicaca/react-contexts'
 import { initialize } from '@titicaca/standard-action-handler'
+improt { useExternalRouter } from '@titicaca/router'
 
 const { navigate } = useHistoryFunctions()
+const routeExternally = useExternalRouter()
 
-const handleStandardActions = initialize({ navigate })
+const handleStandardActions = initialize({ navigate, routeExternally })
 
 handleStandardActions(href, {})
 

--- a/packages/standard-action-handler/README.md
+++ b/packages/standard-action-handler/README.md
@@ -31,12 +31,10 @@
   - parameter
     - { path }
 - ### `/web-action/copy-to-clipboard`
-
   - 텍스트를 클립보드에 복사합니다.
   - parameter
     - { path, query }
       - query : text=[복사할 텍스트]
-
 - ### `/web-action/new-window`
   - href를 새 창에서 엽니다.
   - parameter
@@ -77,14 +75,14 @@ ContextOptions: {
     navigate: (
       rawHref: string,
       parmas?: NavigateOptions
-     ) => string | undefined | void
+    ) => string | undefined | void
     /** new-window action에서 사용할 routeExternally */
     routeExternally?: ({
       href, target,
-     }: {
+    }: {
       href: string
       target: TargetType
-     }) => void
+    }) => void
   }
 ```
 

--- a/packages/standard-action-handler/src/index.ts
+++ b/packages/standard-action-handler/src/index.ts
@@ -5,11 +5,20 @@ import showToast from './show-toast'
 import fetchApi from './fetch-api'
 import share from './share'
 import copyToClipboard from './copy-to-clipboard'
+import newWindow from './new-window'
 import { ContextOptions } from './types'
 
 export function initialize(options: ContextOptions) {
   const handler = new Handler({
-    handlers: [serial, invokeCta, showToast, fetchApi, share, copyToClipboard],
+    handlers: [
+      serial,
+      invokeCta,
+      showToast,
+      fetchApi,
+      share,
+      copyToClipboard,
+      newWindow,
+    ],
     options,
   })
 

--- a/packages/standard-action-handler/src/new-window.test.ts
+++ b/packages/standard-action-handler/src/new-window.test.ts
@@ -1,0 +1,18 @@
+import newWindow from './new-window'
+
+test('새창열기 기능을 테스트합니다', () => {
+  const href = 'https://triple.guide/'
+  const routeExternally = jest.fn()
+
+  const navigate = () => {}
+
+  newWindow(
+    {
+      path: '/web-action/new-window',
+      query: `href=${encodeURIComponent(href)}`,
+    },
+    { navigate, routeExternally },
+  )
+  expect(routeExternally.mock.calls[0][0].href).toBe(href)
+  expect(routeExternally.mock.calls[0][0].target).toBe('new')
+})

--- a/packages/standard-action-handler/src/new-window.test.ts
+++ b/packages/standard-action-handler/src/new-window.test.ts
@@ -13,6 +13,6 @@ test('새창열기 기능을 테스트합니다', () => {
     },
     { navigate, routeExternally },
   )
-  expect(routeExternally.mock.calls[0][0].href).toBe(href)
-  expect(routeExternally.mock.calls[0][0].target).toBe('new')
+
+  expect(routeExternally).toHaveBeenCalledWith({ href, target: 'new' })
 })

--- a/packages/standard-action-handler/src/new-window.ts
+++ b/packages/standard-action-handler/src/new-window.ts
@@ -1,7 +1,6 @@
 import { ContextOptions } from '@titicaca/standard-action-handler/src/types'
 import qs from 'qs'
 
-import { TargetType } from './types'
 import { UrlElements } from './../../view-utilities/src/url'
 
 export default async function newWindow(
@@ -9,12 +8,11 @@ export default async function newWindow(
   { routeExternally }: ContextOptions,
 ) {
   if (path === '/web-action/new-window' && query) {
-    const { href, target } = qs.parse(query) as {
+    const { href } = qs.parse(query) as {
       href?: string
-      target?: TargetType
     }
-    if (href && target && routeExternally) {
-      routeExternally({ href, target })
+    if (href && routeExternally) {
+      routeExternally({ href, target: 'new' })
       return true
     }
   }

--- a/packages/standard-action-handler/src/new-window.ts
+++ b/packages/standard-action-handler/src/new-window.ts
@@ -1,0 +1,22 @@
+import { ContextOptions } from '@titicaca/standard-action-handler/src/types'
+import qs from 'qs'
+
+import { TargetType } from './types'
+import { UrlElements } from './../../view-utilities/src/url'
+
+export default async function newWindow(
+  { path, query }: UrlElements,
+  { routeExternally }: ContextOptions,
+) {
+  if (path === '/web-action/new-window' && query) {
+    const { href, target } = qs.parse(query) as {
+      href?: string
+      target?: TargetType
+    }
+    if (href && target && routeExternally) {
+      routeExternally({ href, target })
+      return true
+    }
+  }
+  return false
+}

--- a/packages/standard-action-handler/src/new-window.ts
+++ b/packages/standard-action-handler/src/new-window.ts
@@ -1,7 +1,7 @@
-import { ContextOptions } from '@titicaca/standard-action-handler/src/types'
 import qs from 'qs'
+import { UrlElements } from '@titicaca/view-utilities/src/url'
 
-import { UrlElements } from './../../view-utilities/src/url'
+import { ContextOptions } from './types'
 
 export default async function newWindow(
   { path, query }: UrlElements,

--- a/packages/standard-action-handler/src/types.ts
+++ b/packages/standard-action-handler/src/types.ts
@@ -6,7 +6,7 @@ export interface NavigateOptions {
   [key: string]: unknown
 }
 
-export type TargetType = 'current' | 'new' | 'browser'
+type TargetType = 'current' | 'new' | 'browser'
 
 export interface ContextOptions {
   cta?: string

--- a/packages/standard-action-handler/src/types.ts
+++ b/packages/standard-action-handler/src/types.ts
@@ -6,12 +6,21 @@ export interface NavigateOptions {
   [key: string]: unknown
 }
 
+export type TargetType = 'current' | 'new' | 'browser'
+
 export interface ContextOptions {
   cta?: string
   navigate: (
     rawHref: string,
     params?: NavigateOptions,
   ) => string | undefined | void
+  routeExternally?: ({
+    href,
+    target,
+  }: {
+    href: string
+    target: TargetType
+  }) => void
 }
 
 export type WebAction = (


### PR DESCRIPTION
## PR 설명

새창열기 기능을 추가합니다.

TL;DR

인앱에서는 `inlink`를 사용해 새 창을 여는 것이 가능하지만, 웹 브라우저에서는 불가능한 현상이 있었습니다. `inlink`로 표현한 링크를 모두 새 창에서 여는 것으로 변경하기에는 기존에 사용하고 있는 `inlink` 링크들이 웹 브라우저에서 같은 창에서 페이지를 여는 기능을 사용하는 경우가 있었습니다. 따라서 새 창 열기를 `standard-action-handler`에 새로운 기능으로 추가합니다. 

## 변경 내역
- `/web-action/new-window?href="이동할 URL"`

## 체크리스트

## 스크린샷 & URL

