### PR TITLE
Chromatic 변경 사항에서 오늘 날짜 제외

### DIFF
--- a/docs/decorators/index.tsx
+++ b/docs/decorators/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@titicaca/react-contexts'
 import { TripleClientMetadataProvider } from '@titicaca/react-triple-client-interfaces'
 import { GlobalStyle } from '@titicaca/core-elements'
+import MockDate from 'mockdate'
 
 export function globalStyleDecorator(Story: StoryFn) {
   return (
@@ -117,4 +118,9 @@ export function tripleClientMetadataDecorator(Story: StoryFn) {
       <Story />
     </TripleClientMetadataProvider>
   )
+}
+
+export function newDateMockingDecorator(Story: StoryFn) {
+  MockDate.set('1/1/2022')
+  return <Story />
 }

--- a/docs/stories/date-picker/day-picker.stories.tsx
+++ b/docs/stories/date-picker/day-picker.stories.tsx
@@ -1,13 +1,16 @@
 import { DayPicker } from '@titicaca/date-picker'
 import { ComponentStoryObj, Meta } from '@storybook/react'
 
+import { newDateMockingDecorator } from 'decorators'
+
 export default {
   title: 'date-picker / DayPicker',
   component: DayPicker,
+  decorators: [newDateMockingDecorator],
 } as Meta
 
 export const Basic: ComponentStoryObj<typeof DayPicker> = {
-  storyName: '단일 날자 선택 컴포넌트',
+  storyName: '단일 날짜 선택 컴포넌트',
   args: {
     day: null,
     hideTodayLabel: true,

--- a/docs/stories/date-picker/day-picker.stories.tsx
+++ b/docs/stories/date-picker/day-picker.stories.tsx
@@ -1,7 +1,7 @@
 import { DayPicker } from '@titicaca/date-picker'
 import { ComponentStoryObj, Meta } from '@storybook/react'
 
-import { newDateMockingDecorator } from 'decorators'
+import { newDateMockingDecorator } from '../../decorators'
 
 export default {
   title: 'date-picker / DayPicker',

--- a/docs/stories/date-picker/range-picker-v2.stories.tsx
+++ b/docs/stories/date-picker/range-picker-v2.stories.tsx
@@ -4,9 +4,12 @@ import {
 } from '@titicaca/date-picker'
 import { ComponentStoryObj, Meta } from '@storybook/react'
 
+import { newDateMockingDecorator } from 'decorators'
+
 export default {
   title: 'date-picker / RangePickerV2',
   component: RangePickerV2,
+  decorators: [newDateMockingDecorator],
 } as Meta
 
 export const Basic: ComponentStoryObj<typeof RangePickerV2> = {

--- a/docs/stories/date-picker/range-picker-v2.stories.tsx
+++ b/docs/stories/date-picker/range-picker-v2.stories.tsx
@@ -4,7 +4,7 @@ import {
 } from '@titicaca/date-picker'
 import { ComponentStoryObj, Meta } from '@storybook/react'
 
-import { newDateMockingDecorator } from 'decorators'
+import { newDateMockingDecorator } from '../../decorators'
 
 export default {
   title: 'date-picker / RangePickerV2',

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "lerna": "^4.0.0",
         "lint-staged": "^11.2.3",
         "lodash.debounce": "^4.0.8",
+        "mockdate": "^3.0.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-test-renderer": "^17.0.2",
@@ -33920,6 +33921,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "dev": true
     },
     "node_modules/modify-values": {
       "version": "1.0.1",
@@ -70709,6 +70716,12 @@
         "infer-owner": "^1.0.4",
         "mkdirp": "^1.0.3"
       }
+    },
+    "mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "dev": true
     },
     "modify-values": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "lerna": "^4.0.0",
     "lint-staged": "^11.2.3",
     "lodash.debounce": "^4.0.8",
+    "mockdate": "^3.0.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-test-renderer": "^17.0.2",


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

오늘 날짜가 변하면 Chromatic이 변경 사항으로 감지하는 것을 방지하기 위해 `MockDate` 라이브러리를 적용합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

[관련 이슈](https://github.com/titicacadev/triple-frontend/issues/1753)
<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
