### PR TITLE
[triple-document] images 요소의 이벤트 핸들러를 Override할 수 있도록 합니다.

### DIFF
--- a/packages/triple-document/src/elements/images.tsx
+++ b/packages/triple-document/src/elements/images.tsx
@@ -20,14 +20,22 @@ type MediaDisplayProperty = CSS.Property.Display | 'gapless-block'
 
 export default function Images({
   value: { images, display },
+  onImageClick: overridedOnImageClick,
+  onLinkClick: overridedOnLinkClick,
 }: {
   value: {
     images: ImageMeta[]
     display: MediaDisplayProperty
   }
+  onImageClick?: ReturnType<typeof useImageClickHandler>
+  onLinkClick?: ReturnType<typeof useLinkClickHandler>
 }) {
-  const onImageClick = useImageClickHandler()
-  const onLinkClick = useLinkClickHandler()
+  const defaultOnImageClick = useImageClickHandler()
+  const onImageClick = overridedOnImageClick || defaultOnImageClick
+
+  const defaultOnLinkClick = useLinkClickHandler()
+  const onLinkClick = overridedOnLinkClick || defaultOnLinkClick
+
   const ImageSource = useImageSource()
   const { videoAutoPlay, hideVideoControls, optimized } = useMediaConfig()
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

필요에 따라 Context가 아닌 Props를 통해 이벤트 핸들러를 주입 가능하도록 합니다. `images` 요소만 별도로 사용하고자 하는데, 이벤트 핸들링을 다루기 위해서는 `TripleDocument` 전체를 Mount해야 하는 불편이 있었습니다.

## 변경 내역

- `images` 요소 렌더링에 사용하는 `Images` 컴포넌트에 `onLinkClick`, `onImageClick` props를 추가합니다.
- 각 핸들러는 Optional type입니다.
- 핸들러가 props로 전달될 경우, Context가 아닌 props의 핸들러를 사용합니다.

## 스크린샷 & URL

https://titicaca.atlassian.net/browse/ENGDIVA-999