### PR TITLE
[view-utilities] makeDeepLinkGenerator가 지원하는 옵션을 확장합니다.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ const { overrides, ...rest } = createConfig({
     'af_channel',
     'af_prt',
     'af_click_lookback',
+    'af_reengagement_window',
     'is_retargeting',
     'small_square',
     'slot_id',

--- a/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
+++ b/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
@@ -49,3 +49,35 @@ test('it appends proper onelink attribution queries', () => {
 
   expect(deepLink).toEqual(expectedDeepLink)
 })
+
+test('it allows pid override', () => {
+  const overridenPid = 'overriden'
+
+  const generateDeepLink = makeDeepLinkGenerator({
+    oneLinkParams: {
+      subdomain: SUBDOMAIN,
+      id: ONELINK_ID,
+      pid: PID,
+    },
+    appScheme: APP_SCHEME,
+    webURLBase: WEB_URL_BASE,
+  })
+
+  const deepLink = generateDeepLink({
+    path: APP_PATH,
+    pid: overridenPid,
+  })
+
+  const expectedDeepLink = generateUrl({
+    scheme: 'https',
+    host: `${SUBDOMAIN}.onelink.me`,
+    path: `/${ONELINK_ID}`,
+    query: qs.stringify({
+      af_dp: `${APP_SCHEME}://${APP_PATH}`,
+      af_web_dp: WEB_URL_BASE,
+      pid: overridenPid,
+    }),
+  })
+
+  expect(deepLink).toEqual(expectedDeepLink)
+})

--- a/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
+++ b/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
@@ -112,3 +112,37 @@ test('it provides reengagement window', () => {
 
   expect(deepLink).toEqual(expectedDeepLink)
 })
+
+test('it allows af_web_dp override', () => {
+  const overridenUrl = 'https://foo.bar'
+
+  const generateDeepLink = makeDeepLinkGenerator({
+    oneLinkParams: {
+      subdomain: SUBDOMAIN,
+      id: ONELINK_ID,
+      pid: PID,
+    },
+    appScheme: APP_SCHEME,
+    webURLBase: WEB_URL_BASE,
+  })
+
+  const deepLink = generateDeepLink({
+    path: APP_PATH,
+    webUrl: overridenUrl,
+    reengagementWindow: '7d',
+  })
+
+  const expectedDeepLink = generateUrl({
+    scheme: 'https',
+    host: `${SUBDOMAIN}.onelink.me`,
+    path: `/${ONELINK_ID}`,
+    query: qs.stringify({
+      af_dp: `${APP_SCHEME}://${APP_PATH}`,
+      af_web_dp: overridenUrl,
+      pid: PID,
+      af_reengagement_window: '7d',
+    }),
+  })
+
+  expect(deepLink).toEqual(expectedDeepLink)
+})

--- a/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
+++ b/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
@@ -11,7 +11,7 @@ const APP_PATH = '/hoteles/c2eb4fba-cad1-4c08-94b2-9430039d181e'
 const APP_SCHEME = 'triple'
 const WEB_URL_BASE = 'https://triple.guide'
 
-test('Deep Link를 생성합니다.', () => {
+test('it appends proper onelink attribution queries', () => {
   const generateDeepLink = makeDeepLinkGenerator({
     oneLinkParams: {
       subdomain: SUBDOMAIN,

--- a/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
+++ b/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
@@ -1,34 +1,29 @@
 import qs from 'qs'
 
-import { generateUrl, parseUrl } from '../url'
+import { generateUrl } from '../url'
 
 import { makeDeepLinkGenerator } from './make-deep-link-generator'
 
-const HOTEL_ID = 'c2eb4fba-cad1-4c08-94b2-9430039d181e' // 제주신라호텔
+const SUBDOMAIN = 'subdomain'
+const ONELINK_ID = 'onelinkid'
+const PID = 'onelinkpid'
+const APP_PATH = '/hoteles/c2eb4fba-cad1-4c08-94b2-9430039d181e'
+const APP_SCHEME = 'triple'
+const WEB_URL_BASE = 'https://triple.guide'
 
 test('Deep Link를 생성합니다.', () => {
   const generateDeepLink = makeDeepLinkGenerator({
     oneLinkParams: {
-      subdomain: 'triple',
-      id: 'aZP6',
-      pid: 'triple-web',
+      subdomain: SUBDOMAIN,
+      id: ONELINK_ID,
+      pid: PID,
     },
-    appScheme: 'triple',
-    webURLBase: 'https://triple.guide',
+    appScheme: APP_SCHEME,
+    webURLBase: WEB_URL_BASE,
   })
 
-  const path = generateUrl({
-    path: '/inlink',
-    query: qs.stringify({
-      path: generateUrl({
-        path: `/hotels/${HOTEL_ID}`,
-        query: '_triple_no_navbar',
-      }),
-    }),
-  })
-
-  const rawDeepLink = generateDeepLink({
-    path,
+  const deepLink = generateDeepLink({
+    path: APP_PATH,
     channel: 'naver',
     campaign: 'winter_sale',
     keywords: 'triple',
@@ -36,31 +31,21 @@ test('Deep Link를 생성합니다.', () => {
     adSet: 'naver_email',
   })
 
-  const { href, ...parsedDeepLink } = parseUrl(rawDeepLink)
-  const parsedDeepLinkQuery = qs.parse(parsedDeepLink.query || '')
-
-  const createdDeepLinkParameters = {
-    ...parsedDeepLink,
-    query: parsedDeepLinkQuery,
-  }
-
-  const comparisonDeepLinkParameters = {
+  const expectedDeepLink = generateUrl({
     scheme: 'https',
-    host: 'triple.onelink.me',
-    path: '/aZP6',
-    query: {
-      af_dp:
-        'triple:///inlink?path=%2Fhotels%2Fc2eb4fba-cad1-4c08-94b2-9430039d181e%3F_triple_no_navbar',
-      af_web_dp: 'https://triple.guide',
-      pid: 'triple-web',
-      af_adset: 'naver_email',
+    host: `${SUBDOMAIN}.onelink.me`,
+    path: `/${ONELINK_ID}`,
+    query: qs.stringify({
+      af_dp: `${APP_SCHEME}://${APP_PATH}`,
+      af_web_dp: WEB_URL_BASE,
+      pid: PID,
       c: 'winter_sale',
+      af_adset: 'naver_email',
       af_ad: 'video',
       af_keywords: 'triple',
       af_channel: 'naver',
-    },
-    hash: '',
-  }
+    }),
+  })
 
-  expect(createdDeepLinkParameters).toEqual(comparisonDeepLinkParameters)
+  expect(deepLink).toEqual(expectedDeepLink)
 })

--- a/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
+++ b/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
@@ -81,3 +81,37 @@ test('it allows pid override', () => {
 
   expect(deepLink).toEqual(expectedDeepLink)
 })
+
+test('it provides reengagement window', () => {
+  const overridenPid = 'overriden'
+
+  const generateDeepLink = makeDeepLinkGenerator({
+    oneLinkParams: {
+      subdomain: SUBDOMAIN,
+      id: ONELINK_ID,
+      pid: PID,
+    },
+    appScheme: APP_SCHEME,
+    webURLBase: WEB_URL_BASE,
+  })
+
+  const deepLink = generateDeepLink({
+    path: APP_PATH,
+    pid: overridenPid,
+    reengagementWindow: '7d',
+  })
+
+  const expectedDeepLink = generateUrl({
+    scheme: 'https',
+    host: `${SUBDOMAIN}.onelink.me`,
+    path: `/${ONELINK_ID}`,
+    query: qs.stringify({
+      af_dp: `${APP_SCHEME}://${APP_PATH}`,
+      af_web_dp: WEB_URL_BASE,
+      pid: overridenPid,
+      af_reengagement_window: '7d',
+    }),
+  })
+
+  expect(deepLink).toEqual(expectedDeepLink)
+})

--- a/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
+++ b/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
@@ -83,8 +83,6 @@ test('it allows pid override', () => {
 })
 
 test('it provides reengagement window', () => {
-  const overridenPid = 'overriden'
-
   const generateDeepLink = makeDeepLinkGenerator({
     oneLinkParams: {
       subdomain: SUBDOMAIN,
@@ -97,7 +95,6 @@ test('it provides reengagement window', () => {
 
   const deepLink = generateDeepLink({
     path: APP_PATH,
-    pid: overridenPid,
     reengagementWindow: '7d',
   })
 
@@ -108,7 +105,7 @@ test('it provides reengagement window', () => {
     query: qs.stringify({
       af_dp: `${APP_SCHEME}://${APP_PATH}`,
       af_web_dp: WEB_URL_BASE,
-      pid: overridenPid,
+      pid: PID,
       af_reengagement_window: '7d',
     }),
   })

--- a/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
+++ b/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.test.ts
@@ -129,7 +129,6 @@ test('it allows af_web_dp override', () => {
   const deepLink = generateDeepLink({
     path: APP_PATH,
     webUrl: overridenUrl,
-    reengagementWindow: '7d',
   })
 
   const expectedDeepLink = generateUrl({
@@ -140,7 +139,6 @@ test('it allows af_web_dp override', () => {
       af_dp: `${APP_SCHEME}://${APP_PATH}`,
       af_web_dp: overridenUrl,
       pid: PID,
-      af_reengagement_window: '7d',
     }),
   })
 

--- a/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.ts
+++ b/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.ts
@@ -31,6 +31,7 @@ interface GeneratorParams {
   partner?: string
   clickLookBack?: string
   isRetargeting?: boolean
+  reengagementWindow?: string
 }
 
 export type DeepLinkGenerator = (params: GeneratorParams) => string
@@ -58,6 +59,7 @@ export function makeDeepLinkGenerator({
     partner,
     clickLookBack,
     isRetargeting,
+    reengagementWindow,
   }) => {
     const appLink = generateUrl({ scheme: appScheme, path })
 
@@ -74,6 +76,7 @@ export function makeDeepLinkGenerator({
       af_prt: partner,
       af_click_lookback: clickLookBack,
       is_retargeting: isRetargeting,
+      af_reengagement_window: reengagementWindow,
     })
 
     return generateUrl({

--- a/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.ts
+++ b/packages/view-utilities/src/generate-deep-link/make-deep-link-generator.ts
@@ -32,6 +32,7 @@ interface GeneratorParams {
   clickLookBack?: string
   isRetargeting?: boolean
   reengagementWindow?: string
+  webUrl?: string
 }
 
 export type DeepLinkGenerator = (params: GeneratorParams) => string
@@ -60,12 +61,13 @@ export function makeDeepLinkGenerator({
     clickLookBack,
     isRetargeting,
     reengagementWindow,
+    webUrl,
   }) => {
     const appLink = generateUrl({ scheme: appScheme, path })
 
     const query = qs.stringify({
       af_dp: appLink,
-      af_web_dp: webURLBase || appLink,
+      af_web_dp: webUrl || webURLBase || appLink,
       pid: pid || defaultPid,
 
       c: campaign,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

[triple-email-api](https://github.com/titicacadev/triple-email-api)의 로직에서 OneLink 생성이 필요한데, 이전에 발송했던 OneLink params 중 `makeDeepLinkGenerator`가 지원하지 않는 속성이 있었습니다.

첫 이메일 캠페인에 썼던 OneLink params: https://titicaca.slack.com/archives/C01PCRU2XQR/p1635840393047300?thread_ts=1635300966.009600&cid=C01PCRU2XQR
JIRA 티켓: https://titicaca.atlassian.net/jira/software/projects/ENGDIVA/boards/57?selectedIssue=ENGDIVA-730

## 변경 내역

- `af_reengagement_window`를 지원합니다.
- `af_web_dp`를 `webUrl`로 Override 가능하게 합니다.
- 이전 테스트 케이스를 개선하고, 새로 추가한 params들에 대한 케이스를 추가합니다.

