### PR TITLE
ExternalLink의 imageUrl이 있을 때만 Image 노출

### DIFF
--- a/packages/social-reviews/src/external-links.tsx
+++ b/packages/social-reviews/src/external-links.tsx
@@ -45,12 +45,12 @@ function ExternalLinkItem<Data>({
         <FlexBox minWidth={0} flexGrow={1}>
           <H3 maxLines={2}>{title}</H3>
           {summary && (
-            <Text size="small" alpha={0.7} margin={{ top: 8 }} ellipsis>
+            <Text size="small" alpha={0.7} margin={{ top: 6 }} ellipsis>
               {summary}
             </Text>
           )}
           {meta && (
-            <Text size="tiny" alpha={0.4} margin={{ top: 8 }} ellipsis>
+            <Text size="tiny" alpha={0.4} margin={{ top: 6 }} ellipsis>
               {meta}
             </Text>
           )}

--- a/packages/social-reviews/src/external-links.tsx
+++ b/packages/social-reviews/src/external-links.tsx
@@ -56,13 +56,15 @@ function ExternalLinkItem<Data>({
           )}
         </FlexBox>
 
-        <FlexBox width={60} flexShrink={0}>
-          <Image borderRadius={4}>
-            <Image.FixedRatioFrame frame="big">
-              <Image.Img src={imageUrl} alt={`${title} 썸네일`} />
-            </Image.FixedRatioFrame>
-          </Image>
-        </FlexBox>
+        {imageUrl && (
+          <FlexBox width={60} flexShrink={0}>
+            <Image borderRadius={4}>
+              <Image.FixedRatioFrame frame="big">
+                <Image.Img src={imageUrl} alt={`${title} 썸네일`} />
+              </Image.FixedRatioFrame>
+            </Image>
+          </FlexBox>
+        )}
       </FlexBox>
     </ExternalLinkEntry>
   )


### PR DESCRIPTION
## PR 설명

1. ExternalLink 데이터에 `imageUrl`이 비어있을 경우 이미지를 노출하지 않습니다. (현재는 이미지가 빈 회색으로 노출되고 있습니다.)
[슬랙 링크](https://titicaca.slack.com/archives/CRHS5TUNM/p1653268299802699)
2. 텍스트 간격을 `8`에서 `6`으로 조정합니다. (추가 수정 요청 사항)

## 변경 내역

1. Image 컴포넌트 노출 부분을 `{imageUrl && (...)}` 조건부 노출로 변경
2. 텍스트 마진 6으로 조정

## 체크리스트

- [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요?

## 스크린샷 & URL

![Screen Shot 2022-05-23 at 10 56 20 AM](https://user-images.githubusercontent.com/722173/169729028-fe52b633-e39e-477a-b304-a2526039bb8e.png)

