### PR TITLE
[ab-experiments] ESLint 검사를 활성화하고 오류를 수정합니다.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,4 +6,4 @@ packages/*/lib/**
 docs/storybook-static
 
 packages/i18n
-packages/ab-experiments
+

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,4 +6,3 @@ packages/*/lib/**
 docs/storybook-static
 
 packages/i18n
-

--- a/packages/ab-experiments/src/google-optimize-context/context.tsx
+++ b/packages/ab-experiments/src/google-optimize-context/context.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, PropsWithChildren, createContext, useContext } from 'react';
+import {
+  useState,
+  useEffect,
+  PropsWithChildren,
+  createContext,
+  useContext,
+} from 'react'
 import Head from 'next/head'
 
 declare global {
@@ -22,7 +28,7 @@ export function GoogleOptimizeExperimentProvider({
   const [variant, setVariant] = useState<number>(-1)
 
   useEffect(() => {
-    function gtag(...args: any[]) {
+    function gtag(...args: unknown[]) {
       if (window.dataLayer) {
         window.dataLayer.push(args)
       } else {

--- a/packages/ab-experiments/src/triple-ab-experiment-context/context.tsx
+++ b/packages/ab-experiments/src/triple-ab-experiment-context/context.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import {
   createContext,
   PropsWithChildren,
@@ -7,7 +8,7 @@ import {
   useMemo,
   useRef,
   useState,
-} from 'react';
+} from 'react'
 import {
   useEventTrackingContext,
   useSessionAvailability,
@@ -64,11 +65,10 @@ export function TripleABExperimentProvider({
     }
   }, [metaFromSSR, sessionAvailable, slug])
 
-  const value = useMemo(() => ({ ...experimentMetas, [slug]: meta }), [
-    experimentMetas,
-    slug,
-    meta,
-  ])
+  const value = useMemo(
+    () => ({ ...experimentMetas, [slug]: meta }),
+    [experimentMetas, slug, meta],
+  )
 
   return (
     <TripleABExperimentContext.Provider value={value}>

--- a/packages/ab-experiments/src/triple-ab-experiment-context/service.ts
+++ b/packages/ab-experiments/src/triple-ab-experiment-context/service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { get, HttpResponse, RequestOptions } from '@titicaca/fetcher'
 
 export interface TripleABExperimentMeta {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

Related to https://github.com/titicacadev/triple-frontend/issues/1755

https://github.com/titicacadev/triple-frontend/pull/1737 에서 비활성화했던 ab-experiments 디렉토리의 ESLint 검사를 다시 활성화합니다. 그리고 발생한 오류를 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역 
- .eslintignore에서 ab-experiments 를 제거합니다.
- naming convention 오류에 대응합니다.
