### PR TITLE
Map에서 의도치 않은 spinner를 삭제합니다.

### DIFF
--- a/packages/map/src/map-view.tsx
+++ b/packages/map/src/map-view.tsx
@@ -11,7 +11,6 @@ import {
   GoogleMapProps,
   useLoadScript,
 } from '@react-google-maps/api'
-import { Spinner } from '@titicaca/core-elements'
 
 import { getGeometry, literalToString } from './utilities'
 
@@ -131,7 +130,5 @@ export function MapView({
     >
       {children}
     </GoogleMap>
-  ) : (
-    <Spinner />
-  )
+  ) : null
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
- 현재 Map에서 컴포넌트 내가 아닌 뷰포트 중앙에 뜨는 spinner를 사용하고 있습니다.
- 위와 같은 사용을 의도되지 않은 랜더링으로 보고 이를 제거합니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- [packages/map/src/map-view.tsx](https://github.com/titicacadev/triple-frontend/compare/fix/remove-map-spinner?expand=1#diff-e2c9d3c5488a9e35379a1f9d9670e85691e66f4376c228e6c6f6569e0e4d0d28): `Spinner`를 삭제합니다. `isLoaded` 분기는 필수적이므로 로딩 중에는 `null`을 리턴합니다.

## 논의할 점

- tf에서 적절한 spinner 소스를 발견하지 못했고, 기존 `Spinner`가 공간을 확보하는 placeholder기능을 하지 않음에도 문제가 없었으므로 로딩 중에는 `null`을 리턴하도록 했습니다. 로딩 중인 경우를 다루는 나은 방법에 대해 의견을 부탁드립니다🙇‍♂️

<!-- ## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

<!-- ## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
