### PR TITLE
[user-verification] 인증여부 확인 API 경로를 변경합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44288,6 +44288,7 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^6.3.0",
+        "@titicaca/fetcher": "^6.3.0",
         "@titicaca/modals": "^6.3.0",
         "@titicaca/react-hooks": "^6.3.0",
         "@titicaca/react-triple-client-interfaces": "^6.3.0",
@@ -59869,6 +59870,7 @@
       "version": "file:packages/user-verification",
       "requires": {
         "@titicaca/core-elements": "^6.3.0",
+        "@titicaca/fetcher": "*",
         "@titicaca/modals": "^6.3.0",
         "@titicaca/react-hooks": "^6.3.0",
         "@titicaca/react-triple-client-interfaces": "^6.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44292,11 +44292,7 @@
         "@titicaca/modals": "^6.3.0",
         "@titicaca/react-hooks": "^6.3.0",
         "@titicaca/react-triple-client-interfaces": "^6.3.0",
-        "@titicaca/router": "^6.3.0",
-        "isomorphic-fetch": "^2.2.1"
-      },
-      "devDependencies": {
-        "@types/isomorphic-fetch": "^0.0.35"
+        "@titicaca/router": "^6.3.0"
       },
       "peerDependencies": {
         "@titicaca/react-contexts": "*"
@@ -59870,13 +59866,11 @@
       "version": "file:packages/user-verification",
       "requires": {
         "@titicaca/core-elements": "^6.3.0",
-        "@titicaca/fetcher": "*",
+        "@titicaca/fetcher": "^6.3.0",
         "@titicaca/modals": "^6.3.0",
         "@titicaca/react-hooks": "^6.3.0",
         "@titicaca/react-triple-client-interfaces": "^6.3.0",
-        "@titicaca/router": "^6.3.0",
-        "@types/isomorphic-fetch": "^0.0.35",
-        "isomorphic-fetch": "^2.2.1"
+        "@titicaca/router": "^6.3.0"
       }
     },
     "@titicaca/view-utilities": {

--- a/packages/user-verification/package.json
+++ b/packages/user-verification/package.json
@@ -27,11 +27,7 @@
     "@titicaca/modals": "^6.3.0",
     "@titicaca/react-hooks": "^6.3.0",
     "@titicaca/react-triple-client-interfaces": "^6.3.0",
-    "@titicaca/router": "^6.3.0",
-    "isomorphic-fetch": "^2.2.1"
-  },
-  "devDependencies": {
-    "@types/isomorphic-fetch": "^0.0.35"
+    "@titicaca/router": "^6.3.0"
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*"

--- a/packages/user-verification/package.json
+++ b/packages/user-verification/package.json
@@ -23,6 +23,7 @@
   ],
   "dependencies": {
     "@titicaca/core-elements": "^6.3.0",
+    "@titicaca/fetcher": "^6.3.0",
     "@titicaca/modals": "^6.3.0",
     "@titicaca/react-hooks": "^6.3.0",
     "@titicaca/react-triple-client-interfaces": "^6.3.0",

--- a/packages/user-verification/src/confirmation-services.test.ts
+++ b/packages/user-verification/src/confirmation-services.test.ts
@@ -1,0 +1,196 @@
+import { get } from '@titicaca/fetcher'
+
+import { confirmVerification } from './confirmation-services'
+
+jest.mock('@titicaca/fetcher')
+
+afterEach(() => {
+  ;(get as unknown as jest.MockedFunction<typeof get>).mockRestore()
+})
+
+describe('confirmVerification', () => {
+  describe('sms-verification', () => {
+    it('returns not-verified state when it is not verified', async () => {
+      const getMock = (
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 404,
+          parsedBody: { message: 'not found' },
+          ok: false,
+        }),
+      )
+
+      expect(await confirmVerification('sms-verification')).toStrictEqual({
+        verified: false,
+      })
+      expect(getMock).toHaveBeenCalledWith('/api/users/smscert')
+    })
+
+    it('returns verified state when it is verified', async () => {
+      const getMock = (
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 200,
+          parsedBody: {
+            phoneId: 123,
+            phoneNumber: '+821012345678',
+            os: 'ios 15.2.1',
+            certificated: true,
+            certificatedAt: 1645575936545,
+            verified: true,
+            verifiedAt: 1645575936545,
+            formatted: {
+              phoneNumber: '01012345678',
+              countryCallingCode: 82,
+              countryCode: 'KR',
+            },
+          },
+          ok: true,
+        }),
+      )
+      const result = await confirmVerification('sms-verification')
+
+      expect(getMock).toHaveBeenCalledWith('/api/users/smscert')
+      expect(result).toHaveProperty('verified', true)
+      expect(result).toHaveProperty('phoneNumber', '+821012345678')
+    })
+  })
+
+  describe('personal-id-verification-with-residence', () => {
+    it('returns not-verified state when it is not verified', async () => {
+      const getMock = (
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 404,
+          parsedBody: { message: 'not found' },
+          ok: false,
+        }),
+      )
+
+      expect(
+        await confirmVerification('personal-id-verification-with-residence'),
+      ).toStrictEqual({
+        verified: false,
+      })
+      expect(getMock).toHaveBeenCalledWith('/api/users/kto-stay-2021')
+    })
+
+    it('returns verified state when it is verified', async () => {
+      const getMock = (
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 200,
+          parsedBody: {
+            userId: 28,
+            residence: [
+              {
+                key: 'korea-sido',
+                value: '11',
+              },
+              {
+                key: 'korea-sgg',
+                value: '11710',
+              },
+            ],
+            nameChecked: true,
+            phoneNumber: '01012345678',
+          },
+          ok: true,
+        }),
+      )
+      const result = await confirmVerification(
+        'personal-id-verification-with-residence',
+      )
+
+      expect(result).toHaveProperty('verified', true)
+      expect(result).toHaveProperty('phoneNumber', '01012345678')
+      expect(getMock).toHaveBeenCalledWith('/api/users/kto-stay-2021')
+    })
+  })
+
+  describe('personal-id-verification', () => {
+    it('returns not-verified state whtn it is not verified', async () => {
+      const getMock = (
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 404,
+          parsedBody: { message: 'not found' },
+          ok: false,
+        }),
+      )
+
+      expect(
+        await confirmVerification('personal-id-verification'),
+      ).toStrictEqual({
+        verified: false,
+      })
+      expect(getMock).toHaveBeenCalledWith('/api/users/namecheck')
+    })
+
+    it('returns verified state when it is verified', async () => {
+      const getMock = (
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 200,
+          parsedBody: {
+            name: '트리플',
+            birthday: '20160111',
+            gender: 'MALE',
+            mobile: '01012345678',
+            isForeign: false,
+            createdAt: '2022-02-23T00:25:36.535301',
+          },
+          ok: true,
+        }),
+      )
+
+      const result = await confirmVerification('personal-id-verification')
+
+      expect(getMock).toHaveBeenCalledWith('/api/users/namecheck')
+      expect(result).toHaveProperty('verified', true)
+      expect(result).toHaveProperty('phoneNumber', '01012345678')
+    })
+  })
+})

