### PR TITLE
[replies] 입력창의 오류를 해결합니다. 

### DIFF
--- a/packages/replies/src/auto-resizing-textarea.tsx
+++ b/packages/replies/src/auto-resizing-textarea.tsx
@@ -75,9 +75,9 @@ function AutoResizingTextarea(
 
   useEffect(() => {
     if (value === '') {
-      setRows(1)
+      setRows(minRows)
     }
-  }, [value])
+  }, [value, minRows])
 
   return (
     <Textarea

--- a/packages/replies/src/auto-resizing-textarea.tsx
+++ b/packages/replies/src/auto-resizing-textarea.tsx
@@ -5,6 +5,7 @@ import {
   ForwardedRef,
   useImperativeHandle,
   useRef,
+  useEffect,
 } from 'react'
 import styled from 'styled-components'
 
@@ -71,6 +72,12 @@ function AutoResizingTextarea(
       textareaRef.current?.focus()
     },
   }))
+
+  useEffect(() => {
+    if (value === '') {
+      setRows(1)
+    }
+  }, [value])
 
   return (
     <Textarea

--- a/packages/replies/src/auto-resizing-textarea.tsx
+++ b/packages/replies/src/auto-resizing-textarea.tsx
@@ -18,6 +18,7 @@ const Textarea = styled.textarea<{ lineHeight: number }>`
   padding: 0;
   color: var(--color-gray);
   line-height: ${({ lineHeight }) => lineHeight}px;
+  flex-grow: 2;
 
   ::placeholder {
     color: var(--color-gray300);

--- a/packages/replies/src/register.tsx
+++ b/packages/replies/src/register.tsx
@@ -11,7 +11,8 @@ import { useRepliesContext } from './context'
 import { ResourceType, Reply, Placeholders } from './types'
 
 const RegisterButton = styled.button<{ active: boolean }>`
-  min-width: 26px;
+  width: 26px;
+  white-space: nowrap;
   padding: 0;
   font-size: 15px;
   font-weight: bold;

--- a/packages/replies/src/register.tsx
+++ b/packages/replies/src/register.tsx
@@ -11,7 +11,7 @@ import { useRepliesContext } from './context'
 import { ResourceType, Reply, Placeholders } from './types'
 
 const RegisterButton = styled.button<{ active: boolean }>`
-  width: 26px;
+  min-width: 26px;
   padding: 0;
   font-size: 15px;
   font-weight: bold;


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

3가지 이슈를 수정합니다.
- 버튼의 디자인이 깨지는 오류를 해결합니다.
- 댓글&답글 작성 후, 입력창의 높이가 변경되지 않는 오류를 해결합니다.
- 입력창의 넓이를 flex 속성을 이용해서 확장합니다.

[매거진에 댓글 달기 테스트 시트 5번](https://docs.google.com/spreadsheets/d/1kzWfbAFQookK-sqi4OnpiAUHx0jKgQyR5X99y2DWPgU/edit#gid=195797161)

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경내역

- 등록 버튼의 최소 넓이를 지정합니다.
- useEffect를 이용해서 입력된 값이 없을 때, Textarea의 높이를 초기화합니다.
- flex-grow 속성을 사용해서, 확장합니다.