### PR TITLE
[router] 앱 사용중 여부를 react-triple-client-interfaces 패키지의 정보로 구분합니다.

### DIFF
--- a/docs/stories/booking-completion/booking-completion.stories.tsx
+++ b/docs/stories/booking-completion/booking-completion.stories.tsx
@@ -4,12 +4,17 @@ import { ComponentStoryObj, Meta } from '@storybook/react'
 import {
   envProviderDecorator,
   sessionContextProviderDecorator,
+  tripleClientMetadataDecorator,
 } from '../../decorators'
 
 export default {
   title: 'booking-completion / Booking Complete',
   component: BookingCompletion,
-  decorators: [envProviderDecorator, sessionContextProviderDecorator],
+  decorators: [
+    envProviderDecorator,
+    sessionContextProviderDecorator,
+    tripleClientMetadataDecorator,
+  ],
 } as Meta
 
 export const Basic: ComponentStoryObj<typeof BookingCompletion> = {

--- a/docs/stories/reviews/reviews.stories.tsx
+++ b/docs/stories/reviews/reviews.stories.tsx
@@ -9,6 +9,7 @@ import { ComponentStoryObj, Meta } from '@storybook/react'
 import {
   historyProviderDecorator,
   sessionContextProviderDecorator,
+  tripleClientMetadataDecorator,
 } from '../../decorators'
 
 export default {
@@ -41,6 +42,7 @@ export default {
     ),
     historyProviderDecorator,
     sessionContextProviderDecorator,
+    tripleClientMetadataDecorator,
   ],
 } as Meta
 

--- a/docs/stories/router/external-link.stories.tsx
+++ b/docs/stories/router/external-link.stories.tsx
@@ -5,6 +5,7 @@ import {
   envProviderDecorator,
   globalStyleDecorator,
   sessionContextProviderDecorator,
+  tripleClientMetadataDecorator,
 } from '../../decorators'
 
 export default {
@@ -17,6 +18,7 @@ export default {
     globalStyleDecorator,
     envProviderDecorator,
     sessionContextProviderDecorator,
+    tripleClientMetadataDecorator,
   ],
 } as Meta
 

--- a/docs/stories/router/local-link.stories.tsx
+++ b/docs/stories/router/local-link.stories.tsx
@@ -5,6 +5,7 @@ import {
   envProviderDecorator,
   globalStyleDecorator,
   sessionContextProviderDecorator,
+  tripleClientMetadataDecorator,
 } from '../../decorators'
 
 export default {
@@ -17,6 +18,7 @@ export default {
     globalStyleDecorator,
     envProviderDecorator,
     sessionContextProviderDecorator,
+    tripleClientMetadataDecorator,
   ],
 } as Meta
 