--- a/packages/user-verification/src/confirmation-services.test.ts
+++ b/packages/user-verification/src/confirmation-services.test.ts
@@ -68,6 +68,30 @@ describe('confirmVerification', () => {
       expect(result).toHaveProperty('verified', true)
       expect(result).toHaveProperty('phoneNumber', '+821012345678')
     })
+
+    it('returns undefined state when it is responded with an error', async () => {
+      const getMock = (
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 500,
+          parsedBody: {
+            message: 'internal server error',
+          },
+          ok: false,
+        }),
+      )
+      const result = await confirmVerification('sms-verification')
+
+      expect(getMock).toHaveBeenCalledWith('/api/users/smscert')
+      expect(result).toHaveProperty('verified', undefined)
+    })
   })
 
   describe('personal-id-verification-with-residence', () => {
@@ -134,6 +158,32 @@ describe('confirmVerification', () => {
       expect(result).toHaveProperty('phoneNumber', '01012345678')
       expect(getMock).toHaveBeenCalledWith('/api/users/kto-stay-2021')
     })
+
+    it('returns undefined state when it is responded with an error', async () => {
+      const getMock = (
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 500,
+          parsedBody: {
+            message: 'internal server error',
+          },
+          ok: false,
+        }),
+      )
+      const result = await confirmVerification(
+        'personal-id-verification-with-residence',
+      )
+
+      expect(result).toHaveProperty('verified', undefined)
+      expect(getMock).toHaveBeenCalledWith('/api/users/kto-stay-2021')
+    })
   })
 
   describe('personal-id-verification', () => {
@@ -191,6 +241,31 @@ describe('confirmVerification', () => {
       expect(getMock).toHaveBeenCalledWith('/api/users/namecheck')
       expect(result).toHaveProperty('verified', true)
       expect(result).toHaveProperty('phoneNumber', '01012345678')
+    })
+
+    it('returns undefined state when it is responded with an error', async () => {
+      const getMock = (
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 500,
+          parsedBody: {
+            message: 'internal server error',
+          },
+          ok: false,
+        }),
+      )
+
+      const result = await confirmVerification('personal-id-verification')
+
+      expect(getMock).toHaveBeenCalledWith('/api/users/namecheck')
+      expect(result).toHaveProperty('verified', undefined)
     })
   })
 })

