### PR TITLE
[static-page-contents] ESLint 검사를 활성화하고 오류를 수정합니다.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,7 +10,6 @@ packages/style-box
 packages/type-definitions
 packages/web-storage
 packages/listing-filter
-packages/static-page-contents
 packages/public-header
 packages/ab-experiments
 packages/action-sheet

--- a/packages/static-page-contents/src/index.tsx
+++ b/packages/static-page-contents/src/index.tsx
@@ -1,26 +1,6 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react'
 import styled from 'styled-components'
 import { gray500, gray, blue, brightGray } from '@titicaca/color-palette'
-
-function useFetchStatic(url: string) {
-  const [content, setContent] = useState<string>('')
-  const [init, setInit] = useState<boolean>(false)
-
-  const fetchStatic = useCallback(async () => {
-    const response = await fetch(`/pages/${url}`)
-
-    const html = await response.text()
-    const [, bodyHTML] = html.match(/<body[^>]*>((.|[\n\r])*)<\/body>/im) || [
-      '',
-      '',
-    ]
-
-    setContent(response.ok ? bodyHTML : '')
-    setInit(true)
-  }, [url])
-
-  return { content, init, fetchStatic }
-}
 
 const Contents = styled.div`
   padding: 20px;
@@ -113,4 +93,24 @@ export function StaticPageContents({
     default:
       return onFallback()
   }
+}
+
+function useFetchStatic(url: string) {
+  const [content, setContent] = useState<string>('')
+  const [init, setInit] = useState<boolean>(false)
+
+  const fetchStatic = useCallback(async () => {
+    const response = await fetch(`/pages/${url}`)
+
+    const html = await response.text()
+    const [, bodyHtml] = html.match(/<body[^>]*>((.|[\n\r])*)<\/body>/im) || [
+      '',
+      '',
+    ]
+
+    setContent(response.ok ? bodyHtml : '')
+    setInit(true)
+  }, [url])
+
+  return { content, init, fetchStatic }
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
Related to https://github.com/titicacadev/triple-frontend/issues/1755

https://github.com/titicacadev/triple-frontend/pull/1737 에서 비활성화했던 static-page-contents 디렉토리의 ESLint 검사를 다시 활성화합니다. 그리고 발생한 오류를 수정합니다.

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역 
- .eslintignore에서 static-page-contents 를 제거합니다.
- naming convention 오류에 대응합니다.
- triple-code-convention 을 적용합니다.