--- a/docs/stories/router/styled-local-link.stories.tsx
+++ b/docs/stories/router/styled-local-link.stories.tsx
@@ -6,6 +6,7 @@ import {
   globalStyleDecorator,
   envProviderDecorator,
   sessionContextProviderDecorator,
+  tripleClientMetadataDecorator,
 } from '../../decorators'
 
 const StyledLocalLink = styled(LocalLink)`
@@ -28,6 +29,7 @@ export default {
     globalStyleDecorator,
     envProviderDecorator,
     sessionContextProviderDecorator,
+    tripleClientMetadataDecorator,
   ],
 } as Meta
 

--- a/docs/stories/social-reviews/social-reviews.stories.tsx
+++ b/docs/stories/social-reviews/social-reviews.stories.tsx
@@ -4,12 +4,17 @@ import SocialReviews from '@titicaca/social-reviews'
 import {
   envProviderDecorator,
   sessionContextProviderDecorator,
+  tripleClientMetadataDecorator,
 } from '../../decorators'
 
 export default {
   title: 'Social-Reviews / SocialReviews',
   component: SocialReviews,
-  decorators: [envProviderDecorator, sessionContextProviderDecorator],
+  decorators: [
+    envProviderDecorator,
+    sessionContextProviderDecorator,
+    tripleClientMetadataDecorator,
+  ],
 } as ComponentMeta<typeof SocialReviews>
 
 export const BaseSocialReviews: ComponentStoryObj<typeof SocialReviews> = {

--- a/docs/stories/triple-document/tna-slot.stories.tsx
+++ b/docs/stories/triple-document/tna-slot.stories.tsx
@@ -5,6 +5,7 @@ import SLOTS from '../__mocks__/slots.sample.json'
 import {
   envProviderDecorator,
   sessionContextProviderDecorator,
+  tripleClientMetadataDecorator,
 } from '../../decorators'
 
 const { tnaProducts: TnaProducts } = ELEMENTS
@@ -12,7 +13,11 @@ const { tnaProducts: TnaProducts } = ELEMENTS
 export default {
   title: 'triple-document / T&A Slot',
   component: TnaProducts,
-  decorators: [envProviderDecorator, sessionContextProviderDecorator],
+  decorators: [
+    envProviderDecorator,
+    sessionContextProviderDecorator,
+    tripleClientMetadataDecorator,
+  ],
 } as Meta
 
 export function InTripleDocument() {

--- a/docs/stories/triple-document/triple-document.stories.tsx
+++ b/docs/stories/triple-document/triple-document.stories.tsx
@@ -12,6 +12,7 @@ import MOCK_ITINERARY from '../__mocks__/triple-document.itinerary.json'
 import {
   envProviderDecorator,
   sessionContextProviderDecorator,
+  tripleClientMetadataDecorator,
 } from '../../decorators'
 
 const {
@@ -27,7 +28,11 @@ const {
 
 export default {
   title: 'triple-document',
-  decorators: [envProviderDecorator, sessionContextProviderDecorator],
+  decorators: [
+    envProviderDecorator,
+    sessionContextProviderDecorator,
+    tripleClientMetadataDecorator,
+  ],
 } as Meta
 
 export function Sample() {

--- a/integration-test/src/router-modal.test.tsx
+++ b/integration-test/src/router-modal.test.tsx
@@ -5,8 +5,8 @@ import {
   EnvProvider,
   HistoryProvider,
   SessionContextProvider,
-  UserAgentProvider,
 } from '@titicaca/react-contexts'
+import { TripleClientMetadataProvider } from '@titicaca/react-triple-client-interfaces'
 import { ExternalLink } from '@titicaca/router'
 import { PropsWithChildren } from 'react'
 
@@ -23,7 +23,9 @@ test('브라우저를 허용하지 않는 링크라면 브라우저 환경에서
     type: 'browser',
     sessionAvailable: false,
   })
-  const UserAgentProvider = createUserAgentProvider({ isPublic: true })
+  const TripleClientMetadataProvider = createTripleClientMetadataProvider({
+    isPublic: true,
+  })
 
   const { getByRole } = render(
     <ExternalLink href={href} target="new" allowSource="app">
@@ -32,7 +34,7 @@ test('브라우저를 허용하지 않는 링크라면 브라우저 환경에서
     {
       wrapper: ({ children }) => (
         <EnvProviderWrapper>
-          <UserAgentProvider>
+          <TripleClientMetadataProvider>
             <SessionProvider>
               <HistoryProvider>
                 {children}
@@ -40,7 +42,7 @@ test('브라우저를 허용하지 않는 링크라면 브라우저 환경에서
                 <TransitionModal deepLink="MOCK_DEEP_LINK" />
               </HistoryProvider>
             </SessionProvider>
-          </UserAgentProvider>
+          </TripleClientMetadataProvider>
         </EnvProviderWrapper>
       ),
     },
@@ -63,7 +65,9 @@ test('로그인한 앱에서만 열리는 링크라면 로그인하지 않은 �
     type: 'app',
     sessionAvailable: false,
   })
-  const UserAgentProvider = createUserAgentProvider({ isPublic: false })
+  const TripleClientMetadataProvider = createTripleClientMetadataProvider({
+    isPublic: false,
+  })
 
   const { getByRole } = render(
     <ExternalLink href={href} target="new" allowSource="app-with-session">
@@ -72,13 +76,13 @@ test('로그인한 앱에서만 열리는 링크라면 로그인하지 않은 �
     {
       wrapper: ({ children }) => (
         <EnvProviderWrapper>
-          <UserAgentProvider>
+          <TripleClientMetadataProvider>
             <SessionProvider>
               <HistoryProvider>
                 <LoginCtaModalProvider>{children}</LoginCtaModalProvider>
               </HistoryProvider>
             </SessionProvider>
-          </UserAgentProvider>
+          </TripleClientMetadataProvider>
         </EnvProviderWrapper>
       ),
     },
@@ -152,16 +156,20 @@ function createSessionContextProvider({
   }
 }
 
-function createUserAgentProvider({ isPublic }: { isPublic: boolean }) {
-  return function UserAgentProviderWrapper({
+function createTripleClientMetadataProvider({
+  isPublic,
+}: {
+  isPublic: boolean
+}) {
+  return function TripleClientMetadataProviderWrapper({
     children,
   }: PropsWithChildren<unknown>) {
     return (
-      <UserAgentProvider
-        value={{ isPublic } as Parameters<typeof UserAgentProvider>[0]['value']}
+      <TripleClientMetadataProvider
+        {...(isPublic ? null : { appName: 'Triple-iOS', appVersion: '5.13.0' })}
       >
         {children}
-      </UserAgentProvider>
+      </TripleClientMetadataProvider>
     )
   }
 }

--- a/packages/replies/src/reply.test.tsx
+++ b/packages/replies/src/reply.test.tsx
@@ -2,12 +2,24 @@ import { PropsWithChildren } from 'react'
 import '@testing-library/jest-dom'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { EnvProvider, SessionContextProvider } from '@titicaca/react-contexts'
+import { useNavigate } from '@titicaca/router'
 
 import { RepliesProvider } from './context'
 import Reply from './list/reply'
 import { Reply as ReplyType } from './types'
 
+jest.mock('@titicaca/router')
 jest.mock('./replies-api-client')
+
+beforeEach(() => {
+  ;(
+    useNavigate as unknown as jest.MockedFunction<
+      () => ReturnType<typeof useNavigate>
+    >
+  ).mockImplementation(() => {
+    return () => {}
+  })
+})
 
 const MOCKED_REPLY = {
   id: '00000000-0000-0000-0000-00000000000',

--- a/packages/router/src/common/disabled-link-notifier.test.ts
+++ b/packages/router/src/common/disabled-link-notifier.test.ts
@@ -1,14 +1,13 @@
 import { renderHook } from '@testing-library/react-hooks'
 import { useLoginCtaModal, useTransitionModal } from '@titicaca/modals'
-import {
-  useSessionAvailability,
-  useUserAgentContext,
-} from '@titicaca/react-contexts'
+import { useSessionAvailability } from '@titicaca/react-contexts'
+import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 
 import { useDisabledLinkNotifierCreator } from './disabled-link-notifier'
 
 jest.mock('@titicaca/modals')
 jest.mock('@titicaca/react-contexts')
+jest.mock('@titicaca/react-triple-client-interfaces')
 
 describe('allowSource가 "all"일 때 앱 여부, 세션 여부에 상관없이 아무 처리를 하지 않습니다.', () => {
   test.each([
@@ -141,10 +140,12 @@ function prepareTest({
   sessionAvailable: boolean
 }) {
   ;(
-    useUserAgentContext as unknown as jest.MockedFunction<
-      () => Pick<ReturnType<typeof useUserAgentContext>, 'isPublic'>
+    useTripleClientMetadata as unknown as jest.MockedFunction<
+      () => ReturnType<typeof useTripleClientMetadata>
     >
-  ).mockImplementation(() => ({ isPublic }))
+  ).mockImplementation(() =>
+    isPublic ? null : { appName: 'Triple-iOS', appVersion: '5.13.0' },
+  )
   ;(
     useSessionAvailability as jest.MockedFunction<typeof useSessionAvailability>
   ).mockImplementation(() => sessionAvailable)

--- a/packages/router/src/common/disabled-link-notifier.ts
+++ b/packages/router/src/common/disabled-link-notifier.ts
@@ -3,10 +3,8 @@ import {
   useLoginCtaModal,
   TransitionType,
 } from '@titicaca/modals'
-import {
-  useSessionAvailability,
-  useUserAgentContext,
-} from '@titicaca/react-contexts'
+import { useSessionAvailability } from '@titicaca/react-contexts'
+import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 
 export type AllowSource = 'all' | 'app' | 'app-with-session' | 'none'
 
@@ -24,7 +22,7 @@ export function useDisabledLinkNotifierCreator({
 }: {
   alert?: (message: string) => void
 } = {}) {
-  const { isPublic } = useUserAgentContext()
+  const app = useTripleClientMetadata()
   const sessionAvailable = useSessionAvailability()
   const { show: showTransitionModal } = useTransitionModal()
   const { show: showLoginCtaModal } = useLoginCtaModal()
@@ -38,10 +36,7 @@ export function useDisabledLinkNotifierCreator({
       }
     }
 
-    if (
-      isPublic === true &&
-      (allowSource === 'app' || allowSource === 'app-with-session')
-    ) {
+    if (!app && (allowSource === 'app' || allowSource === 'app-with-session')) {
       return () => {
         showTransitionModal(TransitionType.General)
       }

--- a/packages/router/src/external/hook.test.ts
+++ b/packages/router/src/external/hook.test.ts
@@ -1,6 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks'
-import { useUserAgentContext } from '@titicaca/react-contexts'
-import { useTripleClientNavigate } from '@titicaca/react-triple-client-interfaces'
+import {
+  useTripleClientMetadata,
+  useTripleClientNavigate,
+} from '@titicaca/react-triple-client-interfaces'
 
 import { useDisabledLinkNotifierCreator } from '../common/disabled-link-notifier'
 import useDefaultRouter from '../common/default-router'
@@ -16,7 +18,7 @@ jest.mock('../common/default-router')
 jest.mock('./href-handler')
 
 beforeEach(() => {
-  mockUserAgentHook()
+  mockTripleClientMetadata()
   mockAppBridgeHook()
   mockDisabledLinkNotifierCreatorHook({
     shouldRaiseAlert: false,
@@ -69,12 +71,16 @@ test('customRouter가 작동하면 default 라우터가 작동하지 않습니�
   expect(defaultRouter).not.toBeCalled()
 })
 
-function mockUserAgentHook({ isPublic = false }: { isPublic?: boolean } = {}) {
+function mockTripleClientMetadata({
+  isPublic = false,
+}: { isPublic?: boolean } = {}) {
   ;(
-    useUserAgentContext as unknown as jest.MockedFunction<
-      () => Pick<ReturnType<typeof useUserAgentContext>, 'isPublic'>
+    useTripleClientMetadata as unknown as jest.MockedFunction<
+      () => ReturnType<typeof useTripleClientMetadata>
     >
-  ).mockImplementation(() => ({ isPublic }))
+  ).mockImplementation(() =>
+    isPublic ? null : { appName: 'Triple-iOS', appVersion: '5.13.0' },
+  )
 }
 
 function mockAppBridgeHook() {

--- a/packages/router/src/external/href-handler.ts
+++ b/packages/router/src/external/href-handler.ts
@@ -1,5 +1,5 @@
-import { useUserAgentContext } from '@titicaca/react-contexts'
 import {
+  useTripleClientMetadata,
   useTripleClientNavigate,
   OutlinkOptions,
   AppSpecificLinkProps,
@@ -12,7 +12,7 @@ import { HrefProps } from '../common/types'
 import { checkHrefIsAbsoluteUrl } from './utils'
 
 export function useExternalHrefHandler() {
-  const { isPublic } = useUserAgentContext()
+  const app = useTripleClientMetadata()
   const { openInlink, openOutlink } = useTripleClientNavigate()
   const addWebUrlBase = useWebUrlBaseAdder()
 
@@ -31,13 +31,13 @@ export function useExternalHrefHandler() {
     Pick<OutlinkOptions, 'title'> & { stopDefaultHandler: () => void }) => {
     const outOfTriple = checkHrefIsAbsoluteUrl(href)
 
-    if (target === 'current' && isPublic === false && outOfTriple === true) {
+    if (target === 'current' && app && outOfTriple === true) {
       stopDefaultHandler()
 
       return
     }
 
-    if (target === 'new' && isPublic === false) {
+    if (target === 'new' && app) {
       stopDefaultHandler()
 
       if (outOfTriple === true) {
@@ -54,7 +54,7 @@ export function useExternalHrefHandler() {
       return
     }
 
-    if (target === 'browser' && isPublic === false) {
+    if (target === 'browser' && app) {
       stopDefaultHandler()
 
       openOutlink(outOfTriple ? href : addWebUrlBase(href), {

--- a/packages/router/src/external/link.test.tsx
+++ b/packages/router/src/external/link.test.tsx
@@ -1,12 +1,12 @@
 import '@testing-library/jest-dom'
 import 'jest-styled-components'
 import { fireEvent, render } from '@testing-library/react'
-import {
-  useSessionAvailability,
-  useUserAgentContext,
-} from '@titicaca/react-contexts'
+import { useSessionAvailability } from '@titicaca/react-contexts'
 import { useLoginCtaModal, useTransitionModal } from '@titicaca/modals'
-import { useTripleClientNavigate } from '@titicaca/react-triple-client-interfaces'
+import {
+  useTripleClientMetadata,
+  useTripleClientNavigate,
+} from '@titicaca/react-triple-client-interfaces'
 import styled from 'styled-components'
 import renderer from 'react-test-renderer'
 
@@ -195,10 +195,12 @@ function prepareTest({
   const webUrlBase = 'https://triple.guide'
 
   ;(
-    useUserAgentContext as unknown as jest.MockedFunction<
-      () => Pick<ReturnType<typeof useUserAgentContext>, 'isPublic'>
+    useTripleClientMetadata as unknown as jest.MockedFunction<
+      () => ReturnType<typeof useTripleClientMetadata>
     >
-  ).mockImplementation(() => ({ isPublic }))
+  ).mockImplementation(() =>
+    isPublic ? null : { appName: 'Triple-iOS', appVersion: '5.13.0' },
+  )
   ;(
     useTripleClientNavigate as jest.MockedFunction<
       typeof useTripleClientNavigate

--- a/packages/router/src/external/link.tsx
+++ b/packages/router/src/external/link.tsx
@@ -1,5 +1,5 @@
 import { MouseEventHandler, PropsWithChildren, useEffect } from 'react'
-import { useUserAgentContext } from '@titicaca/react-contexts'
+import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 
 import { ANCHOR_TARGET_MAP } from '../common/target'
 import { RouterGuardedLink } from '../common/router-guarded-link'
@@ -35,12 +35,12 @@ export function ExternalLink({
     onError?: (error: Error) => void
   }
 >) {
-  const { isPublic } = useUserAgentContext()
+  const app = useTripleClientMetadata()
   const handleHrefExternally = useExternalHrefHandler()
 
   const hrefIsAbsoluteUrl = checkHrefIsAbsoluteUrl(href)
   const forbiddenLinkCondition =
-    !isPublic && hrefIsAbsoluteUrl && target === 'current'
+    app && hrefIsAbsoluteUrl && target === 'current'
 
   const handleClick: MouseEventHandler<HTMLAnchorElement> = (e) => {
     if (onClick) {

--- a/packages/router/src/href-to-props/use-href-to-props.test.ts
+++ b/packages/router/src/href-to-props/use-href-to-props.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks'
-import { useEnv, useUserAgentContext } from '@titicaca/react-contexts'
+import { useEnv } from '@titicaca/react-contexts'
 import { checkIfRoutable } from '@titicaca/view-utilities'
+import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 
 import { useHrefToProps } from './use-href-to-props'
 
@@ -9,6 +10,7 @@ jest.mock('@titicaca/view-utilities', () => ({
   ...jest.requireActual('@titicaca/view-utilities'),
   checkIfRoutable: jest.fn(),
 }))
+jest.mock('@titicaca/react-triple-client-interfaces')
 
 describe('href', () => {
   test('href에서 트리플 도메인을 제거합니다.', () => {
@@ -162,10 +164,12 @@ function prepareTest({ isPublic }: { isPublic: boolean }) {
   const webUrlBase = 'https://triple.guide'
 
   ;(
-    useUserAgentContext as unknown as jest.MockedFunction<
-      () => Pick<ReturnType<typeof useUserAgentContext>, 'isPublic'>
+    useTripleClientMetadata as unknown as jest.MockedFunction<
+      () => ReturnType<typeof useTripleClientMetadata>
     >
-  ).mockImplementation(() => ({ isPublic }))
+  ).mockImplementation(() =>
+    isPublic ? null : { appName: 'Triple-iOS', appVersion: '5.13.0' },
+  )
   ;(
     useEnv as unknown as jest.MockedFunction<
       () => Pick<ReturnType<typeof useEnv>, 'webUrlBase'>

--- a/packages/router/src/href-to-props/use-href-to-props.ts
+++ b/packages/router/src/href-to-props/use-href-to-props.ts
@@ -1,11 +1,12 @@
 import { useCallback } from 'react'
 import qs, { ParsedQs } from 'qs'
-import { useEnv, useUserAgentContext } from '@titicaca/react-contexts'
+import { useEnv } from '@titicaca/react-contexts'
 import {
   checkIfRoutable,
   generateUrl,
   parseUrl,
 } from '@titicaca/view-utilities'
+import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 
 import { AllowSource } from '../common/disabled-link-notifier'
 import { TargetType } from '../common/target'
@@ -205,7 +206,7 @@ export function useHrefToProps(params?: {
   allowSource: AllowSource
 } {
   const { webUrlBase } = useEnv()
-  const { isPublic } = useUserAgentContext()
+  const app = useTripleClientMetadata()
 
   const { onError } = params || {}
 
@@ -214,7 +215,7 @@ export function useHrefToProps(params?: {
       try {
         return {
           href: canonizeHref({ href, webUrlBase }),
-          target: getTarget({ href, isPublic }),
+          target: getTarget({ href, isPublic: !app }),
           allowSource: getAllowSource({ href, webUrlBase }),
         }
       } catch (error) {
@@ -225,6 +226,6 @@ export function useHrefToProps(params?: {
         return { href, target: 'new', allowSource: 'app-with-session' }
       }
     },
-    [isPublic, onError, webUrlBase],
+    [app, onError, webUrlBase],
   )
 }

--- a/packages/router/src/local/hook.test.ts
+++ b/packages/router/src/local/hook.test.ts
@@ -1,6 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks'
-import { useUserAgentContext } from '@titicaca/react-contexts'
-import { useTripleClientNavigate } from '@titicaca/react-triple-client-interfaces'
+import {
+  useTripleClientMetadata,
+  useTripleClientNavigate,
+} from '@titicaca/react-triple-client-interfaces'
 
 import useDefaultRouter from '../common/default-router'
 import { useDisabledLinkNotifierCreator } from '../common/disabled-link-notifier'
@@ -16,7 +18,7 @@ jest.mock('../common/default-router')
 jest.mock('./href-handler')
 
 beforeEach(() => {
-  mockUserAgentHook()
+  mockTripleClientMetadata()
   mockAppBridgeHook()
   mockDisabledLinkNotifierCreatorHook({ shouldRaiseAlert: false })
   mockNextRouter()
@@ -68,12 +70,16 @@ test('customRouter가 작동하면 default 라우터가 작동하지 않습니�
   expect(defaultRouter).not.toBeCalled()
 })
 
-function mockUserAgentHook({ isPublic = false }: { isPublic?: boolean } = {}) {
+function mockTripleClientMetadata({
+  isPublic = false,
+}: { isPublic?: boolean } = {}) {
   ;(
-    useUserAgentContext as unknown as jest.MockedFunction<
-      () => Pick<ReturnType<typeof useUserAgentContext>, 'isPublic'>
+    useTripleClientMetadata as unknown as jest.MockedFunction<
+      () => ReturnType<typeof useTripleClientMetadata>
     >
-  ).mockImplementation(() => ({ isPublic }))
+  ).mockImplementation(() =>
+    isPublic ? null : { appName: 'Triple-iOS', appVersion: '5.13.0' },
+  )
 }
 
 function mockAppBridgeHook() {

--- a/packages/router/src/local/href-handler.ts
+++ b/packages/router/src/local/href-handler.ts
@@ -1,6 +1,6 @@
-import { useUserAgentContext } from '@titicaca/react-contexts'
 import { useRouter } from 'next/router'
 import {
+  useTripleClientMetadata,
   useTripleClientNavigate,
   AppSpecificLinkProps,
 } from '@titicaca/react-triple-client-interfaces'
@@ -25,7 +25,7 @@ export interface NextjsRoutingOptions {
 
 export function useLocalHrefHandler() {
   const router = useRouter()
-  const { isPublic } = useUserAgentContext()
+  const app = useTripleClientMetadata()
   const { openInlink, openOutlink } = useTripleClientNavigate()
   const addWebUrlBase = useWebUrlBaseAdder()
   const addBasePath = useBasePathAdder()
@@ -74,7 +74,7 @@ export function useLocalHrefHandler() {
 
     const finalHref = addBasePath(href)
 
-    if (target === 'new' && isPublic === false) {
+    if (target === 'new' && app) {
       stopDefaultHandler()
 
       openInlink(finalHref, {
@@ -87,7 +87,7 @@ export function useLocalHrefHandler() {
       return
     }
 
-    if (target === 'browser' && isPublic === false) {
+    if (target === 'browser' && app) {
       stopDefaultHandler()
 
       openOutlink(addWebUrlBase(finalHref), {

--- a/packages/router/src/local/link.test.tsx
+++ b/packages/router/src/local/link.test.tsx
@@ -2,12 +2,12 @@ import '@testing-library/jest-dom'
 import 'jest-styled-components'
 import { useRouter } from 'next/router'
 import { fireEvent, render } from '@testing-library/react'
-import {
-  useSessionAvailability,
-  useUserAgentContext,
-} from '@titicaca/react-contexts'
+import { useSessionAvailability } from '@titicaca/react-contexts'
 import { useLoginCtaModal, useTransitionModal } from '@titicaca/modals'
-import { useTripleClientNavigate } from '@titicaca/react-triple-client-interfaces'
+import {
+  useTripleClientMetadata,
+  useTripleClientNavigate,
+} from '@titicaca/react-triple-client-interfaces'
 import renderer from 'react-test-renderer'
 import styled from 'styled-components'
 
@@ -151,10 +151,12 @@ function prepareTest({
     >
   ).mockImplementation(() => ({ basePath, push: nextPush }))
   ;(
-    useUserAgentContext as unknown as jest.MockedFunction<
-      () => Pick<ReturnType<typeof useUserAgentContext>, 'isPublic'>
+    useTripleClientMetadata as unknown as jest.MockedFunction<
+      () => ReturnType<typeof useTripleClientMetadata>
     >
-  ).mockImplementation(() => ({ isPublic }))
+  ).mockImplementation(() =>
+    isPublic ? null : { appName: 'Triple-iOS', appVersion: '5.13.0' },
+  )
   ;(
     useSessionAvailability as jest.MockedFunction<typeof useSessionAvailability>
   ).mockImplementation(() => sessionAvailability)

--- a/packages/router/src/navigate/index.test.ts
+++ b/packages/router/src/navigate/index.test.ts
@@ -1,12 +1,11 @@
 import { renderHook } from '@testing-library/react-hooks'
 import { useLoginCtaModal, useTransitionModal } from '@titicaca/modals'
-import {
-  useUserAgentContext,
-  useSessionAvailability,
-  useEnv,
-} from '@titicaca/react-contexts'
+import { useSessionAvailability, useEnv } from '@titicaca/react-contexts'
 import { checkIfRoutable } from '@titicaca/view-utilities'
-import { useTripleClientNavigate } from '@titicaca/react-triple-client-interfaces'
+import {
+  useTripleClientMetadata,
+  useTripleClientNavigate,
+} from '@titicaca/react-triple-client-interfaces'
 
 import { useNavigate } from '.'
 
@@ -23,7 +22,7 @@ const routablePath = mockRoutablePath()
 
 describe('브라우저', () => {
   beforeEach(() => {
-    mockUserAgentContext({ isPublic: true })
+    mockTripleClientMetadata({ isPublic: true })
   })
 
   describe('routable한 href를 가진 URL로 호출하면 현재 창에서 라우팅합니다.', () => {
@@ -85,7 +84,7 @@ describe('브라우저', () => {
 
 describe('앱', () => {
   beforeEach(() => {
-    mockUserAgentContext({ isPublic: false })
+    mockTripleClientMetadata({ isPublic: false })
   })
 
   describe('세션이 없고 routable하지 않은 href를 가지고 있는 URL로 호출하면 로그인 유도 모달을 표시합니다.', () => {
@@ -147,12 +146,14 @@ describe('앱', () => {
   })
 })
 
-function mockUserAgentContext({ isPublic }: { isPublic: boolean }) {
+function mockTripleClientMetadata({ isPublic }: { isPublic: boolean }) {
   ;(
-    useUserAgentContext as unknown as jest.MockedFunction<
-      () => Pick<ReturnType<typeof useUserAgentContext>, 'isPublic'>
+    useTripleClientMetadata as unknown as jest.MockedFunction<
+      () => ReturnType<typeof useTripleClientMetadata>
     >
-  ).mockImplementation(() => ({ isPublic }))
+  ).mockImplementation(() =>
+    isPublic ? null : { appName: 'Triple-iOS', appVersion: '5.13.0' },
+  )
 }
 
 function mockWebUrlBase() {

--- a/packages/router/src/navigate/index.ts
+++ b/packages/router/src/navigate/index.ts
@@ -5,13 +5,10 @@ import {
 } from '@titicaca/modals'
 import { checkIfRoutable, parseUrl } from '@titicaca/view-utilities'
 import { useCallback } from 'react'
-import {
-  useEnv,
-  useSessionAvailability,
-  useUserAgentContext,
-} from '@titicaca/react-contexts'
+import { useEnv, useSessionAvailability } from '@titicaca/react-contexts'
 import {
   OutlinkOptions,
+  useTripleClientMetadata,
   useTripleClientNavigate,
 } from '@titicaca/react-triple-client-interfaces'
 
@@ -21,10 +18,10 @@ export function useNavigate({
   changeLocationHref = defaultChangeLocationHref,
 }: { changeLocationHref?: (href: string) => void } = {}) {
   const { webUrlBase } = useEnv()
-  const { isPublic } = useUserAgentContext()
   const sessionAvailable = useSessionAvailability()
   const { show: showTransitionModal } = useTransitionModal()
   const { show: showLoginCtaModal } = useLoginCtaModal()
+  const app = useTripleClientMetadata()
   const { openOutlink, openNativeLink } = useTripleClientNavigate()
 
   const navigateInBrowser = useCallback(
@@ -81,7 +78,7 @@ export function useNavigate({
     ],
   )
 
-  return isPublic ? navigateInBrowser : navigateInApp
+  return app ? navigateInApp : navigateInBrowser
 }
 
 function defaultChangeLocationHref(href: string) {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

기존에 `useUserAgentContext`를 쓰던 로직을 `useTripleClientMetadata`를 사용하도록 변경합니다.

## 변경 내역

- `@titicaca/router` 패키지 내에서 `useUserAgentContext`의 `isPublic`으로 분기하던 로직들을 `useTripleClientMetadata`를 이용하도록 변경합니다.
- `router` 패키지 내 테스트 케이스의 Mock들을 변경합니다.
- Integration test를 수정합니다.
- `replies` 패키지 테스트 과정에서 `router`의 `useNavigate` 모킹이 누락된 부분을 발견하여 추가합니다.

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
