### PR TITLE
[app-installation-cta] ESLint 검사를 활성화하고 오류를 수정합니다.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,4 +8,3 @@ docs/storybook-static
 packages/i18n
 packages/ab-experiments
 packages/action-sheet
-packages/app-installation-cta

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,7 @@
 
 ## v6 to v7
 
-### 네이밍이 변경된 패키지가 있습니다.
+### 네이밍이 변경된 패키지
 
 #### app-installation-cta
 
@@ -14,10 +14,10 @@
 
 #### poi-list-elements
 
-- POICardElement => PoiCardElement
-- POIListElementBaseProps => PoiListElementBaseProps
+- POICardElement -> PoiCardElement
+- POIListElementBaseProps -> PoiListElementBaseProps
 
-### type-definitions
+#### type-definitions
 
 - PointGeoJSON -> PointGeoJson
 - ListingPOI -> ListingPoi

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,16 +2,22 @@
 
 ## v6 to v7
 
-### poi-list-elements
+### 네이밍이 변경된 패키지가 있습니다.
 
-다음과 같은 네이밍 변경이 있었습니다.
+#### app-installation-cta
+
+- AppInstallationCTA -> AppInstallationCta
+- ArticleCardCTA -> ArticleCardCta
+- BannerCTA -> BannerCta
+- ChatbotCTA -> ChatbotCta
+- FloatingButtonCTA -> FloatingButtonCta
+
+#### poi-list-elements
 
 - POICardElement => PoiCardElement
 - POIListElementBaseProps => PoiListElementBaseProps
 
-### type-definitions 인터페이스의 네이밍 변경
-
-다음과 같은 네이밍 변경이 있었습니다.
+### type-definitions
 
 - PointGeoJSON -> PointGeoJson
 - ListingPOI -> ListingPoi

--- a/packages/app-installation-cta/src/app-installation-cta.tsx
+++ b/packages/app-installation-cta/src/app-installation-cta.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react';
+import { useState } from 'react'
 import { LayeringMixinProps } from '@titicaca/core-elements'
 
 import { Overlay, BottomFixedContainer } from './elements'
 import ImageBanner from './image-banner'
 import TextBanner from './text-banner'
 
