### PR TITLE
[author] ESLint, Stylelint 검사를 활성화하고 오류를 수정합니다.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,10 +6,9 @@ packages/*/lib/**
 docs/storybook-static
 
 packages/i18n
-packages/type-definitions
 packages/public-header
 packages/ab-experiments
 packages/action-sheet
 packages/app-installation-cta
-packages/author
 packages/poi-detail
+

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -5,4 +5,3 @@ package-lock.json
 packages/*/lib/**
 docs/storybook-static
 
-packages/author

--- a/package-lock.json
+++ b/package-lock.json
@@ -43534,7 +43534,8 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^6.4.0",
-        "@titicaca/core-elements": "^6.4.0"
+        "@titicaca/core-elements": "^6.4.0",
+        "@titicaca/type-definitions": "^6.4.0"
       }
     },
     "packages/booking-completion": {
@@ -57942,7 +57943,8 @@
       "version": "file:packages/author",
       "requires": {
         "@titicaca/color-palette": "^6.4.0",
-        "@titicaca/core-elements": "^6.4.0"
+        "@titicaca/core-elements": "^6.4.0",
+        "@titicaca/type-definitions": "*"
       }
     },
     "@titicaca/booking-completion": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -57944,7 +57944,7 @@
       "requires": {
         "@titicaca/color-palette": "^6.4.0",
         "@titicaca/core-elements": "^6.4.0",
-        "@titicaca/type-definitions": "*"
+        "@titicaca/type-definitions": "^6.4.0"
       }
     },
     "@titicaca/booking-completion": {

--- a/packages/author/package.json
+++ b/packages/author/package.json
@@ -17,6 +17,7 @@
   ],
   "dependencies": {
     "@titicaca/color-palette": "^6.4.0",
-    "@titicaca/core-elements": "^6.4.0"
+    "@titicaca/core-elements": "^6.4.0",
+    "@titicaca/type-definitions": "^6.4.0"
   }
 }

--- a/packages/author/src/index.tsx
+++ b/packages/author/src/index.tsx
@@ -1,4 +1,5 @@
 import { Container, Text, MarginPadding, Image } from '@titicaca/core-elements'
+import { ImageMeta } from '@titicaca/type-definitions'
 
 import AuthorIntro from './author-intro'
 
@@ -11,7 +12,7 @@ export default function Author({
   source: {
     name: string
     bio?: string
-    image?: any
+    image?: ImageMeta
     intro?: { text?: string; rawHTML?: string }
   }
   bioOverride?: string

--- a/packages/author/tsconfig.build.json
+++ b/packages/author/tsconfig.build.json
@@ -7,6 +7,9 @@
     },
     {
       "path": "../core-elements/tsconfig.build.json"
+    },
+    {
+      "path": "../type-definitions/tsconfig.build.json"
     }
   ]
 }

--- a/packages/author/tsconfig.json
+++ b/packages/author/tsconfig.json
@@ -6,7 +6,8 @@
     "baseUrl": ".",
     "paths": {
       "@titicaca/color-palette": ["../color-palette/src"],
-      "@titicaca/core-elements": ["../core-elements/src"]
+      "@titicaca/core-elements": ["../core-elements/src"],
+      "@titicaca/type-definitions": ["../type-definitions/src"]
     }
   },
   "include": ["./src"],
@@ -16,6 +17,9 @@
     },
     {
       "path": "../core-elements"
+    },
+    {
+      "path": "../type-definitions"
     }
   ]
 }


### PR DESCRIPTION
## PR 설명
Related to https://github.com/titicacadev/triple-frontend/issues/1755

https://github.com/titicacadev/triple-frontend/pull/1737 에서 비활성화했던 author 디렉토리의 ESLint, StyleLint 검사를 다시 활성화합니다. 그리고 발생한 오류를 수정합니다.

## 변경 내역
- .eslintignore에서 author 를 제거합니다.
- .stylelintignore에서 author 를 제거합니다. 
- image type을 정의합니다.
  - @titicaca/type-definitions 패키지 추가