### PR TITLE
[app-banner] ESLint 검사를 활성화하고 오류를 수정합니다.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,7 +14,6 @@ packages/static-page-contents
 packages/public-header
 packages/ab-experiments
 packages/action-sheet
-packages/app-banner
 packages/app-installation-cta
 packages/author
 packages/content-sharing

--- a/packages/app-banner/src/index.tsx
+++ b/packages/app-banner/src/index.tsx
@@ -75,7 +75,7 @@ export default function AppBanner({
   description,
   cta,
   href,
-  onCTAClick,
+  onCtaClick,
   zTier,
   zIndex = 1,
   ...props
@@ -84,7 +84,7 @@ export default function AppBanner({
   description?: string
   cta?: string
   href?: string
-  onCTAClick?: (e?: SyntheticEvent) => any
+  onCtaClick?: (e?: SyntheticEvent) => void
 } & LayeringMixinProps) {
   return (
     <AppBannerFrame {...props} zTier={zTier} zIndex={zIndex}>
@@ -103,7 +103,7 @@ export default function AppBanner({
           {description}
         </Text>
       </ContentContainer>
-      <CallToAction href={href} onClick={onCTAClick}>
+      <CallToAction href={href} onClick={onCtaClick}>
         {cta || '앱에서 보기'}
       </CallToAction>
     </AppBannerFrame>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

Related to https://github.com/titicacadev/triple-frontend/issues/1755

https://github.com/titicacadev/triple-frontend/pull/1737 에서 비활성화했던 app-banner 디렉토리의 ESLint 검사를 다시 활성화합니다. 그리고 발생한 오류를 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역 
- .eslintignore에서 app-banner 를 제거합니다.
- naming convention 오류에 대응합니다.
- Props 스키마에 변화가 있습니다. (Breaking change입니다.)
  - onCTAClick -> onCtaClick