### PR TITLE
[type-definitions] ESLint 검사를 활성화하고 오류를 수정합니다.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,7 +9,6 @@ packages/i18n
 packages/react-hooks
 packages/scrap-button
 packages/style-box
-packages/type-definitions
 packages/web-storage
 packages/listing-filter
 packages/static-page-contents

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,14 @@
 # 마이그레이션 가이드
 
+## v6 to v7
+
+### type-definitions 인터페이스의 네이밍 변경
+
+다음과 같은 네이밍 변경이 있었습니다.
+
+- PointGeoJSON -> PointGeoJson
+- ListingPOI -> ListingPoi
+
 ## v5 to v6
 
 ### map 구조 변경 및 기존 컴포넌트 오타 수정

--- a/docs/stories/map/types.ts
+++ b/docs/stories/map/types.ts
@@ -1,6 +1,6 @@
 import type {
   TranslatedProperty,
-  PointGeoJSON,
+  PointGeoJson,
   ImageMeta,
 } from '@titicaca/type-definitions'
 
@@ -36,7 +36,7 @@ export interface HotelResourceType {
     regionId: string
     names: TranslatedProperty
     comment: string
-    pointGeolocation: PointGeoJSON
+    pointGeolocation: PointGeoJson
     grade: number
     areas: BaseResourceType[]
     image: ImageMeta
@@ -87,7 +87,7 @@ export interface RecommendationItineraryPoiCard {
     addresses: TranslatedProperty
     location: number[]
     comment: string
-    pointGeolocation: PointGeoJSON
+    pointGeolocation: PointGeoJson
     grade: number
     areas: BaseResourceType[]
     categories?: BaseResourceType[] // type: [attraction, restaurant]

--- a/docs/stories/scroll-spy/scroll-spy.stories.tsx
+++ b/docs/stories/scroll-spy/scroll-spy.stories.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { ComponentStoryObj, Meta } from '@storybook/react'
 import { ScrollSpyContainer, ScrollSpyEntity } from '@titicaca/scroll-spy'
 import { PoiListElement } from '@titicaca/poi-list-elements'
-import { ListingPOI } from '@titicaca/type-definitions'
+import { ListingPoi } from '@titicaca/type-definitions'
 
 import POIS from '../__mocks__/pois.sample.json'
 
@@ -23,7 +23,7 @@ function ScrollSpy() {
         return (
           <ScrollSpyEntity key={id} id={id}>
             <div onClick={() => setActiveId(id)}>
-              <PoiListElement as="div" poi={poi as unknown as ListingPOI} />
+              <PoiListElement as="div" poi={poi as unknown as ListingPoi} />
             </div>
           </ScrollSpyEntity>
         )

--- a/packages/map/src/focus-tracker.tsx
+++ b/packages/map/src/focus-tracker.tsx
@@ -1,6 +1,6 @@
 import { useGoogleMap } from '@react-google-maps/api'
 import { useEffect } from 'react'
-import { PointGeoJSON } from '@titicaca/type-definitions'
+import { PointGeoJson } from '@titicaca/type-definitions'
 
 const AUTO_ZOOM_THRESHORLD = 10
 
@@ -8,7 +8,7 @@ export function FocusTracker({
   focusGeolocation,
   activeAutoZoom = false,
 }: {
-  focusGeolocation?: PointGeoJSON
+  focusGeolocation?: PointGeoJson
   activeAutoZoom?: boolean
 }) {
   const map = useGoogleMap()

--- a/packages/nearby-pois/src/nearby-pois.tsx
+++ b/packages/nearby-pois/src/nearby-pois.tsx
@@ -9,7 +9,7 @@ import {
   Paragraph,
 } from '@titicaca/core-elements'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
-import { PointGeoJSON } from '@titicaca/type-definitions'
+import { PointGeoJson } from '@titicaca/type-definitions'
 
 import { NearByPoiType } from './types'
 import nearbyPoisReducer, {
@@ -55,7 +55,7 @@ export default function NearbyPois({
   poiId: string
   regionId?: string
   initialTab?: NearByPoiType
-  geolocation: PointGeoJSON
+  geolocation: PointGeoJson
   optimized?: boolean
 } & Parameters<typeof Section>['0']) {
   const [{ currentTab, ...state }, dispatch] = useReducer(nearbyPoisReducer, {

--- a/packages/poi-list-elements/src/types.ts
+++ b/packages/poi-list-elements/src/types.ts
@@ -1,7 +1,7 @@
 import { ReactNode, MouseEventHandler } from 'react'
 import {
   ImageMeta,
-  PointGeoJSON,
+  PointGeoJson,
   TranslatedProperty,
 } from '@titicaca/type-definitions'
 
@@ -39,8 +39,8 @@ export interface PoiListElementType {
     reviewsRating?: number
     grade?: number
     id?: string
-    geolocation?: PointGeoJSON
-    pointGeolocation?: PointGeoJSON
+    geolocation?: PointGeoJson
+    pointGeolocation?: PointGeoJson
     regionId?: string
     image?: ImageMeta
     names: TranslatedProperty

--- a/packages/type-definitions/src/geojson.ts
+++ b/packages/type-definitions/src/geojson.ts
@@ -1,4 +1,4 @@
-export interface PointGeoJSON {
+export interface PointGeoJson {
   type: 'Point'
   coordinates: [number, number]
 }

--- a/packages/type-definitions/src/image.ts
+++ b/packages/type-definitions/src/image.ts
@@ -1,13 +1,13 @@
-interface ImageURL {
+interface ImageUrl {
   url: string
 }
 
 interface CamelSmallSquare {
-  smallSquare: ImageURL
+  smallSquare: ImageUrl
 }
 
 interface SnakeSmallSquare {
-  small_square: ImageURL
+  small_square: ImageUrl
 }
 
 type SmallSquare = CamelSmallSquare | SnakeSmallSquare
@@ -48,8 +48,8 @@ export interface ImageMeta {
   cloudinaryId?: string
   cloudinaryBucket?: string
   sizes: {
-    full: ImageURL
-    large: ImageURL
+    full: ImageUrl
+    large: ImageUrl
   } & SmallSquare
   video?: {
     full: { url: string }

--- a/packages/type-definitions/src/listing-poi.ts
+++ b/packages/type-definitions/src/listing-poi.ts
@@ -1,8 +1,8 @@
 import { TranslatedProperty } from './translated-property'
 import { ImageMeta } from './image'
-import { PointGeoJSON } from './geojson'
+import { PointGeoJson } from './geojson'
 
-interface ListingPOISourceBase {
+interface ListingPoiSourceBase {
   id: string
   areas?: { name: string }[]
   categories?: { id: string; filter?: boolean; name: string }[]
@@ -11,14 +11,14 @@ interface ListingPOISourceBase {
   hasTnaProducts?: boolean
   image?: ImageMeta
   names: TranslatedProperty
-  pointGeolocation: PointGeoJSON
+  pointGeolocation: PointGeoJson
   reviewsRating?: number
   reviewsCount?: number
   scrapsCount?: number
   vicinity?: string
 }
 
-interface ListingPOIBase {
+interface ListingPoiBase {
   id: string
   nameOverride?: string
   reviewed: boolean
@@ -27,25 +27,25 @@ interface ListingPOIBase {
   categories?: { id: string; name: string }[]
 }
 
-export interface ListingAttraction extends ListingPOIBase {
+export interface ListingAttraction extends ListingPoiBase {
   type: 'attraction'
-  source: ListingPOISourceBase & {
+  source: ListingPoiSourceBase & {
     type: 'attraction'
     regionId: string
   }
 }
 
-export interface ListingRestaurant extends ListingPOIBase {
+export interface ListingRestaurant extends ListingPoiBase {
   type: 'restaurant'
-  source: ListingPOISourceBase & {
+  source: ListingPoiSourceBase & {
     type: 'restaurant'
     regionId: string
   }
 }
 
-export interface ListingHotel extends ListingPOIBase {
+export interface ListingHotel extends ListingPoiBase {
   type: 'hotel'
-  source: ListingPOISourceBase & {
+  source: ListingPoiSourceBase & {
     type: 'hotel'
     regionId?: string
     starRating: number
@@ -53,4 +53,4 @@ export interface ListingHotel extends ListingPOIBase {
   }
 }
 
-export type ListingPOI = ListingAttraction | ListingRestaurant | ListingHotel
+export type ListingPoi = ListingAttraction | ListingRestaurant | ListingHotel

--- a/packages/view-utilities/src/measure-distance.ts
+++ b/packages/view-utilities/src/measure-distance.ts
@@ -1,5 +1,5 @@
 import haversine from 'haversine'
-import { PointGeoJSON } from '@titicaca/type-definitions'
+import { PointGeoJson } from '@titicaca/type-definitions'
 
 /**
  * 맵상에서의 직선거리를 구하는 함수
@@ -10,8 +10,8 @@ import { PointGeoJSON } from '@titicaca/type-definitions'
  * - https://en.wikipedia.org/wiki/Haversine_formula
  */
 export function measureDistance(
-  { coordinates: [fromLon, fromLat] }: PointGeoJSON,
-  { coordinates: [toLon, toLat] }: PointGeoJSON,
+  { coordinates: [fromLon, fromLat] }: PointGeoJson,
+  { coordinates: [toLon, toLat] }: PointGeoJson,
 ) {
   return Math.round(
     haversine(


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
Related to https://github.com/titicacadev/triple-frontend/issues/1755

https://github.com/titicacadev/triple-frontend/pull/1737 에서 비활성화했던 type-definitions 디렉토리의 ESLint 검사를 다시 활성화합니다. 그리고 발생한 오류를 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- .eslintignore에서 listing-filter 를 제거합니다.
- naming convention 오류에 대응합니다.
- explicit-member-accessibility 오류에 대응합니다.
- Props 스키마에 변화가 있습니다. (Breaking change입니다.)
  - PointGeoJSON -> PointGeoJson
  - ListingPOI -> ListingPoi