### PR TITLE
[user-verification] External promotion에 대응 가능하도록 인터페이스를 확장합니다.

### DIFF
--- a/packages/user-verification/src/confirmation-services.test.ts
+++ b/packages/user-verification/src/confirmation-services.test.ts
@@ -268,4 +268,120 @@ describe('confirmVerification', () => {
       expect(result).toHaveProperty('verified', undefined)
     })
   })
+
+  describe('external-promotion-*', () => {
+    it('invokes external-promotion eligibility check api', async () => {
+      const getMock = (
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 404,
+          parsedBody: { message: 'not found' },
+          ok: false,
+        }),
+      )
+
+      expect(
+        await confirmVerification('external-promotion-kto-stay-2022'),
+      ).toStrictEqual({
+        verified: false,
+      })
+      expect(getMock).toHaveBeenCalledWith(
+        '/api/users/external-promotion/kto-stay-2022/eligibility',
+      )
+    })
+
+    it('returns not-verified state when it is not verified', async () => {
+      ;(
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 404,
+          parsedBody: { message: 'not found' },
+          ok: false,
+        }),
+      )
+
+      expect(
+        await confirmVerification('external-promotion-kto-stay-2022'),
+      ).toStrictEqual({
+        verified: false,
+      })
+    })
+
+    it('returns verified state when it is verified', async () => {
+      ;(
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 200,
+          parsedBody: {
+            userId: 28,
+            residence: [
+              {
+                key: 'korea-sido',
+                value: '11',
+              },
+              {
+                key: 'korea-sgg',
+                value: '11710',
+              },
+            ],
+            nameChecked: true,
+            phoneNumber: '01012345678',
+          },
+          ok: true,
+        }),
+      )
+      const result = await confirmVerification(
+        'external-promotion-kto-stay-2022',
+      )
+
+      expect(result).toHaveProperty('verified', true)
+      expect(result).toHaveProperty('phoneNumber', '01012345678')
+    })
+
+    it('returns undefined state when it is responded with an error', async () => {
+      ;(
+        get as unknown as jest.MockedFunction<
+          () => Promise<{
+            status: number
+            parsedBody: unknown
+            ok: boolean
+          }>
+        >
+      ).mockImplementation(() =>
+        Promise.resolve({
+          status: 500,
+          parsedBody: {
+            message: 'internal server error',
+          },
+          ok: false,
+        }),
+      )
+      const result = await confirmVerification(
+        'external-promotion-kto-stay-2022',
+      )
+
+      expect(result).toHaveProperty('verified', undefined)
+    })
+  })
 })

--- a/packages/user-verification/src/types.ts
+++ b/packages/user-verification/src/types.ts
@@ -1,4 +1,4 @@
-export type VerificationType =
-  | 'sms-verification'
-  | 'personal-id-verification-with-residence'
-  | 'personal-id-verification'
+/**
+ * @deprecated 다양한 외부 프로모션 타입에 대응하기 위해 string 타입을 사용합니다.
+ */
+export type VerificationType = string

--- a/packages/user-verification/src/use-user-verification.test.ts
+++ b/packages/user-verification/src/use-user-verification.test.ts
@@ -3,7 +3,6 @@ import { useExternalRouter } from '@titicaca/router'
 
 import { useUserVerification } from './use-user-verification'
 import './confirmation-services'
-import type { VerificationType } from './types'
 
 jest.mock('@titicaca/react-hooks', () => ({
   useVisibilityChange: jest.fn(),
@@ -51,9 +50,13 @@ describe('인증 시작함수를 호출하면 인증 페이지를 엽니다.', (
       ['sms-verification', '/verifications/'],
       ['personal-id-verification-with-residence', '/verifications/residence'],
       ['personal-id-verification', '/verifications/personal-id-verification'],
+      [
+        'external-promotion-kto-stay-2022',
+        '/verifications/external-promotion/kto-stay-2022',
+      ],
     ] as const)(
       'VerificationType: %s, path: %s',
-      async (verificationType: VerificationType | undefined, href: string) => {
+      async (verificationType: string | undefined, href: string) => {
         const { routeExternally } = await prepareTest({ verificationType })
 
         expect(routeExternally).toBeCalledWith(


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

다양한 외부 프로모션이 요구하는 사용자 인증 형태에 대응하기 위해 유연한 `VerificationType`을 지원합니다.

## 변경 내역

- `VerificationType`을 `string` 타입으로 완화합니다. (`string`을 직접 사용하도록 유도하기 위해 Deprecate합니다.)
- `"external-promotion-*"` 패턴의 `verificationType`은 외부 프로모션용 검증 API, 인증유도 URL을 사용합니다.
  - Refer https://github.com/titicacadev/triple-verifications-web/pull/102, https://github.com/titicacadev/triple-user/pull/236
