### PR TITLE
[replies] 입력창을 화면 최하단에 고정하는 props를 추가합니다.

### DIFF
--- a/docs/stories/replies/replies.stories.tsx
+++ b/docs/stories/replies/replies.stories.tsx
@@ -19,7 +19,6 @@ export default {
       options: ['itinerary', 'review', 'article'],
       control: {
         type: 'select',
-        required: true,
       },
     },
     placeholders: {
@@ -37,11 +36,15 @@ export default {
       required: false,
       defaultValue: 10,
     },
+    isFixedBottomInput: {
+      type: 'boolean',
+      required: false,
+    },
   },
 } as Meta
 
 export const BaseReplies: ComponentStoryObj<typeof Replies> = {
-  storyName: '기본 댓글',
+  storyName: '기본',
   args: {
     resourceId: 'c31a0e75-0053-4ef2-9407-d2bdc7f116e3',
     resourceType: 'article',
@@ -51,3 +54,5 @@ export const BaseReplies: ComponentStoryObj<typeof Replies> = {
     },
   },
 }
+
+BaseReplies.storyName = '기본'

--- a/docs/stories/replies/replies.stories.tsx
+++ b/docs/stories/replies/replies.stories.tsx
@@ -19,6 +19,7 @@ export default {
       options: ['itinerary', 'review', 'article'],
       control: {
         type: 'select',
+        required: true,
       },
     },
     placeholders: {
@@ -44,7 +45,6 @@ export default {
 } as Meta
 
 export const BaseReplies: ComponentStoryObj<typeof Replies> = {
-  storyName: '기본',
   args: {
     resourceId: 'c31a0e75-0053-4ef2-9407-d2bdc7f116e3',
     resourceType: 'article',

--- a/docs/stories/replies/replies.stories.tsx
+++ b/docs/stories/replies/replies.stories.tsx
@@ -37,7 +37,7 @@ export default {
       required: false,
       defaultValue: 10,
     },
-    isFixedBottomInput: {
+    isFormFixed: {
       type: 'boolean',
       required: false,
     },

--- a/packages/replies/README.md
+++ b/packages/replies/README.md
@@ -17,7 +17,6 @@ return (
     resourceType={resourceType}
     registerPlaceholder={registerPlaceholder}
     size={size || 10}
-    onClick={onClick}
   />
 )
 ```
@@ -30,5 +29,3 @@ return (
 - registerPlaceholder: Register 컴포넌트 내부의 문구를 커스터마이징하는 prop (optional)
   default: 이 일정에 궁금한 점은 댓글로 써주세요.
 - size : api 호출 시 댓글을 가져오는 크기, default: 10 (optional)
-
-- onClick: customizing한 onClick을 icon, text에 적용합니다. (required)

--- a/packages/replies/README.md
+++ b/packages/replies/README.md
@@ -11,12 +11,22 @@ npm install @titicaca/replies
 ```js
 import Replies from '@titicaca/replies'
 
+const placeholders = {
+  reply : '댓글을 입력하세요'
+  childReply : '답글을 입력하세요'
+}
+
+const padding = { left : 30, right : 30, bottom : 30}
+
 return (
   <Replies
     resourceId={resourceId}
     resourceType={resourceType}
-    registerPlaceholder={registerPlaceholder}
+    placeholders={placeholders}
     size={size || 10}
+    padding={padding}
+    isFormFixed={false}
+
   />
 )
 ```
@@ -26,6 +36,9 @@ return (
 - resourceId, resourceType: 아래 스웨거를 참고해주세요. (required)
   https://reply.proxy.triple-dev.titicaca-corp.com/webjars/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config
 
-- registerPlaceholder: Register 컴포넌트 내부의 문구를 커스터마이징하는 prop (optional)
-  default: 이 일정에 궁금한 점은 댓글로 써주세요.
+- placeholders: Register 컴포넌트 내부의 문구를 커스터마이징하는 prop (optional)
+  - 댓글 : 댓글을 입력하세요 (default)
+  - 답글 : 답글을 입력하세요 (default)
 - size : api 호출 시 댓글을 가져오는 크기, default: 10 (optional)
+- isFormFixed : 화면 최하단에 댓글/답글 입력창을 고정할 지 선택하는 prop (optional)
+- padding : 댓글 리스트의 padding을 결정하는 props (optional)

--- a/packages/replies/src/list/index.tsx
+++ b/packages/replies/src/list/index.tsx
@@ -1,4 +1,10 @@
-import { Container, HR1, List, Text } from '@titicaca/core-elements'
+import {
+  Container,
+  HR1,
+  List,
+  Text,
+  MarginPadding,
+} from '@titicaca/core-elements'
 import { Confirm } from '@titicaca/modals'
 import { useHistoryFunctions, useUriHash } from '@titicaca/react-contexts'
 import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
@@ -15,6 +21,7 @@ const HASH_EDIT_CLOSE_MODAL = 'reply.edit-close-modal'
 export default function ReplyList({
   replies,
   isMoreButtonActive,
+  listPadding = { left: 30, right: 30, bottom: 30 },
   fetchMoreReplies,
   focusInput,
   onReplyDelete,
@@ -22,6 +29,7 @@ export default function ReplyList({
 }: {
   replies: ReplyType[]
   isMoreButtonActive: boolean
+  listPadding?: MarginPadding
   fetchMoreReplies: (reply?: ReplyType) => void
   focusInput: () => void
   onReplyDelete: (response: ReplyType) => void
@@ -64,7 +72,7 @@ export default function ReplyList({
       {replies.length <= 0 ? (
         <NotExistReplies />
       ) : (
-        <Container padding={{ bottom: 30, left: 30, right: 30 }}>
+        <Container padding={listPadding}>
           {isMoreButtonActive ? (
             <Text
               padding={{ top: 20 }}

--- a/packages/replies/src/list/index.tsx
+++ b/packages/replies/src/list/index.tsx
@@ -21,7 +21,7 @@ const HASH_EDIT_CLOSE_MODAL = 'reply.edit-close-modal'
 export default function ReplyList({
   replies,
   isMoreButtonActive,
-  listPadding = { left: 30, right: 30, bottom: 30 },
+  padding = { left: 30, right: 30, bottom: 30 },
   fetchMoreReplies,
   focusInput,
   onReplyDelete,
@@ -29,7 +29,7 @@ export default function ReplyList({
 }: {
   replies: ReplyType[]
   isMoreButtonActive: boolean
-  listPadding?: MarginPadding
+  padding?: MarginPadding
   fetchMoreReplies: (reply?: ReplyType) => void
   focusInput: () => void
   onReplyDelete: (response: ReplyType) => void
@@ -72,7 +72,7 @@ export default function ReplyList({
       {replies.length <= 0 ? (
         <NotExistReplies />
       ) : (
-        <Container padding={listPadding}>
+        <Container padding={padding}>
           {isMoreButtonActive ? (
             <Text
               padding={{ top: 20 }}

--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -29,14 +29,14 @@ export default function Replies({
   resourceType,
   placeholders,
   isFixedBottomInput,
-  listPadding,
+  padding,
   size = 10,
 }: {
   resourceId: string
   resourceType: ResourceType
   placeholders?: Placeholders
   isFixedBottomInput?: boolean
-  listPadding?: MarginPadding
+  padding?: MarginPadding
   size?: number
 }) {
   const [replies, setReplies] = useState<Reply[]>([])
@@ -141,7 +141,7 @@ export default function Replies({
       <ReplyList
         replies={replies}
         isMoreButtonActive={hasNextPage}
-        listPadding={listPadding}
+        padding={padding}
         fetchMoreReplies={fetchMoreReplies}
         focusInput={focusInput}
         onReplyDelete={handleReplyDelete}

--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -28,14 +28,14 @@ export default function Replies({
   resourceId,
   resourceType,
   placeholders,
-  isFixedBottomInput,
+  isFormFixed,
   padding,
   size = 10,
 }: {
   resourceId: string
   resourceType: ResourceType
   placeholders?: Placeholders
-  isFixedBottomInput?: boolean
+  isFormFixed?: boolean
   padding?: MarginPadding
   size?: number
 }) {
@@ -134,7 +134,7 @@ export default function Replies({
     registerRef.current?.focusInput()
   }
 
-  const InputContainer = isFixedBottomInput ? FixedBottom : Container
+  const InputContainer = isFormFixed ? FixedBottom : Container
 
   return (
     <RepliesProvider>

--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
+import { Container, MarginPadding } from '@titicaca/core-elements'
+import styled from 'styled-components'
 
 import { fetchReplies, fetchChildReplies } from './replies-api-client'
 import { Reply, ResourceType, Placeholders } from './types'
@@ -14,15 +16,29 @@ import {
   editReply,
 } from './reply-tree-manipulators'
 
+const FixedBottom = styled(Container).attrs({
+  backgroundColor: 'white',
+  position: 'fixed',
+})`
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 3;
+`
+
 export default function Replies({
   resourceId,
   resourceType,
   placeholders,
+  isFixedBottomInput,
+  listPadding,
   size = 10,
 }: {
   resourceId: string
   resourceType: ResourceType
   placeholders?: Placeholders
+  isFixedBottomInput?: boolean
+  listPadding?: MarginPadding
   size?: number
 }) {
   const [replies, setReplies] = useState<Reply[]>([])
@@ -120,27 +136,32 @@ export default function Replies({
     registerRef.current?.focusInput()
   }
 
+  const InputContainer = isFixedBottomInput ? FixedBottom : Container
+
   return (
     <RepliesProvider>
       <ReplyList
         replies={replies}
         isMoreButtonActive={hasNextPage}
+        listPadding={listPadding}
         fetchMoreReplies={fetchMoreReplies}
         focusInput={focusInput}
         onReplyDelete={handleReplyDelete}
         onReplyEdit={handleReplyEdit}
       />
 
-      <GuideText />
+      <InputContainer>
+        <GuideText />
 
-      <Register
-        ref={registerRef}
-        resourceId={resourceId}
-        resourceType={resourceType}
-        placeholders={placeholders}
-        onReplyAdd={handleReplyAdd}
-        onReplyEdit={handleReplyEdit}
-      />
+        <Register
+          ref={registerRef}
+          resourceId={resourceId}
+          resourceType={resourceType}
+          placeholders={placeholders}
+          onReplyAdd={handleReplyAdd}
+          onReplyEdit={handleReplyEdit}
+        />
+      </InputContainer>
     </RepliesProvider>
   )
 }

--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -19,10 +19,8 @@ import {
 const FixedBottom = styled(Container).attrs({
   backgroundColor: 'white',
   position: 'fixed',
+  positioning: { left: 0, right: 0, bottom: 0 },
 })`
-  bottom: 0;
-  left: 0;
-  right: 0;
   z-index: 3;
 `
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

입력창을 화면 최하단에 고정하는 optional props를 추가합니다.

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

**props**

1 `isFormFixed`을 추가합니다.
  - true일 때, 화면 최하단에 댓글/답글 입력창을 고정합니다.
  - false일 때, 댓글/답글 리스트 아래에 댓글/답글 입력창을 위치시킵니다.  (default)

2 `padding`을 추가합니다.
  - replies 패키지를 사용하는 프로젝트에서 댓글/답글 리스트의 padding을 설정할 수 있습니다. 

**docs**
- README.md를 수정합니다.

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