--- a/packages/user-verification/src/confirmation-services.ts
+++ b/packages/user-verification/src/confirmation-services.ts
@@ -1,0 +1,66 @@
+import { get } from '@titicaca/fetcher'
+
+import type { VerificationType } from './types'
+
+export function confirmVerification(type: VerificationType): Promise<{
+  verified: boolean | undefined
+  phoneNumber?: string
+  error?: string
+  payload?: unknown
+}> {
+  if (type === 'sms-verification') {
+    return confirmSmsVerification()
+  } else if (type === 'personal-id-verification-with-residence') {
+    return confirmPersonalIdVerificationWithResidence()
+  } else {
+    return confirmPersonalIdVerification()
+  }
+}
+
+async function confirmSmsVerification() {
+  const response = await get<{
+    phoneNumber: string
+  }>('/api/users/smscert')
+
+  if (response.status === 404) {
+    return { verified: false }
+  } else if (response.ok) {
+    const { phoneNumber, ...payload } = response.parsedBody
+
+    return { verified: true, phoneNumber, payload }
+  } else {
+    return { verified: undefined, error: JSON.stringify(response.parsedBody) }
+  }
+}
+
+async function confirmPersonalIdVerificationWithResidence() {
+  const response = await get<{
+    phoneNumber: string
+  }>('/api/users/kto-stay-2021')
+
+  if (response.status === 404) {
+    return { verified: false }
+  } else if (response.ok) {
+    const { phoneNumber, ...payload } = response.parsedBody
+
+    return { verified: true, phoneNumber, payload }
+  } else {
+    return { verified: undefined, error: JSON.stringify(response.parsedBody) }
+  }
+}
+
+async function confirmPersonalIdVerification() {
+  const response = await get<{
+    mobile: string
+  }>('/api/users/namecheck')
+
+  if (response.status === 404) {
+    return { verified: false }
+  } else if (response.ok) {
+    const { mobile: phoneNumber, ...payload } = response.parsedBody
+
+    return { verified: true, phoneNumber, payload }
+  } else {
+    return { verified: undefined, error: JSON.stringify(response.parsedBody) }
+  }
+}

--- a/packages/user-verification/src/index.ts
+++ b/packages/user-verification/src/index.ts
@@ -1,7 +1,8 @@
-import { useUserVerification, VerificationType } from './use-user-verification'
+import { useUserVerification } from './use-user-verification'
 import VerificationRequest from './verification-request'
 
 export { useSendVerifiedMessage } from './verified-message'
 export type { VerifiedMessage } from './verified-message'
+export type { VerificationType } from './types'
 
-export { useUserVerification, VerificationRequest, VerificationType }
+export { useUserVerification, VerificationRequest }

--- a/packages/user-verification/src/types.ts
+++ b/packages/user-verification/src/types.ts
@@ -1,0 +1,4 @@
+export type VerificationType =
+  | 'sms-verification'
+  | 'personal-id-verification-with-residence'
+  | 'personal-id-verification'

--- a/packages/user-verification/src/use-user-verification.test.ts
+++ b/packages/user-verification/src/use-user-verification.test.ts
@@ -1,7 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks'
 import { useExternalRouter } from '@titicaca/router'
 
