### PR TITLE
[poi-detail] areas props의 타이핑을 string도 받을수 있도록 확장

### DIFF
--- a/docs/stories/poi-detail/detail-header-v2.stories.tsx
+++ b/docs/stories/poi-detail/detail-header-v2.stories.tsx
@@ -37,10 +37,7 @@ export const Basic: ComponentStoryObj<typeof DetailHeaderV2> = {
       en: 'Tokyo Disney land',
       local: '東京ディズニーランド',
     },
-    areas: [
-      { id: 1, name: '도쿄' },
-      { id: 2, name: '오사카' },
-    ],
+    areaName: '도쿄',
     scrapsCount: 682,
     reviewsCount: 13859,
     reviewsRating: 4.45,

--- a/docs/stories/poi-detail/detail-header.stories.tsx
+++ b/docs/stories/poi-detail/detail-header.stories.tsx
@@ -37,10 +37,7 @@ export const Basic: ComponentStoryObj<typeof DetailHeader> = {
       en: 'Tokyo Disney land',
       local: '東京ディズニーランド',
     },
-    areas: [
-      { id: 1, name: '도쿄' },
-      { id: 2, name: '오사카' },
-    ],
+    areaName: '도쿄',
     scrapsCount: 682,
     reviewsCount: 13859,
     reviewsRating: 4.45,

