### PR TITLE
[ui-flow] react-triple-client-interfaces로 웹-앱 동작을 분기합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44234,6 +44234,7 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/modals": "^6.4.0",
+        "@titicaca/react-triple-client-interfaces": "^6.4.0",
         "qs": "^6.9.0"
       },
       "peerDependencies": {
@@ -59793,6 +59794,7 @@
       "version": "file:packages/ui-flow",
       "requires": {
         "@titicaca/modals": "^6.4.0",
+        "@titicaca/react-triple-client-interfaces": "^6.4.0",
         "qs": "^6.9.0"
       }
     },

--- a/packages/replies/src/reply.test.tsx
+++ b/packages/replies/src/reply.test.tsx
@@ -1,14 +1,16 @@
 import { PropsWithChildren } from 'react'
 import '@testing-library/jest-dom'
 import { fireEvent, render, waitFor } from '@testing-library/react'
-import { EnvProvider, SessionContextProvider } from '@titicaca/react-contexts'
+import { EnvProvider } from '@titicaca/react-contexts'
 import { useNavigate } from '@titicaca/router'
+import { useAppCallback, useSessionCallback } from '@titicaca/ui-flow'
 
 import { RepliesProvider } from './context'
 import Reply from './list/reply'
 import { Reply as ReplyType } from './types'
 
 jest.mock('@titicaca/router')
+jest.mock('@titicaca/ui-flow')
 jest.mock('./replies-api-client')
 
 beforeEach(() => {
@@ -18,6 +20,16 @@ beforeEach(() => {
     >
   ).mockImplementation(() => {
     return () => {}
+  })
+  ;(
+    useAppCallback as unknown as jest.MockedFunction<typeof useAppCallback>
+  ).mockImplementation((_, fn) => fn)
+  ;(
+    useSessionCallback as unknown as jest.MockedFunction<
+      typeof useSessionCallback
+    >
+  ).mockImplementation((fn) => {
+    return fn
   })
 })
 
@@ -229,15 +241,7 @@ function ReplyWithLoginWrapper({ children }: PropsWithChildren<unknown>) {
       afOnelinkPid=""
       afOnelinkSubdomain=""
     >
-      <SessionContextProvider
-        type="browser"
-        props={{
-          initialUser: undefined,
-          initialSessionAvailability: true,
-        }}
-      >
-        <RepliesProvider>{children}</RepliesProvider>
-      </SessionContextProvider>
+      <RepliesProvider>{children}</RepliesProvider>
     </EnvProvider>
   )
 }