-import { useUserVerification, VerificationType } from './use-user-verification'
+import { useUserVerification } from './use-user-verification'
+import type { VerificationType } from './types'
 
 jest.mock('@titicaca/react-hooks', () => ({
   useVisibilityChange: jest.fn(),

--- a/packages/user-verification/src/use-user-verification.test.ts
+++ b/packages/user-verification/src/use-user-verification.test.ts
@@ -2,15 +2,19 @@ import { renderHook } from '@testing-library/react-hooks'
 import { useExternalRouter } from '@titicaca/router'
 
 import { useUserVerification } from './use-user-verification'
+import './confirmation-services'
 import type { VerificationType } from './types'
 
 jest.mock('@titicaca/react-hooks', () => ({
   useVisibilityChange: jest.fn(),
 }))
 jest.mock('@titicaca/router')
-jest.mock('isomorphic-fetch', () => () => {
-  return new Response('{"phoneNumber": "01000000000"}', { status: 200 })
-})
+jest.mock('./confirmation-services', () => ({
+  confirmVerification: () => ({
+    verified: true,
+    phoneNumber: '01012345678',
+  }),
+}))
 jest.mock('./verified-message')
 
 describe('인증 시작함수를 호출하면 인증 페이지를 엽니다.', () => {

--- a/packages/user-verification/src/use-user-verification.ts
+++ b/packages/user-verification/src/use-user-verification.ts
@@ -4,6 +4,7 @@ import { useVisibilityChange } from '@titicaca/react-hooks'
 import { useExternalRouter } from '@titicaca/router'
 
 import { useVerifiedMessageListener, VerifiedMessage } from './verified-message'
+import type { VerificationType } from './types'
 
 interface VerificationState {
   phoneNumber?: string
@@ -11,11 +12,6 @@ interface VerificationState {
   error?: string
   payload?: unknown
 }
-
-export type VerificationType =
-  | 'sms-verification'
-  | 'personal-id-verification-with-residence'
-  | 'personal-id-verification'
 
 const TARGET_PAGE_PATH: Record<VerificationType, string> = {
   'sms-verification': '/verifications/',
@@ -26,7 +22,7 @@ const TARGET_PAGE_PATH: Record<VerificationType, string> = {
 const CONFIRMATION_API_PATH: Record<VerificationType, string> = {
   'sms-verification': '/api/users/smscert',
   'personal-id-verification-with-residence': '/api/users/kto-stay-2021',
-  'personal-id-verification': '/api/users/kto-stay-2021',
+  'personal-id-verification': '/api/users/namecheck',
 }
 
 export function useUserVerification({

--- a/packages/user-verification/tsconfig.build.json
+++ b/packages/user-verification/tsconfig.build.json
@@ -6,6 +6,9 @@
       "path": "../core-elements/tsconfig.build.json"
     },
     {
+      "path": "../fetcher/tsconfig.build.json"
+    },
+    {
       "path": "../modals/tsconfig.build.json"
     },
     {

--- a/packages/user-verification/tsconfig.json
+++ b/packages/user-verification/tsconfig.json
@@ -6,6 +6,7 @@
     "baseUrl": ".",
     "paths": {
       "@titicaca/core-elements": ["../core-elements/src"],
+      "@titicaca/fetcher": ["../fetcher/src"],
       "@titicaca/modals": ["../modals/src"],
       "@titicaca/react-contexts": ["../react-contexts/src"],
       "@titicaca/react-hooks": ["../react-hooks/src"],
@@ -19,6 +20,9 @@
   "references": [
     {
       "path": "../core-elements"
+    },
+    {
+      "path": "../fetcher"
     },
     {
       "path": "../modals"


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

triple-cash-web 작업 중 발견했습니다. `personal-id-verification` 타입의 인증이 https://github.com/titicacadev/triple-user/pull/223 에서 추가한 API를 이용해야 하는데, 임시로 숙박대전용 API를 이용하던 상태였습니다.

## 변경 내역

Verification 상태 체크를 API Path만 달리 해서 수행하던 상태였는데, 응답 Body가 일정해서 가능한 상태였습니다. 그러나 이번에 작업하는 API는 응답 형식이 달라서 그 형식을 유지할 수 없었고, `verificationType`별로 명확한 상태 체크 API 호출 서비스를 별도로 구현합니다.

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