-interface AppInstallationCTAProps {
+interface AppInstallationCtaProps {
   imgUrl: string
   installUrl: string
   message: string
@@ -14,13 +14,13 @@ interface AppInstallationCTAProps {
 /**
  * @deprecated 구체적인 형태의 컴포넌트인 BannerCTA를 사용하세요
  */
-export default function AppInstallationCTA({
+export default function AppInstallationCta({
   imgUrl,
   installUrl,
   message,
   zTier,
   zIndex,
-}: AppInstallationCTAProps & LayeringMixinProps) {
+}: AppInstallationCtaProps & LayeringMixinProps) {
   const [isImageBannerOpen, setIsImageBannerOpen] = useState(true)
 
   if (isImageBannerOpen) {

--- a/packages/app-installation-cta/src/article-card-cta/article-card-cta.tsx
+++ b/packages/app-installation-cta/src/article-card-cta/article-card-cta.tsx
@@ -1,10 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback } from 'react'
 import { Image } from '@titicaca/core-elements'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { StaticIntersectionObserver } from '@titicaca/intersection-observer'
 import { InventoryItemMeta } from '@titicaca/type-definitions'
 
-export default function ArticleCardCTA({
+export default function ArticleCardCta({
   href,
   cta,
   onClick,
@@ -15,13 +15,13 @@ export default function ArticleCardCTA({
 }) {
   const { trackEvent } = useEventTrackingContext()
 
-  const handleCTAIntersect = useCallback(() => {
+  const handleCtaIntersect = useCallback(() => {
     trackEvent({
       ga: ['앱설치 유도 구좌_노출', cta?.desc || ''],
     })
   }, [cta, trackEvent])
 
-  const handleCTAClick = useCallback(() => {
+  const handleCtaClick = useCallback(() => {
     trackEvent({
       ga: ['앱설치 유도 구좌_선택', cta?.desc || ''],
     })
@@ -32,7 +32,7 @@ export default function ArticleCardCTA({
     isIntersecting,
   }: {
     isIntersecting: boolean
-  }) => isIntersecting && handleCTAIntersect()
+  }) => isIntersecting && handleCtaIntersect()
 
   return (
     <StaticIntersectionObserver
@@ -41,7 +41,7 @@ export default function ArticleCardCTA({
     >
       <a href={href}>
         <Image borderRadius={6}>
-          <Image.FixedRatioFrame frame="big" onClick={handleCTAClick}>
+          <Image.FixedRatioFrame frame="big" onClick={handleCtaClick}>
             <Image.Img src={cta?.image} />
           </Image.FixedRatioFrame>
         </Image>

--- a/packages/app-installation-cta/src/banner-cta.tsx
+++ b/packages/app-installation-cta/src/banner-cta.tsx
@@ -1,14 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react'
 import { LayeringMixinProps } from '@titicaca/core-elements'
 import { InventoryItemMeta } from '@titicaca/type-definitions'
 
 import { Overlay, BottomFixedContainer } from './elements'
 import ImageBanner from './image-banner'
 import TextBanner from './text-banner'
-import { CTAProps } from './interfaces'
+import { CtaProps } from './interfaces'
 import { fetchInventoryItems } from './service'
 
-interface BannerCTAProps extends CTAProps {
+interface BannerCtaProps extends CtaProps {
   inventoryId: string
   installUrl: string
   installText?: string
@@ -22,7 +22,7 @@ interface BannerCTAProps extends CTAProps {
  * @param inventoryId 표시할 이미지의 인벤토리 ID
  * @param installUrl 앱 설치 URL
  */
-export default function BannerCTA({
+export default function BannerCta({
   inventoryId,
   installUrl,
   onShow,
@@ -33,13 +33,13 @@ export default function BannerCTA({
   disableTextBanner,
   zTier,
   zIndex,
-}: BannerCTAProps & LayeringMixinProps) {
+}: BannerCtaProps & LayeringMixinProps) {
   const [inventoryItem, setInventoryItem] = useState<InventoryItemMeta>()
   const [isImageBannerOpen, setIsImageBannerOpen] = useState(true)
   const { image = '', desc = '' } = inventoryItem || {}
 
   useEffect(() => {
-    async function fetchCTAImage() {
+    async function fetchCtaImage() {
       const items = await fetchInventoryItems({ inventoryId })
 
       if (items) {
@@ -55,7 +55,7 @@ export default function BannerCTA({
         }
       }
     }
-    fetchCTAImage()
+    fetchCtaImage()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inventoryId])
 

--- a/packages/app-installation-cta/src/chatbot-cta.tsx
+++ b/packages/app-installation-cta/src/chatbot-cta.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { Text, LayeringMixinProps } from '@titicaca/core-elements'
 import { CSSTransition } from 'react-transition-group'
 import { InventoryItemMeta } from '@titicaca/type-definitions'
@@ -8,7 +8,7 @@ import {
   CHATBOT_CLOSED_STORAGE_KEY,
   EVENT_CHATBOT_CTA_READY,
 } from './constants'
-import { CTAProps } from './interfaces'
+import { CtaProps } from './interfaces'
 import {
   ChatbotContainer,
   ChatBalloon,
@@ -17,7 +17,7 @@ import {
   ChatbotIcon,
 } from './elements'
 
-interface ChatbotCTAProps extends CTAProps {
+interface ChatbotCtaProps extends CtaProps {
   available?: boolean
   inventoryId: string
   installUrl: string
@@ -32,7 +32,7 @@ interface ChatbotCTAProps extends CTAProps {
  * @param installUrl 앱 설치 URL
  * @param unmountOnExit 표시되지 않는 상태일 때 컴포넌트 마운트 해제
  */
-export default function ChatbotCTA({
+export default function ChatbotCta({
   available = false,
   inventoryId,
   installUrl,
@@ -42,7 +42,7 @@ export default function ChatbotCTA({
   zTier,
   zIndex,
   unmountOnExit,
-}: ChatbotCTAProps & LayeringMixinProps) {
+}: ChatbotCtaProps & LayeringMixinProps) {
   const [inventoryItem, setInventoryItem] = useState<InventoryItemMeta>()
   const [visibility, setVisibility] = useState(false)
   const chatbotContainerRef = useRef<HTMLDivElement>(null)

--- a/packages/app-installation-cta/src/constants.ts
+++ b/packages/app-installation-cta/src/constants.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 export enum BannerExitStrategy {
   NONE = 'NONE',
   CHATBOT_READY = 'CHATBOT_READY',

--- a/packages/app-installation-cta/src/floating-button-cta.tsx
+++ b/packages/app-installation-cta/src/floating-button-cta.tsx
@@ -1,4 +1,5 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useState, useCallback, useEffect, useRef } from 'react'
 import {
   Text,
   MarginPadding,
@@ -13,7 +14,7 @@ import {
   EVENT_CHATBOT_CTA_READY,
   FLOATING_BUTTON_CLOSED_STORAGE_KEY,
 } from './constants'
-import { CTAProps } from './interfaces'
+import { CtaProps } from './interfaces'
 import {
   FloatingButtonContainer,
   InstallAnchor,
@@ -22,7 +23,7 @@ import {
   FloatingButton,
 } from './elements'
 
-interface FloatingButtonCTAProps extends CTAProps {
+interface FloatingButtonCtaProps extends CtaProps {
   exitStrategy?: BannerExitStrategy
   fixed?: boolean
   appInstallLink?: string
@@ -47,7 +48,7 @@ interface FloatingButtonCTAProps extends CTAProps {
  * @param trackEventParams GA/FA 수집 파라미터
  * @param unmountOnExit 버튼이 표시되지 않을 때 컴포넌트 마운트 해제 여부
  */
-export default function FloatingButtonCTA({
+export default function FloatingButtonCta({
   exitStrategy = BannerExitStrategy.NONE,
   fixed,
   appInstallLink,
@@ -62,7 +63,7 @@ export default function FloatingButtonCTA({
   zTier,
   zIndex,
   unmountOnExit,
-}: FloatingButtonCTAProps & LayeringMixinProps) {
+}: FloatingButtonCtaProps & LayeringMixinProps) {
   const [buttonVisibility, setButtonVisibility] = useState(false)
   const [available, setAvailable] = useState(true)
   const floatingButtonContainerRef = useRef<HTMLDivElement>(null)

--- a/packages/app-installation-cta/src/image-banner.tsx
+++ b/packages/app-installation-cta/src/image-banner.tsx
@@ -7,9 +7,9 @@ import {
   InstallLink,
   DismissButton,
 } from './elements'
-import { CTAProps } from './interfaces'
+import { CtaProps } from './interfaces'
 
-interface ImageBannerProps extends CTAProps {
+interface ImageBannerProps extends CtaProps {
   imgUrl?: string
   installUrl: string
   installText?: string
@@ -61,7 +61,10 @@ export default function ImageBanner({
       </ImageWrapper>
 
       <InstallLink href={installUrl} onClick={handleClick}>
-        👀&nbsp;&nbsp;{installText || '편하게 앱에서 보기'}
+        <span role="img" aria-label="eyes">
+          👀
+        </span>
+        <span>&nbsp;&nbsp;{installText || '편하게 앱에서 보기'}</span>
       </InstallLink>
 
       <DismissButton onClick={handleDismiss}>

--- a/packages/app-installation-cta/src/interfaces.ts
+++ b/packages/app-installation-cta/src/interfaces.ts
@@ -1,6 +1,6 @@
 import { InventoryItemMeta } from '@titicaca/type-definitions'
 
-export interface CTAProps {
+export interface CtaProps {
   onShow?: (item?: InventoryItemMeta) => void
   onClick?: (item?: InventoryItemMeta) => void
   onDismiss?: (item?: InventoryItemMeta) => void

--- a/packages/app-installation-cta/src/text-banner.tsx
+++ b/packages/app-installation-cta/src/text-banner.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react'
 
 import { TextBannerWrapper, DownloadIcon } from './elements'
-import { CTAProps } from './interfaces'
+import { CtaProps } from './interfaces'
 
-interface TextBannerProps extends CTAProps {
+interface TextBannerProps extends CtaProps {
   message: string
   installUrl: string
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
Related to https://github.com/titicacadev/triple-frontend/issues/1755

https://github.com/titicacadev/triple-frontend/pull/1737 에서 비활성화했던 app-installation-cta 디렉토리의 ESLint 검사를 다시 활성화합니다. 그리고 발생한 오류를 수정합니다.

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역 
- .eslintignore에서 static-page-contents 를 제거합니다.
- naming convention 오류에 대응합니다.
- Component 명에 변화가 있습니다. (Breaking change입니다.)
  - AppInstallationCTA -> AppInstallationCta
  - ArticleCardCTA -> ArticleCardCta
  - BannerCTA -> BannerCta
  - ChatbotCTA -> ChatbotCta
  - FloatingButtonCTA -> FloatingButtonCta