--- a/packages/ui-flow/package.json
+++ b/packages/ui-flow/package.json
@@ -23,6 +23,7 @@
   ],
   "dependencies": {
     "@titicaca/modals": "^6.4.0",
+    "@titicaca/react-triple-client-interfaces": "^6.4.0",
     "qs": "^6.9.0"
   },
   "peerDependencies": {

--- a/packages/ui-flow/src/auth-guard/index.ts
+++ b/packages/ui-flow/src/auth-guard/index.ts
@@ -1,6 +1,6 @@
 import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next'
 import { get } from '@titicaca/fetcher'
-import { parseApp } from '@titicaca/react-contexts'
+import { parseTripleClientUserAgent } from '@titicaca/react-triple-client-interfaces'
 import qs from 'qs'
 import { generateUrl, parseUrl, strictQuery } from '@titicaca/view-utilities'
 
@@ -55,7 +55,7 @@ export function authGuard<Props>(
       const { status } = response
 
       if (status === 401) {
-        if (userAgentString && parseApp(userAgentString)) {
+        if (userAgentString && parseTripleClientUserAgent(userAgentString)) {
           return refreshInAppSession({ resolvedUrl, returnUrl })
         }
 

--- a/packages/ui-flow/src/guarded-scraps-provider.tsx
+++ b/packages/ui-flow/src/guarded-scraps-provider.tsx
@@ -2,8 +2,8 @@ import { PropsWithChildren } from 'react'
 import {
   ScrapsProvider,
   useSessionAvailability,
-  useUserAgentContext,
 } from '@titicaca/react-contexts'
+import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 import {
   useTransitionModal,
   TransitionType,
@@ -20,7 +20,7 @@ export function GuardedScrapsProvider({
   beforeScrapedChange,
   ...props
 }: PropsWithChildren<Parameters<typeof ScrapsProvider>[0]>) {
-  const { isPublic } = useUserAgentContext()
+  const app = useTripleClientMetadata()
   const sessionAvailable = useSessionAvailability()
   const { show: showTransitionModal } = useTransitionModal()
   const { show: showLoginCta } = useLoginCtaModal()
@@ -28,7 +28,7 @@ export function GuardedScrapsProvider({
   return (
     <ScrapsProvider
       beforeScrapedChange={(target, scraped) => {
-        if (isPublic) {
+        if (!app) {
           showTransitionModal(TransitionType.Scrap)
           return false
         }

--- a/packages/ui-flow/src/use-app-callback.test.ts
+++ b/packages/ui-flow/src/use-app-callback.test.ts
@@ -1,14 +1,14 @@
 import { renderHook, act } from '@testing-library/react-hooks'
-import { useUserAgentContext } from '@titicaca/react-contexts'
+import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 import { TransitionType, useTransitionModal } from '@titicaca/modals'
 
 import { useAppCallback } from './use-app-callback'
 
-jest.mock('@titicaca/react-contexts')
+jest.mock('@titicaca/react-triple-client-interfaces')
 jest.mock('@titicaca/modals')
 
 test('일반 브라우저에서 앱 전환 모달 표시 함수를 호출합니다.', () => {
-  mockUserAgentContext({ isPublic: true })
+  mockTripleClientMetadata(null)
   const mockShow = mockTransitionModalContext()
 
   const { result } = renderHook(() => {
@@ -25,7 +25,7 @@ test('일반 브라우저에서 앱 전환 모달 표시 함수를 호출합니�
 })
 
 test('앱에서 앱 전환 모달 표시 함수를 호출하지 않습니다.', () => {
-  mockUserAgentContext({ isPublic: false })
+  mockTripleClientMetadata({ appName: 'Triple-iOS', appVersion: '5.13.0' })
   const mockShow = mockTransitionModalContext()
 
   const { result } = renderHook(() => {
@@ -41,16 +41,16 @@ test('앱에서 앱 전환 모달 표시 함수를 호출하지 않습니다.', 
   expect(mockShow).toBeCalledTimes(0)
 })
 
-function mockUserAgentContext({ isPublic }: { isPublic: boolean }) {
-  const mockedUseUserAgentContext = useUserAgentContext as jest.MockedFunction<
-    typeof useUserAgentContext
-  >
+function mockTripleClientMetadata(
+  app: ReturnType<typeof useTripleClientMetadata>,
+) {
+  const mockedTripleClientMetadataContext =
+    useTripleClientMetadata as jest.MockedFunction<
+      typeof useTripleClientMetadata
+    >
 
-  mockedUseUserAgentContext.mockImplementation(
-    () =>
-      ({
-        isPublic,
-      } as ReturnType<typeof useUserAgentContext>),
+  mockedTripleClientMetadataContext.mockImplementation(
+    () => app as ReturnType<typeof useTripleClientMetadata>,
   )
 }
 

--- a/packages/ui-flow/src/use-app-callback.ts
+++ b/packages/ui-flow/src/use-app-callback.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { TransitionType, useTransitionModal } from '@titicaca/modals'
-import { useUserAgentContext } from '@titicaca/react-contexts'
+import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 
 /**
  * User Agent가 앱 환경일 때만 주어진 콜백을 실행하는 함수를 반환하는 훅
@@ -17,12 +17,12 @@ export function useAppCallback<T extends (...args: any[]) => any>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   returnValue?: any,
 ): (...args: Parameters<T>) => ReturnType<T> | void {
-  const { isPublic } = useUserAgentContext()
+  const app = useTripleClientMetadata()
   const { show } = useTransitionModal()
 
   return useCallback(
     (...args) => {
-      if (!isPublic) {
+      if (app) {
         return fn(...args)
       }
 
@@ -30,6 +30,6 @@ export function useAppCallback<T extends (...args: any[]) => any>(
 
       return returnValue
     },
-    [fn, isPublic, show, transitionType, returnValue],
+    [fn, app, show, transitionType, returnValue],
   )
 }

--- a/packages/ui-flow/tsconfig.build.json
+++ b/packages/ui-flow/tsconfig.build.json
@@ -6,6 +6,9 @@
       "path": "../modals/tsconfig.build.json"
     },
     {
+      "path": "../react-triple-client-interfaces/tsconfig.build.json"
+    },
+    {
       "path": "../fetcher/tsconfig.build.json"
     },
     {

--- a/packages/ui-flow/tsconfig.json
+++ b/packages/ui-flow/tsconfig.json
@@ -7,13 +7,19 @@
     "paths": {
       "@titicaca/fetcher": ["../fetcher/src"],
       "@titicaca/modals": ["../modals/src"],
-      "@titicaca/react-contexts": ["../react-contexts/src"]
+      "@titicaca/react-contexts": ["../react-contexts/src"],
+      "@titicaca/react-triple-client-interfaces": [
+        "../react-triple-client-interfaces/src"
+      ]
     }
   },
   "include": ["./src"],
   "references": [
     {
       "path": "../modals"
+    },
+    {
+      "path": "../react-triple-client-interfaces"
     },
     {
       "path": "../fetcher"


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

`@titicaca/ui-flow` 패키지에서 `useUserAgentContext` 대신 `useTripleClientMetadata`를 이용합니다. 

## 변경 내역

- `ui-flow` 패키지의 의존성에 `react-triple-client-interfaces`를 추가합니다.
- `ui-flow` 내부 로직에서 `useTripleClientMetadata`를 호출합니다.
- 이로 인해 실패하는 reply 테스트 케이스를 위해 mocking을 개선합니다.

