### PR TITLE
[replies] FixedBottom 컨테이너에 safeAreaInsetMixin을 추가합니다.

### DIFF
--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
-import { Container, MarginPadding } from '@titicaca/core-elements'
+import {
+  Container,
+  MarginPadding,
+  safeAreaInsetMixin,
+} from '@titicaca/core-elements'
 import styled from 'styled-components'
 
 import { fetchReplies, fetchChildReplies } from './replies-api-client'
@@ -22,6 +26,8 @@ const FixedBottom = styled(Container).attrs({
   positioning: { left: 0, right: 0, bottom: 0 },
 })`
   z-index: 3;
+
+  ${safeAreaInsetMixin}
 `
 
 export default function Replies({


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

Viewport 하단 영역에 safeAreaInset이 필요한 경우, 이 mixin이 없다면 터치 이벤트를 방해할 수 있습니다.

## 변경 내역

`FixedBottom` 컨테이너에 `core-elements` 패키지의 `safeAreaInsetMixin`을 추가합니다.

