### PR TITLE
[replies] 노출하는 댓글 갯수를 변경할 수 있도록 props를 추가합니다.

### DIFF
--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -38,7 +38,7 @@ export default function Replies({
   isFormFixed,
   padding,
   size = 10,
-  initialSize = 3,
+  initialSize,
 }: {
   resourceId: string
   resourceType: ResourceType
@@ -133,7 +133,7 @@ export default function Replies({
   )
 
   const fetchInitialReplies = useCallback(async () => {
-    if (initialSize > size) {
+    if (initialSize && initialSize > size) {
       throw new Error('Failed to fetchInitialReplies')
     }
 

--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -138,20 +138,18 @@ export default function Replies({
         throw new Error('Failed to fetchInitialReplies')
       }
 
-      const pageNumber = Math.floor(Number(replies.length / initialSize))
-
       const [initialReplies, nextReplies] = await Promise.all([
         fetchReplies({
           resourceId,
           resourceType,
           size: initialSize,
-          page: pageNumber,
+          page: 0,
         }),
         fetchReplies({
           resourceId,
           resourceType,
           size: initialSize,
-          page: pageNumber + 1,
+          page: 1,
         }),
       ])
 
@@ -160,7 +158,7 @@ export default function Replies({
       setReplies(newReplies)
       setHasNextPage(nextReplies.length > 0)
     },
-    [resourceId, resourceType, size, replies],
+    [resourceId, resourceType, size],
   )
 
   useEffect(() => {

--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -132,37 +132,40 @@ export default function Replies({
     [resourceId, resourceType, size, replies],
   )
 
-  const fetchInitialReplies = useCallback(async () => {
-    if (initialSize && initialSize > size) {
-      throw new Error('Failed to fetchInitialReplies')
-    }
+  const fetchInitialReplies = useCallback(
+    async (initialSize: number) => {
+      if (initialSize > size) {
+        throw new Error('Failed to fetchInitialReplies')
+      }
 
-    const pageNumber = Math.floor(Number(replies.length / size))
+      const pageNumber = Math.floor(Number(replies.length / initialSize))
 
-    const [initialReplies, nextReplies] = await Promise.all([
-      fetchReplies({
-        resourceId,
-        resourceType,
-        size: initialSize,
-        page: pageNumber,
-      }),
-      fetchReplies({
-        resourceId,
-        resourceType,
-        size: initialSize,
-        page: pageNumber + 1,
-      }),
-    ])
+      const [initialReplies, nextReplies] = await Promise.all([
+        fetchReplies({
+          resourceId,
+          resourceType,
+          size: initialSize,
+          page: pageNumber,
+        }),
+        fetchReplies({
+          resourceId,
+          resourceType,
+          size: initialSize,
+          page: pageNumber + 1,
+        }),
+      ])
 
-    const newReplies = checkUniqueReply(initialReplies)
+      const newReplies = checkUniqueReply(initialReplies)
 
-    setReplies(newReplies)
-    setHasNextPage(nextReplies.length > 0)
-  }, [initialSize, size, replies, resourceId, resourceType])
+      setReplies(newReplies)
+      setHasNextPage(nextReplies.length > 0)
+    },
+    [resourceId, resourceType, size, replies],
+  )
 
   useEffect(() => {
     if (initialSize) {
-      fetchInitialReplies()
+      fetchInitialReplies(initialSize)
     } else {
       fetchMoreReplies()
     }

--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -37,6 +37,7 @@ export default function Replies({
   isFormFixed,
   padding,
   size = 10,
+  initialSize = 3,
 }: {
   resourceId: string
   resourceType: ResourceType
@@ -44,8 +45,10 @@ export default function Replies({
   isFormFixed?: boolean
   padding?: MarginPadding
   size?: number
+  initialSize?: number
 }) {
   const [replies, setReplies] = useState<Reply[]>([])
+  const [initialFetch, setInitialFetch] = useState(true)
   const [hasNextPage, setHasNextPage] = useState(false)
 
   const handleReplyAdd = (response: Reply): void => {
@@ -99,7 +102,7 @@ export default function Replies({
         : await fetchReplies({
             resourceId,
             resourceType,
-            size,
+            size: initialFetch ? initialSize : size,
             page: pageNumber,
           })
 
@@ -107,11 +110,12 @@ export default function Replies({
         const nextRepliesResponse: Reply[] = await fetchReplies({
           resourceId,
           resourceType,
-          size,
+          size: initialFetch ? initialSize : size,
           page: pageNumber + 1,
         })
 
         setHasNextPage(nextRepliesResponse.length > 0)
+        setInitialFetch(false)
       }
 
       const { children: newReplies } = appendReplyChildren(
@@ -125,7 +129,7 @@ export default function Replies({
 
       setReplies(newReplies)
     },
-    [resourceId, resourceType, size, replies],
+    [resourceId, resourceType, size, initialSize, initialFetch, replies],
   )
 
   useEffect(() => {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

페이지 진입시 노출하는 댓글 갯수를 변경할 수 있도록 props를 추가합니다.

자세한 내용은 [관련 스레드](https://titicaca.slack.com/archives/CRHS5TUNM/p1654228329233469)에서!

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

### props

#### `initialSize` (초기에 노출할 댓글 갯수)
  - initialSize를 정의한다면 정의한 숫자만큼 댓글이 노출됩니다.

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 스크린샷 & URL

아래는 댓글 16개가 달린 [공유 일정](https://triple-dev.titicaca-corp.com/trips/lounge/itineraries/6e891c08-c879-4f89-ac87-8ba35e4fa61b)이며, 초기 렌더링 시 3개를 노출합니다.

![image](https://user-images.githubusercontent.com/38130934/171831653-560153c3-a74b-4134-be9d-177734182a36.png)

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