--- a/packages/poi-detail/src/area-names.tsx
+++ b/packages/poi-detail/src/area-names.tsx
@@ -17,7 +17,7 @@ interface Area {
 
 export default function AreaNames({
   areaName,
-  areas,
+  areas = [],
   vicinity,
   arrowAction,
 }: {

--- a/packages/poi-detail/src/area-names.tsx
+++ b/packages/poi-detail/src/area-names.tsx
@@ -10,28 +10,19 @@ const AreaContainer = styled(Container)`
   background-position: left top;
 `
 
-interface Area {
-  id: number | string
-  name: string
-}
-
 export default function AreaNames({
-  areas,
-  vicinity,
+  areaName,
   arrowAction,
 }: {
-  areas: Area[] | string
-  vicinity?: string
+  areaName: string
   arrowAction?: ReactNode
 }) {
-  const names = (Array.isArray(areas) ? areas[0]?.name : areas) || vicinity
-
-  return names ? (
+  return (
     <AreaContainer>
       <Text size="tiny" bold margin={{ top: 10 }} alpha={0.8} lineHeight={1.38}>
-        {names}
+        {areaName}
         {arrowAction}
       </Text>
     </AreaContainer>
-  ) : null
+  )
 }

--- a/packages/poi-detail/src/area-names.tsx
+++ b/packages/poi-detail/src/area-names.tsx
@@ -16,15 +16,18 @@ interface Area {
 }
 
 export default function AreaNames({
+  areaName,
   areas,
   vicinity,
   arrowAction,
 }: {
-  areas: Area[] | string
+  areaName?: string
+  areas?: Area[] | string
   vicinity?: string
   arrowAction?: ReactNode
 }) {
-  const names = (Array.isArray(areas) ? areas[0]?.name : areas) || vicinity
+  const names =
+    areaName || (Array.isArray(areas) ? areas[0]?.name : areas) || vicinity
 
   return names ? (
     <AreaContainer>

--- a/packages/poi-detail/src/area-names.tsx
+++ b/packages/poi-detail/src/area-names.tsx
@@ -24,8 +24,7 @@ export default function AreaNames({
   vicinity?: string
   arrowAction?: ReactNode
 }) {
-  const names =
-    (areas && Array.isArray(areas) ? areas[0]?.name : areas) || vicinity
+  const names = (Array.isArray(areas) ? areas[0]?.name : areas) || vicinity
 
   return names ? (
     <AreaContainer>

--- a/packages/poi-detail/src/area-names.tsx
+++ b/packages/poi-detail/src/area-names.tsx
@@ -22,12 +22,11 @@ export default function AreaNames({
   arrowAction,
 }: {
   areaName?: string
-  areas?: Area[] | string
+  areas?: Area[]
   vicinity?: string
   arrowAction?: ReactNode
 }) {
-  const names =
-    areaName || (Array.isArray(areas) ? areas[0]?.name : areas) || vicinity
+  const names = areaName || areas[0]?.name || vicinity
 
   return names ? (
     <AreaContainer>

--- a/packages/poi-detail/src/area-names.tsx
+++ b/packages/poi-detail/src/area-names.tsx
@@ -20,11 +20,12 @@ export default function AreaNames({
   vicinity,
   arrowAction,
 }: {
-  areas: Area[]
+  areas: Area[] | string
   vicinity?: string
   arrowAction?: ReactNode
 }) {
-  const names = areas[0]?.name || vicinity
+  const names =
+    (areas && Array.isArray(areas) ? areas[0]?.name : areas) || vicinity
 
   return names ? (
     <AreaContainer>

--- a/packages/poi-detail/src/area-names.tsx
+++ b/packages/poi-detail/src/area-names.tsx
@@ -10,7 +10,7 @@ const AreaContainer = styled(Container)`
   background-position: left top;
 `
 
-export default function Area({
+export default function AreaNames({
   areaName,
   arrowAction,
 }: {

--- a/packages/poi-detail/src/area-names.tsx
+++ b/packages/poi-detail/src/area-names.tsx
@@ -10,19 +10,28 @@ const AreaContainer = styled(Container)`
   background-position: left top;
 `
 
+interface Area {
+  id: number | string
+  name: string
+}
+
 export default function AreaNames({
-  areaName,
+  areas,
+  vicinity,
   arrowAction,
 }: {
-  areaName: string
+  areas: Area[] | string
+  vicinity?: string
   arrowAction?: ReactNode
 }) {
-  return (
+  const names = (Array.isArray(areas) ? areas[0]?.name : areas) || vicinity
+
+  return names ? (
     <AreaContainer>
       <Text size="tiny" bold margin={{ top: 10 }} alpha={0.8} lineHeight={1.38}>
-        {areaName}
+        {names}
         {arrowAction}
       </Text>
     </AreaContainer>
-  )
+  ) : null
 }

--- a/packages/poi-detail/src/area.tsx
+++ b/packages/poi-detail/src/area.tsx
@@ -10,7 +10,7 @@ const AreaContainer = styled(Container)`
   background-position: left top;
 `
 
-export default function AreaNames({
+export default function Area({
   areaName,
   arrowAction,
 }: {

--- a/packages/poi-detail/src/detail-header-v2/index.test.tsx
+++ b/packages/poi-detail/src/detail-header-v2/index.test.tsx
@@ -67,6 +67,7 @@ describe('when user is on app', () => {
     render(
       <DetailHeaderV2
         names={{ ko: 'test', en: 'test', local: 'test' }}
+        areaName="테스트 지역"
         scrapsCount={1}
         reviewsCount={0}
         reviewsRating={0}
@@ -113,6 +114,7 @@ describe('when user is on web', () => {
     render(
       <DetailHeaderV2
         names={{ ko: 'test', en: 'test', local: 'test' }}
+        areaName="테스트 지역"
         scrapsCount={1}
         reviewsCount={0}
         reviewsRating={0}

--- a/packages/poi-detail/src/detail-header-v2/index.tsx
+++ b/packages/poi-detail/src/detail-header-v2/index.tsx
@@ -18,7 +18,7 @@ import { formatNumber } from '@titicaca/view-utilities'
 import { TranslatedProperty } from '@titicaca/type-definitions'
 
 import CopyActionSheet from '../copy-action-sheet'
-import Area from '../area'
+import AreaNames from '../area-names'
 import { HASH_COPY_ACTION_SHEET } from '../constants'
 
 const ArrowButton = styled.button`
@@ -102,7 +102,7 @@ export default function DetailHeaderV2({
             ) : null}
           </Container>
         )}
-        <Area
+        <AreaNames
           areaName={areaName}
           arrowAction={
             onAreaClick ? (

--- a/packages/poi-detail/src/detail-header-v2/index.tsx
+++ b/packages/poi-detail/src/detail-header-v2/index.tsx
@@ -59,7 +59,7 @@ export default function DetailHeaderV2({
   ...props
 }: {
   names: TranslatedProperty
-  areas?: Area[]
+  areas?: Area[] | string
   scrapsCount: number
   reviewsCount: number
   reviewsRating: number

--- a/packages/poi-detail/src/detail-header-v2/index.tsx
+++ b/packages/poi-detail/src/detail-header-v2/index.tsx
@@ -18,7 +18,7 @@ import { formatNumber } from '@titicaca/view-utilities'
 import { TranslatedProperty } from '@titicaca/type-definitions'
 
 import CopyActionSheet from '../copy-action-sheet'
-import AreaNames from '../area-names'
+import Area from '../area'
 import { HASH_COPY_ACTION_SHEET } from '../constants'
 
 const ArrowButton = styled.button`
@@ -102,7 +102,7 @@ export default function DetailHeaderV2({
             ) : null}
           </Container>
         )}
-        <AreaNames
+        <Area
           areaName={areaName}
           arrowAction={
             onAreaClick ? (

--- a/packages/poi-detail/src/detail-header-v2/index.tsx
+++ b/packages/poi-detail/src/detail-header-v2/index.tsx
@@ -41,32 +41,25 @@ const ArrowButton = styled.button`
 
 const LongClickableSection = longClickable(Section)
 
-interface Area {
-  id: number | string
-  name: string
-}
-
 export default function DetailHeaderV2({
   names,
-  areas = [],
+  areaName,
   scrapsCount,
   reviewsCount,
   reviewsRating,
   onReviewsRatingClick,
   onCopy,
   onAreaClick,
-  vicinity,
   ...props
 }: {
   names: TranslatedProperty
-  areas?: Area[] | string
+  areaName: string
   scrapsCount: number
   reviewsCount: number
   reviewsRating: number
   onReviewsRatingClick: () => void
   onAreaClick?: () => void
   onCopy: (value: string) => void
-  vicinity?: string
 } & Parameters<typeof Section>['0']) {
   const app = useTripleClientMetadata()
   const uriHash = useUriHash()
@@ -110,8 +103,7 @@ export default function DetailHeaderV2({
           </Container>
         )}
         <AreaNames
-          areas={areas}
-          vicinity={vicinity}
+          areaName={areaName}
           arrowAction={
             onAreaClick ? (
               <ArrowButton onClick={onAreaClick}>지도보기</ArrowButton>

--- a/packages/poi-detail/src/detail-header-v2/index.tsx
+++ b/packages/poi-detail/src/detail-header-v2/index.tsx
@@ -48,6 +48,7 @@ interface Area {
 
 export default function DetailHeaderV2({
   names,
+  areaName,
   areas = [],
   scrapsCount,
   reviewsCount,
@@ -59,6 +60,10 @@ export default function DetailHeaderV2({
   ...props
 }: {
   names: TranslatedProperty
+  areaName?: string
+  /**
+   * @deprecated areaName 으로 통합됩니다.
+   */
   areas?: Area[] | string
   scrapsCount: number
   reviewsCount: number
@@ -66,6 +71,9 @@ export default function DetailHeaderV2({
   onReviewsRatingClick: () => void
   onAreaClick?: () => void
   onCopy: (value: string) => void
+  /**
+   * @deprecated areaName 으로 통합됩니다.
+   */
   vicinity?: string
 } & Parameters<typeof Section>['0']) {
   const app = useTripleClientMetadata()
@@ -110,6 +118,7 @@ export default function DetailHeaderV2({
           </Container>
         )}
         <AreaNames
+          areaName={areaName}
           areas={areas}
           vicinity={vicinity}
           arrowAction={

--- a/packages/poi-detail/src/detail-header-v2/index.tsx
+++ b/packages/poi-detail/src/detail-header-v2/index.tsx
@@ -64,7 +64,7 @@ export default function DetailHeaderV2({
   /**
    * @deprecated areaName 으로 통합됩니다.
    */
-  areas?: Area[] | string
+  areas?: Area[]
   scrapsCount: number
   reviewsCount: number
   reviewsRating: number

--- a/packages/poi-detail/src/detail-header-v2/index.tsx
+++ b/packages/poi-detail/src/detail-header-v2/index.tsx
@@ -41,25 +41,32 @@ const ArrowButton = styled.button`
 
 const LongClickableSection = longClickable(Section)
 
+interface Area {
+  id: number | string
+  name: string
+}
+
 export default function DetailHeaderV2({
   names,
-  areaName,
+  areas = [],
   scrapsCount,
   reviewsCount,
   reviewsRating,
   onReviewsRatingClick,
   onCopy,
   onAreaClick,
+  vicinity,
   ...props
 }: {
   names: TranslatedProperty
-  areaName: string
+  areas?: Area[] | string
   scrapsCount: number
   reviewsCount: number
   reviewsRating: number
   onReviewsRatingClick: () => void
   onAreaClick?: () => void
   onCopy: (value: string) => void
+  vicinity?: string
 } & Parameters<typeof Section>['0']) {
   const app = useTripleClientMetadata()
   const uriHash = useUriHash()
@@ -103,7 +110,8 @@ export default function DetailHeaderV2({
           </Container>
         )}
         <AreaNames
-          areaName={areaName}
+          areas={areas}
+          vicinity={vicinity}
           arrowAction={
             onAreaClick ? (
               <ArrowButton onClick={onAreaClick}>지도보기</ArrowButton>

--- a/packages/poi-detail/src/detail-header/index.test.tsx
+++ b/packages/poi-detail/src/detail-header/index.test.tsx
@@ -67,6 +67,7 @@ describe('when user is on app', () => {
     render(
       <DetailHeader
         names={{ ko: 'test', en: 'test', local: 'test' }}
+        areaName="테스트 지역"
         scrapsCount={1}
         reviewsCount={0}
         reviewsRating={0}
@@ -113,6 +114,7 @@ describe('when user is on web', () => {
     render(
       <DetailHeader
         names={{ ko: 'test', en: 'test', local: 'test' }}
+        areaName="테스트 지역"
         scrapsCount={1}
         reviewsCount={0}
         reviewsRating={0}

--- a/packages/poi-detail/src/detail-header/index.tsx
+++ b/packages/poi-detail/src/detail-header/index.tsx
@@ -44,7 +44,7 @@ export default function DetailHeader({
   /**
    * @deprecated areaName 으로 통합됩니다.
    */
-  areas?: Area[] | string
+  areas?: Area[]
   scrapsCount: number
   reviewsCount: number
   reviewsRating: number

--- a/packages/poi-detail/src/detail-header/index.tsx
+++ b/packages/poi-detail/src/detail-header/index.tsx
@@ -29,6 +29,7 @@ interface Area {
 
 export default function DetailHeader({
   names,
+  areaName,
   areas = [],
   scrapsCount,
   reviewsCount,
@@ -39,12 +40,19 @@ export default function DetailHeader({
   ...props
 }: {
   names: TranslatedProperty
+  areaName?: string
+  /**
+   * @deprecated areaName 으로 통합됩니다.
+   */
   areas?: Area[] | string
   scrapsCount: number
   reviewsCount: number
   reviewsRating: number
   onReviewsRatingClick: () => void
   onCopy: (value: string) => void
+  /**
+   * @deprecated areaName 으로 통합됩니다.
+   */
   vicinity?: string
 } & Parameters<typeof Section>['0']) {
   const app = useTripleClientMetadata()
@@ -90,7 +98,7 @@ export default function DetailHeader({
             )}
           </Container>
         )}
-        <AreaNames areas={areas} vicinity={vicinity} />
+        <AreaNames areaName={areaName} areas={areas} vicinity={vicinity} />
       </LongClickableSection>
       <CopyActionSheet
         open={uriHash === HASH_COPY_ACTION_SHEET}

--- a/packages/poi-detail/src/detail-header/index.tsx
+++ b/packages/poi-detail/src/detail-header/index.tsx
@@ -22,30 +22,23 @@ import { HASH_COPY_ACTION_SHEET } from '../constants'
 
 const LongClickableSection = longClickable(Section)
 
-interface Area {
-  id: number | string
-  name: string
-}
-
 export default function DetailHeader({
   names,
-  areas = [],
+  areaName,
   scrapsCount,
   reviewsCount,
   reviewsRating,
   onReviewsRatingClick,
   onCopy,
-  vicinity,
   ...props
 }: {
   names: TranslatedProperty
-  areas?: Area[] | string
+  areaName: string
   scrapsCount: number
   reviewsCount: number
   reviewsRating: number
   onReviewsRatingClick: () => void
   onCopy: (value: string) => void
-  vicinity?: string
 } & Parameters<typeof Section>['0']) {
   const app = useTripleClientMetadata()
   const uriHash = useUriHash()
@@ -90,7 +83,7 @@ export default function DetailHeader({
             )}
           </Container>
         )}
-        <AreaNames areas={areas} vicinity={vicinity} />
+        <AreaNames areaName={areaName} />
       </LongClickableSection>
       <CopyActionSheet
         open={uriHash === HASH_COPY_ACTION_SHEET}

--- a/packages/poi-detail/src/detail-header/index.tsx
+++ b/packages/poi-detail/src/detail-header/index.tsx
@@ -22,23 +22,30 @@ import { HASH_COPY_ACTION_SHEET } from '../constants'
 
 const LongClickableSection = longClickable(Section)
 
+interface Area {
+  id: number | string
+  name: string
+}
+
 export default function DetailHeader({
   names,
-  areaName,
+  areas = [],
   scrapsCount,
   reviewsCount,
   reviewsRating,
   onReviewsRatingClick,
   onCopy,
+  vicinity,
   ...props
 }: {
   names: TranslatedProperty
-  areaName: string
+  areas?: Area[] | string
   scrapsCount: number
   reviewsCount: number
   reviewsRating: number
   onReviewsRatingClick: () => void
   onCopy: (value: string) => void
+  vicinity?: string
 } & Parameters<typeof Section>['0']) {
   const app = useTripleClientMetadata()
   const uriHash = useUriHash()
@@ -83,7 +90,7 @@ export default function DetailHeader({
             )}
           </Container>
         )}
-        <AreaNames areaName={areaName} />
+        <AreaNames areas={areas} vicinity={vicinity} />
       </LongClickableSection>
       <CopyActionSheet
         open={uriHash === HASH_COPY_ACTION_SHEET}

--- a/packages/poi-detail/src/detail-header/index.tsx
+++ b/packages/poi-detail/src/detail-header/index.tsx
@@ -17,7 +17,7 @@ import { TranslatedProperty } from '@titicaca/type-definitions'
 import { formatNumber } from '@titicaca/view-utilities'
 
 import CopyActionSheet from '../copy-action-sheet'
-import Area from '../area'
+import AreaNames from '../area-names'
 import { HASH_COPY_ACTION_SHEET } from '../constants'
 
 const LongClickableSection = longClickable(Section)
@@ -83,7 +83,7 @@ export default function DetailHeader({
             )}
           </Container>
         )}
-        <Area areaName={areaName} />
+        <AreaNames areaName={areaName} />
       </LongClickableSection>
       <CopyActionSheet
         open={uriHash === HASH_COPY_ACTION_SHEET}

--- a/packages/poi-detail/src/detail-header/index.tsx
+++ b/packages/poi-detail/src/detail-header/index.tsx
@@ -17,7 +17,7 @@ import { TranslatedProperty } from '@titicaca/type-definitions'
 import { formatNumber } from '@titicaca/view-utilities'
 
 import CopyActionSheet from '../copy-action-sheet'
-import AreaNames from '../area-names'
+import Area from '../area'
 import { HASH_COPY_ACTION_SHEET } from '../constants'
 
 const LongClickableSection = longClickable(Section)
@@ -83,7 +83,7 @@ export default function DetailHeader({
             )}
           </Container>
         )}
-        <AreaNames areaName={areaName} />
+        <Area areaName={areaName} />
       </LongClickableSection>
       <CopyActionSheet
         open={uriHash === HASH_COPY_ACTION_SHEET}

--- a/packages/poi-detail/src/detail-header/index.tsx
+++ b/packages/poi-detail/src/detail-header/index.tsx
@@ -39,7 +39,7 @@ export default function DetailHeader({
   ...props
 }: {
   names: TranslatedProperty
-  areas?: Area[]
+  areas?: Area[] | string
   scrapsCount: number
   reviewsCount: number
   reviewsRating: number


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
detail-header컴포넌트의 areas props의 타이핑을 확장
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- string타입을 추가하고, 타입에 따라 분기되도록 수정
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
