### PR TITLE
[standard-action-handler] standardActionHandler Hook 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44127,6 +44127,7 @@
       "version": "6.4.0",
       "license": "MIT",
       "dependencies": {
+        "@titicaca/router": "^6.4.0",
         "@titicaca/view-utilities": "^6.4.0",
         "qs": "^6.9.4"
       },
@@ -58409,6 +58410,7 @@
     "@titicaca/standard-action-handler": {
       "version": "file:packages/standard-action-handler",
       "requires": {
+        "@titicaca/router": "^6.4.0",
         "@titicaca/view-utilities": "^6.4.0",
         "@types/isomorphic-fetch": "^0.0.35",
         "@types/qs": "^6.9.2",

--- a/packages/standard-action-handler/package.json
+++ b/packages/standard-action-handler/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "@titicaca/view-utilities": "^6.4.0",
+    "@titicaca/router": "^6.4.0",
     "qs": "^6.9.4"
   },
   "devDependencies": {

--- a/packages/standard-action-handler/src/hook.test.tsx
+++ b/packages/standard-action-handler/src/hook.test.tsx
@@ -1,39 +1,17 @@
-import { EnvProvider, SessionContextProvider } from '@titicaca/react-contexts'
 import { renderHook } from '@testing-library/react-hooks'
-import { PropsWithChildren } from 'react'
 
-import { useWebAction } from './hook'
+import Handler from './handler'
+import { useStandardActionHandler } from './hook'
+
+jest.mock('@titicaca/router')
+jest.mock('./handler')
 
 describe('stadard-action-hanlder hook', () => {
-  it('useWebAction hook 사용 시 initialize 함수가 반환됩니다.', () => {
-    const wrapper = ({ children }: PropsWithChildren<unknown>) => {
-      return (
-        <EnvProvider
-          afOnelinkId=""
-          afOnelinkPid=""
-          afOnelinkSubdomain=""
-          appUrlScheme=""
-          defaultPageDescription=""
-          defaultPageTitle=""
-          facebookAppId=""
-          webUrlBase=""
-        >
-          <SessionContextProvider
-            type="browser"
-            props={{
-              initialUser: undefined,
-              initialSessionAvailability: true,
-            }}
-          >
-            {children}
-          </SessionContextProvider>
-        </EnvProvider>
-      )
-    }
+  it('useStandardAction hook 실행 시 Handler가 호출됩니다.', () => {
+    const handlerSpy = jest.spyOn(Handler.prototype, 'toFunction')
+    renderHook(() => useStandardActionHandler())
 
-    const { result } = renderHook(() => useWebAction(), {
-      wrapper,
-    })
-    expect(typeof result.current).toBe('function')
+    expect(Handler).toHaveBeenCalled()
+    expect(handlerSpy).toHaveBeenCalled()
   })
 })

--- a/packages/standard-action-handler/src/hook.test.tsx
+++ b/packages/standard-action-handler/src/hook.test.tsx
@@ -1,0 +1,39 @@
+import { EnvProvider, SessionContextProvider } from '@titicaca/react-contexts'
+import { renderHook } from '@testing-library/react-hooks'
+import { PropsWithChildren } from 'react'
+
+import { useWebAction } from './hook'
+
+describe('stadard-action-hanlder hook', () => {
+  it('useWebAction hook 사용 시 initialize 함수가 반환됩니다.', () => {
+    const wrapper = ({ children }: PropsWithChildren<unknown>) => {
+      return (
+        <EnvProvider
+          afOnelinkId=""
+          afOnelinkPid=""
+          afOnelinkSubdomain=""
+          appUrlScheme=""
+          defaultPageDescription=""
+          defaultPageTitle=""
+          facebookAppId=""
+          webUrlBase=""
+        >
+          <SessionContextProvider
+            type="browser"
+            props={{
+              initialUser: undefined,
+              initialSessionAvailability: true,
+            }}
+          >
+            {children}
+          </SessionContextProvider>
+        </EnvProvider>
+      )
+    }
+
+    const { result } = renderHook(() => useWebAction(), {
+      wrapper,
+    })
+    expect(typeof result.current).toBe('function')
+  })
+})

--- a/packages/standard-action-handler/src/hook.ts
+++ b/packages/standard-action-handler/src/hook.ts
@@ -2,7 +2,7 @@ import { useNavigate, useExternalRouter } from '@titicaca/router'
 
 import { initialize } from './index'
 
-export function useWebAction() {
+export function useStandardActionHandler() {
   const navigate = useNavigate()
   const routeExternally = useExternalRouter()
 

--- a/packages/standard-action-handler/src/hook.ts
+++ b/packages/standard-action-handler/src/hook.ts
@@ -1,0 +1,10 @@
+import { useNavigate, useExternalRouter } from '@titicaca/router'
+
+import { initialize } from './index'
+
+export function useWebAction() {
+  const navigate = useNavigate()
+  const routeExternally = useExternalRouter()
+
+  return initialize({ navigate, routeExternally })
+}

--- a/packages/standard-action-handler/src/types.ts
+++ b/packages/standard-action-handler/src/types.ts
@@ -1,7 +1,7 @@
 import { UrlElements } from '@titicaca/view-utilities'
 
 export interface NavigateOptions {
-  target?: string
+  target?: 'browser'
   title?: string
   [key: string]: unknown
 }

--- a/packages/standard-action-handler/tsconfig.build.json
+++ b/packages/standard-action-handler/tsconfig.build.json
@@ -4,6 +4,9 @@
   "references": [
     {
       "path": "../view-utilities/tsconfig.build.json"
+    },
+    {
+      "path": "../router/tsconfig.build.json"
     }
   ]
 }

--- a/packages/standard-action-handler/tsconfig.json
+++ b/packages/standard-action-handler/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "src",
     "baseUrl": ".",
     "paths": {
+      "@titicaca/router": ["../router/src"],
       "@titicaca/view-utilities": ["../view-utilities/src"]
     }
   },
@@ -12,6 +13,9 @@
   "references": [
     {
       "path": "../view-utilities"
+    },
+    {
+      "path": "../router"
     }
   ]
 }

--- a/packages/triple-document/src/types.ts
+++ b/packages/triple-document/src/types.ts
@@ -33,7 +33,7 @@ export interface Link {
   href?: string
   label?: string
   level?: string
-  target?: string
+  target?: 'browser'
 }
 
 export type LinkEventHandler = (e: SyntheticEvent, link: Link) => void


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

`standard-action-handler` Hook을 생성합니다. 

현재 `stadard-action-handler`를 쓰는 곳에서 `useNavigate`, `useExternalRouter`를 파라미터로 직접 넘겨주고 있기 때문에 이를 편하게 하기 위해 Hook을 만들었습니다.

`initialize` 함수의 결과를 반환합니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
