### PR TITLE
[web-storage] ESLint 검사를 활성화하고 오류를 수정합니다.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,7 +6,6 @@ packages/*/lib/**
 docs/storybook-static
 
 packages/i18n
-packages/react-hooks
 packages/type-definitions
 packages/listing-filter
 packages/public-header

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,8 +6,8 @@ packages/*/lib/**
 docs/storybook-static
 
 packages/i18n
-packages/style-box
-packages/web-storage
+packages/react-hooks
+packages/type-definitions
 packages/listing-filter
 packages/public-header
 packages/ab-experiments

--- a/packages/web-storage/src/boundary.tsx
+++ b/packages/web-storage/src/boundary.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { Component } from 'react'
 import { Alert } from '@titicaca/modals'
 
 import { WebStorageError } from './error'
@@ -15,14 +15,14 @@ export class WebStorageErrorBoundary extends Component<
   WebStorageErrorBoundaryProps,
   WebStorageErrorBoundaryState
 > {
-  constructor(props: WebStorageErrorBoundaryProps) {
+  public constructor(props: WebStorageErrorBoundaryProps) {
     super(props)
 
     this.state = { error: null }
   }
 
-  static getDerivedStateFromError(
-    error: any,
+  public static getDerivedStateFromError(
+    error: Error,
   ): Partial<WebStorageErrorBoundaryState> {
     if (error instanceof WebStorageError) {
       return { error }
@@ -31,13 +31,13 @@ export class WebStorageErrorBoundary extends Component<
     return { error: null }
   }
 
-  componentDidCatch(error: Error) {
+  public componentDidCatch(error: Error) {
     if (!(error instanceof WebStorageError)) {
       throw error
     }
   }
 
-  render() {
+  public render() {
     const {
       props: { onConfirm, children },
       state: { error },

--- a/packages/web-storage/src/error.ts
+++ b/packages/web-storage/src/error.ts
@@ -2,14 +2,14 @@ import { CustomError } from 'ts-custom-error'
 
 import { WebStorageType } from './types'
 
-type ErrorType = 'NotBrowser' | 'Unavailable' | 'QuotaExceeded'
+type ErrorType = 'notBrowser' | 'unavailable' | 'quotaExceeded'
 
 export class WebStorageError extends CustomError {
   private type: ErrorType
 
   private storageType: WebStorageType
 
-  constructor({
+  public constructor({
     type,
     storageType,
   }: {
@@ -17,9 +17,9 @@ export class WebStorageError extends CustomError {
     storageType: WebStorageType
   }) {
     const messageMap: { [key in ErrorType]: string } = {
-      NotBrowser: '브라우저 환경일 때만 WebStorage API를 사용할 수 있습니다.',
-      Unavailable: `${storageType}에 접근할 수 없습니다.`,
-      QuotaExceeded: `${storageType}의 허용된 용량을 모두 사용했습니다.`,
+      notBrowser: '브라우저 환경일 때만 WebStorage API를 사용할 수 있습니다.',
+      unavailable: `${storageType}에 접근할 수 없습니다.`,
+      quotaExceeded: `${storageType}의 허용된 용량을 모두 사용했습니다.`,
     }
 
     super(messageMap[type])
@@ -27,16 +27,16 @@ export class WebStorageError extends CustomError {
     this.storageType = storageType
   }
 
-  get userGuideMessage() {
+  public get userGuideMessage() {
     switch (this.type) {
-      case 'NotBrowser':
+      case 'notBrowser':
         return '브라우저에서 사용해주세요.'
-      case 'QuotaExceeded':
+      case 'quotaExceeded':
         if (this.storageType === 'sessionStorage') {
           return '브라우저를 완전히 종료하고 다시 접속해 주세요.'
         }
         return '브라우저 캐시를 모두 비워주세요.'
-      case 'Unavailable':
+      case 'unavailable':
         return '브라우저의 쿠키 차단 설정을 해제해주세요.'
       default:
         return '알 수 없는 에러가 발생했습니다. 잠시 후 다시 시도해 주세요.'

--- a/packages/web-storage/src/storage.ts
+++ b/packages/web-storage/src/storage.ts
@@ -16,7 +16,7 @@ function addCookieKeyPrefix(key: string) {
 
 function getCookieStorage({ storageType }: { storageType: WebStorageType }) {
   if (!cookieAvailable()) {
-    throw new WebStorageError({ type: 'Unavailable', storageType })
+    throw new WebStorageError({ type: 'unavailable', storageType })
   }
 
   const cookie = new Cookies()
@@ -46,7 +46,7 @@ function getCookieStorage({ storageType }: { storageType: WebStorageType }) {
       } catch (error) {
         if (checkQuotaExceededError(error)) {
           throw new WebStorageError({
-            type: 'QuotaExceeded',
+            type: 'quotaExceeded',
             storageType,
           })
         }
@@ -69,7 +69,7 @@ function getCookieStorage({ storageType }: { storageType: WebStorageType }) {
 
 export function getWebStorage(type: WebStorageType = 'localStorage') {
   if (typeof window === 'undefined') {
-    throw new WebStorageError({ type: 'NotBrowser', storageType: type })
+    throw new WebStorageError({ type: 'notBrowser', storageType: type })
   }
 
   if (!storageAvailable(type)) {
@@ -97,7 +97,7 @@ export function getWebStorage(type: WebStorageType = 'localStorage') {
       } catch (error) {
         if (checkQuotaExceededError(error)) {
           throw new WebStorageError({
-            type: 'QuotaExceeded',
+            type: 'quotaExceeded',
             storageType: type,
           })
         }

--- a/packages/web-storage/src/utils.ts
+++ b/packages/web-storage/src/utils.ts
@@ -7,7 +7,7 @@ import { WebStorageType } from './types'
  * 참고: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#testing_for_availability
  * @param error
  */
-export function checkQuotaExceededError(error: any): boolean {
+export function checkQuotaExceededError(error: Error): boolean {
   return (
     error instanceof DOMException &&
     // everything except Firefox


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
Related to https://github.com/titicacadev/triple-frontend/issues/1755

https://github.com/titicacadev/triple-frontend/pull/1737 에서 비활성화했던 web-storage 디렉토리의 ESLint 검사를 다시 활성화합니다. 그리고 발생한 오류를 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경내역
- .eslintignore에서 listing-filter 를 제거합니다.
- naming convention 오류에 대응합니다.
- explicit-member-accessibility 오류에 대응합니다.