### PR TITLE
web-to-native-interfaces 모듈을 peerDependencies로 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38760,7 +38760,7 @@
         "semver": "^7.3.5"
       },
       "devDependencies": {
-        "@titicaca/triple-web-to-native-interfaces": "*",
+        "@titicaca/triple-web-to-native-interfaces": "^1.5.0",
         "@types/qs": "^6.9.5",
         "@types/semver": "^7.3.6"
       },
@@ -49979,7 +49979,7 @@
     "@titicaca/react-triple-client-interfaces": {
       "version": "file:packages/react-triple-client-interfaces",
       "requires": {
-        "@titicaca/triple-web-to-native-interfaces": "*",
+        "@titicaca/triple-web-to-native-interfaces": "^1.5.0",
         "@types/qs": "^6.9.5",
         "@types/semver": "^7.3.6",
         "qs": "^6.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38756,11 +38756,11 @@
       "version": "7.3.0",
       "license": "MIT",
       "dependencies": {
-        "@titicaca/triple-web-to-native-interfaces": "1.5.0",
         "qs": "^6.9.4",
         "semver": "^7.3.5"
       },
       "devDependencies": {
+        "@titicaca/triple-web-to-native-interfaces": "*",
         "@types/qs": "^6.9.5",
         "@types/semver": "^7.3.6"
       },
@@ -38897,11 +38897,11 @@
       "dependencies": {
         "@titicaca/core-elements": "^7.3.0",
         "@titicaca/react-hooks": "^7.3.0",
-        "@titicaca/triple-web-to-native-interfaces": "1.5.0",
         "@titicaca/view-utilities": "^7.3.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "@titicaca/triple-web-to-native-interfaces": "*"
       }
     },
     "packages/slider": {
@@ -49979,7 +49979,7 @@
     "@titicaca/react-triple-client-interfaces": {
       "version": "file:packages/react-triple-client-interfaces",
       "requires": {
-        "@titicaca/triple-web-to-native-interfaces": "1.5.0",
+        "@titicaca/triple-web-to-native-interfaces": "*",
         "@types/qs": "^6.9.5",
         "@types/semver": "^7.3.6",
         "qs": "^6.9.4",
@@ -50076,7 +50076,6 @@
       "requires": {
         "@titicaca/core-elements": "^7.3.0",
         "@titicaca/react-hooks": "^7.3.0",
-        "@titicaca/triple-web-to-native-interfaces": "1.5.0",
         "@titicaca/view-utilities": "^7.3.0"
       }
     },

--- a/packages/react-triple-client-interfaces/package.json
+++ b/packages/react-triple-client-interfaces/package.json
@@ -14,11 +14,11 @@
     "build:ci": "BABEL_ENV=build babel --root-mode upward src --out-dir lib --source-maps --extensions .ts,.tsx,.js --no-comments"
   },
   "dependencies": {
-    "@titicaca/triple-web-to-native-interfaces": "1.5.0",
     "qs": "^6.9.4",
     "semver": "^7.3.5"
   },
   "devDependencies": {
+    "@titicaca/triple-web-to-native-interfaces": "*",
     "@types/qs": "^6.9.5",
     "@types/semver": "^7.3.6"
   },

--- a/packages/react-triple-client-interfaces/package.json
+++ b/packages/react-triple-client-interfaces/package.json
@@ -18,7 +18,7 @@
     "semver": "^7.3.5"
   },
   "devDependencies": {
-    "@titicaca/triple-web-to-native-interfaces": "*",
+    "@titicaca/triple-web-to-native-interfaces": "^1.5.0",
     "@types/qs": "^6.9.5",
     "@types/semver": "^7.3.6"
   },

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "@titicaca/core-elements": "^7.3.0",
     "@titicaca/react-hooks": "^7.3.0",
-    "@titicaca/triple-web-to-native-interfaces": "1.5.0",
     "@titicaca/view-utilities": "^7.3.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "@titicaca/triple-web-to-native-interfaces": "*"
   }
 }


### PR DESCRIPTION
## PR 설명

TF와 [triple-web-to-native-interfaces](https://github.com/titicacadev/triple-web-to-native-interfaces)를 동시에 쓰면 다른 버전이 설치되면서 native interface가 이상동작하는 상황이 생깁니다.
triple-web-to-native-interfaces를 TF로 옮겨오면 좋겠지만.. 작업이 크기때문에 일단 TF에서 peerDependencies로 변경해놓습니다.