### PR TITLE
[resource-list-element] `ExtendedResourceListElement`의 가변 높이를 보장하도록 수정합니다.

### DIFF
--- a/packages/resource-list-element/src/extended-resource-list-element.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.tsx
@@ -94,7 +94,7 @@ export default function ExtendedResourceListElement<R extends ResourceMeta>({
 
   return (
     <ResourceListItem onClick={onClick} {...props}>
-      <FlexBox flex alignItems="center" justifyContent="space-between">
+      <FlexBox flex justifyContent="space-between">
         <ContentContainer>
           <Text bold maxLines={2} size="large">
             {name}

--- a/packages/resource-list-element/src/extended-resource-list-element.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.tsx
@@ -56,7 +56,6 @@ const ResourceListItem = styled(List.Item)`
 `
 
 const ContentContainer = styled.div`
-  top: 20px;
   width: calc(100% - 110px);
 `
 

--- a/packages/resource-list-element/src/extended-resource-list-element.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   List,
   Image,
+  FlexBox,
 } from '@titicaca/core-elements'
 import { ImageMeta } from '@titicaca/type-definitions'
 
@@ -49,21 +50,19 @@ export type ResourceListElementProps<R extends ResourceMeta> = {
 
 const ResourceListItem = styled(List.Item)`
   position: relative;
-  min-height: 150px;
   padding: 20px 0;
   box-sizing: border-box;
   cursor: pointer;
 `
 
 const ContentContainer = styled.div`
-  position: absolute;
   top: 20px;
   width: calc(100% - 110px);
 `
 
 const LabelContainer = styled.div`
   position: absolute;
-  bottom: 0;
+  bottom: 20px;
 `
 
 export default function ExtendedResourceListElement<R extends ResourceMeta>({
@@ -96,112 +95,116 @@ export default function ExtendedResourceListElement<R extends ResourceMeta>({
 
   return (
     <ResourceListItem onClick={onClick} {...props}>
-      <Container position="relative">
-        <Container clearing>
-          <Image>
-            <Image.FixedDimensionsFrame size="small" width={90} floated="right">
-              {image ? (
-                optimized ? (
-                  <Image.OptimizedImg
-                    cloudinaryId={image.cloudinaryId as string}
-                    cloudinaryBucket={image.cloudinaryBucket}
-                    alt={name}
-                  />
-                ) : (
-                  <Image.Img
-                    src={
-                      ('small_square' in image.sizes
-                        ? image.sizes.small_square
-                        : image.sizes.smallSquare
-                      ).url
-                    }
-                    alt={name}
-                  />
-                )
-              ) : (
-                <Image.Placeholder src={imagePlaceholder || ''} />
-              )}
-            </Image.FixedDimensionsFrame>
-          </Image>
+      <FlexBox flex alignItems="center" justifyContent="space-between">
+        <ContentContainer>
+          <Text bold maxLines={2} size="large">
+            {name}
+          </Text>
 
-          {!hideScrapButton && id && type ? (
-            <Container position="absolute" positioning={{ top: 3, right: 3 }}>
-              <OverlayScrapButton resource={{ id, type, scraped }} size={36} />
+          <Text
+            alpha={0.7}
+            maxLines={maxCommentLines}
+            size="small"
+            margin={{ top: 5 }}
+          >
+            {comment}
+          </Text>
+
+          <ReviewScrapStat
+            reviewsCount={reviewsCount}
+            scrapsCount={scrapsCount}
+            reviewsRating={reviewsRating}
+            margin={{ top: 5 }}
+          />
+
+          {formattedNames ? (
+            <Container margin={{ top: 5 }}>
+              <Text inlineBlock size="tiny" color="gray" alpha={0.5}>
+                {formattedNames}
+              </Text>
             </Container>
           ) : null}
-        </Container>
 
-        {children}
-
-        {labels.length > 0 ? (
-          <LabelContainer>
-            <Label.Group horizontalGap={5}>
-              {labels.map(({ text, color, emphasized }, index) => (
-                <Label key={index} promo color={color} emphasized={emphasized}>
-                  {text}
+          {distance || distance === 0 || note || isAdvertisement ? (
+            <Container margin={{ top: 3 }}>
+              {isAdvertisement ? (
+                <Label
+                  emphasized
+                  size="tiny"
+                  promo
+                  color="white"
+                  margin={{ right: 5 }}
+                  verticalAlign="middle"
+                >
+                  광고
                 </Label>
-              ))}
-            </Label.Group>
-          </LabelContainer>
-        ) : null}
-      </Container>
+              ) : null}
+              {distance || distance === 0 ? (
+                <Text inline color="blue" size="small" alpha={1}>
+                  {`${distance}${distanceSuffix} `}
+                </Text>
+              ) : null}
+              {note ? (
+                <Text inline size="small" alpha={0.4}>
+                  {note}
+                </Text>
+              ) : null}
+            </Container>
+          ) : null}
+        </ContentContainer>
 
-      <ContentContainer>
-        <Text bold maxLines={2} size="large">
-          {name}
-        </Text>
+        <Container position="relative">
+          <Container clearing>
+            <Image>
+              <Image.FixedDimensionsFrame size="small" width={90}>
+                {image ? (
+                  optimized ? (
+                    <Image.OptimizedImg
+                      cloudinaryId={image.cloudinaryId as string}
+                      cloudinaryBucket={image.cloudinaryBucket}
+                      alt={name}
+                    />
+                  ) : (
+                    <Image.Img
+                      src={
+                        ('small_square' in image.sizes
+                          ? image.sizes.small_square
+                          : image.sizes.smallSquare
+                        ).url
+                      }
+                      alt={name}
+                    />
+                  )
+                ) : (
+                  <Image.Placeholder src={imagePlaceholder || ''} />
+                )}
+              </Image.FixedDimensionsFrame>
+            </Image>
 
-        <Text
-          alpha={0.7}
-          maxLines={maxCommentLines}
-          size="small"
-          margin={{ top: 5 }}
-        >
-          {comment}
-        </Text>
-
-        <ReviewScrapStat
-          reviewsCount={reviewsCount}
-          scrapsCount={scrapsCount}
-          reviewsRating={reviewsRating}
-          margin={{ top: 5 }}
-        />
-
-        {formattedNames ? (
-          <Container margin={{ top: 5 }}>
-            <Text inlineBlock size="tiny" color="gray" alpha={0.5}>
-              {formattedNames}
-            </Text>
+            {!hideScrapButton && id && type ? (
+              <Container position="absolute" positioning={{ top: 3, right: 3 }}>
+                <OverlayScrapButton
+                  resource={{ id, type, scraped }}
+                  size={36}
+                />
+              </Container>
+            ) : null}
           </Container>
-        ) : null}
+        </Container>
+      </FlexBox>
+      {children}
 
-        {distance || distance === 0 || note || isAdvertisement ? (
-          <Container margin={{ top: 3 }}>
-            {isAdvertisement ? (
-              <Label
-                emphasized
-                size="tiny"
-                promo
-                color="white"
-                margin={{ right: 5 }}
-                verticalAlign="middle"
-              >
-                광고
+      {labels.length > 0 ? (
+        <LabelContainer>
+          <Label.Group horizontalGap={5}>
+            {labels.map(({ text, color, emphasized }, index) => (
+              <Label key={index} promo color={color} emphasized={emphasized}>
+                {text}
               </Label>
-            ) : null}
-            {distance || distance === 0 ? (
-              <Text inline color="blue" size="small" alpha={1}>
-                {`${distance}${distanceSuffix} `}
-              </Text>
-            ) : null}
-            {note ? (
-              <Text inline size="small" alpha={0.4}>
-                {note}
-              </Text>
-            ) : null}
-          </Container>
-        ) : null}
-      </ContentContainer>
+            ))}
+          </Label.Group>
+        </LabelContainer>
+      ) : null}
     </ResourceListItem>
   )
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
Closes #1519 
https://titicaca.slack.com/archives/C01CHRQBP1U/p1645594225549139

genie-web과 hotels-web에서도 `ExtendedResourceListElement`를 사용하는데 깨지는 부분을 발견했습니다
이 부분은 해당 PR의 수정사항이 반영되어 깨지는 부분이기에 제가 직접 두개 플젝에서 수정작업을 거치도록하겠습니다!
(content-web은 해당사항 없습니다!)

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
