### PR TITLE
[replies] 프로필 및 멘션을 클릭했을 때, 액션을 추가합니다.

### DIFF
--- a/packages/replies/src/list/reply.tsx
+++ b/packages/replies/src/list/reply.tsx
@@ -10,7 +10,7 @@ import {
 import { formatTimestamp, findFoldedPosition } from '@titicaca/view-utilities'
 import { useAppCallback, useSessionCallback } from '@titicaca/ui-flow'
 import { TransitionType } from '@titicaca/modals'
-import { ExternalLink, useNavigate } from '@titicaca/router'
+import { useNavigate } from '@titicaca/router'
 import {
   useUriHash,
   useHistoryFunctions,
@@ -395,14 +395,7 @@ function Content({
         ) : (
           <>
             {mentionedUser && !blinded && (
-              <ExternalLink
-                href={mentionedUser?.href as string}
-                target="new"
-                allowSource="app"
-                onClick={onClick}
-              >
-                <MentionUser>{mentionedUser?.name}</MentionUser>
-              </ExternalLink>
+              <MentionUser onClick={onClick}>{mentionedUser?.name}</MentionUser>
             )}
             <Text
               size={15}

--- a/packages/replies/src/list/reply.tsx
+++ b/packages/replies/src/list/reply.tsx
@@ -74,7 +74,7 @@ const CONTENT_TEXT = {
 export default function Reply({
   reply,
   reply: {
-    writer: { profileImage, name },
+    writer: { profileImage, name, href: writeHref },
     blinded,
     createdAt,
     content: { mentionedUser, text, markdownText },
@@ -207,11 +207,14 @@ export default function Reply({
     childrenCount,
   })
 
-  const handleMentiondUserNameClick = useAppCallback(
+  const handleProfileUserClick = useAppCallback(
     TransitionType.General,
-    useCallback(() => {
-      navigate(`${mentionedUser?.href || ''}`)
-    }, [navigate, mentionedUser?.href]),
+    useCallback(
+      (href) => {
+        navigate(href)
+      },
+      [navigate],
+    ),
   )
 
   return (
@@ -222,7 +225,7 @@ export default function Reply({
         src={profileImage}
         borderRadius={20}
         alt={name || ''}
-        onClick={() => handleMentiondUserNameClick()}
+        onClick={() => handleProfileUserClick(writeHref)}
       />
 
       <Container padding={{ left: 50, bottom: 3 }} margin={{ bottom: 20 }}>
@@ -232,7 +235,7 @@ export default function Reply({
               size={15}
               bold
               ellipsis
-              onClick={() => handleMentiondUserNameClick()}
+              onClick={() => handleProfileUserClick(writeHref)}
             >
               {name}
             </Text>
@@ -254,7 +257,6 @@ export default function Reply({
           blinded={!!blinded}
           deleted={!!deleted}
           text={derivedText}
-          onClick={handleMentiondUserNameClick}
         />
 
         {!deleted && !blinded ? (
@@ -376,16 +378,25 @@ function Content({
   mentionedUser,
   blinded,
   deleted,
-  onClick,
 }: {
   text: string
   mentionedUser?: Writer
   blinded: boolean
   deleted: boolean
-  onClick: () => void
 }) {
   const [unfolded, setUnfolded] = useState(false)
   const foldedPosition = findFoldedPosition(5, text)
+  const navigate = useNavigate()
+
+  const handleMentiondUserNameClick = useAppCallback(
+    TransitionType.General,
+    useCallback(
+      (href) => {
+        navigate(href)
+      },
+      [navigate],
+    ),
+  )
 
   return (
     <Container padding={{ top: 3 }}>
@@ -395,7 +406,11 @@ function Content({
         ) : (
           <>
             {mentionedUser && !blinded && (
-              <MentionUser onClick={onClick}>{mentionedUser?.name}</MentionUser>
+              <MentionUser
+                onClick={() => handleMentiondUserNameClick(mentionedUser.href)}
+              >
+                {mentionedUser?.name}
+              </MentionUser>
             )}
             <Text
               size={15}

--- a/packages/replies/src/list/reply.tsx
+++ b/packages/replies/src/list/reply.tsx
@@ -207,13 +207,15 @@ export default function Reply({
     childrenCount,
   })
 
-  const handleProfileUserClick = useAppCallback(
+  const handleUserClick = useAppCallback(
     TransitionType.General,
-    useCallback(
-      (href) => {
-        navigate(href)
-      },
-      [navigate],
+    useSessionCallback(
+      useCallback(
+        (href) => {
+          navigate(href)
+        },
+        [navigate],
+      ),
     ),
   )
 
@@ -225,7 +227,7 @@ export default function Reply({
         src={profileImage}
         borderRadius={20}
         alt={name || ''}
-        onClick={() => handleProfileUserClick(writeHref)}
+        onClick={() => handleUserClick(writeHref)}
       />
 
       <Container padding={{ left: 50, bottom: 3 }} margin={{ bottom: 20 }}>
@@ -235,7 +237,7 @@ export default function Reply({
               size={15}
               bold
               ellipsis
-              onClick={() => handleProfileUserClick(writeHref)}
+              onClick={() => handleUserClick(writeHref)}
             >
               {name}
             </Text>

--- a/packages/replies/src/list/reply.tsx
+++ b/packages/replies/src/list/reply.tsx
@@ -207,6 +207,13 @@ export default function Reply({
     childrenCount,
   })
 
+  const handleMentiondUserNameClick = useAppCallback(
+    TransitionType.General,
+    useCallback(() => {
+      navigate(`${mentionedUser?.href || ''}`)
+    }, [navigate, mentionedUser?.href]),
+  )
+
   return (
     <>
       <SquareImage
@@ -215,12 +222,18 @@ export default function Reply({
         src={profileImage}
         borderRadius={20}
         alt={name || ''}
+        onClick={() => handleMentiondUserNameClick()}
       />
 
       <Container padding={{ left: 50, bottom: 3 }} margin={{ bottom: 20 }}>
         <FlexBox flex justifyContent="space-between" alignItems="start">
           <Container minWidth={80} maxWidth={135}>
-            <Text size={15} bold ellipsis>
+            <Text
+              size={15}
+              bold
+              ellipsis
+              onClick={() => handleMentiondUserNameClick()}
+            >
               {name}
             </Text>
           </Container>
@@ -241,6 +254,7 @@ export default function Reply({
           blinded={!!blinded}
           deleted={!!deleted}
           text={derivedText}
+          onClick={handleMentiondUserNameClick}
         />
 
         {!deleted && !blinded ? (
@@ -362,11 +376,13 @@ function Content({
   mentionedUser,
   blinded,
   deleted,
+  onClick,
 }: {
   text: string
   mentionedUser?: Writer
   blinded: boolean
   deleted: boolean
+  onClick: () => void
 }) {
   const [unfolded, setUnfolded] = useState(false)
   const foldedPosition = findFoldedPosition(5, text)
@@ -383,6 +399,7 @@ function Content({
                 href={mentionedUser?.href as string}
                 target="new"
                 allowSource="app"
+                onClick={onClick}
               >
                 <MentionUser>{mentionedUser?.name}</MentionUser>
               </ExternalLink>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

현재 2가지의 오류가 있습니다.
- 웹에서 프로필 사진, 닉네임, 멘션된 닉네임을 클릭했을 때, 액션이 없습니다.
- 앱에서 멘션된 닉네임 클릭 시, 아이코가 노출되는 오류가 있습니다.

원인
- 현재 유저 프로필 페이지가 웹에서 구현이 안된 상황(제가 알기론..)에서  inlink url를 사용하다보니 아이코가 노출되고 있는 것 같습니다. 

해결 방법

`onClick` 함수 생성 및 `navigate`를 이용하는 방식으로 수정해보았습니다.
- 웹에서는 `useAppCallback`을 이용해서 트리플 로그인 설치 유도 모달을 렌더링합니다.
- 앱에서는 `navigate`를 이용해서 해당 딥링크로 이동합니다.

[매거진에 댓글달기 테스트 시트 1번](https://docs.google.com/spreadsheets/d/1kzWfbAFQookK-sqi4OnpiAUHx0jKgQyR5X99y2DWPgU/edit#gid=195797161)

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

