### PR TITLE
[ad-banners] 이벤트 수집이 안되는 오류를 해결합니다.

### DIFF
--- a/packages/ad-banners/src/api.ts
+++ b/packages/ad-banners/src/api.ts
@@ -1,5 +1,3 @@
-import qs from 'querystring'
-
 import { get, post } from '@titicaca/fetcher'
 
 import { Banner } from './typing'
@@ -128,7 +126,7 @@ function getSearchQuery(
 
   switch (bannerType) {
     case BannerTypes.ContentDetailsBanner:
-      return qs.stringify({
+      return {
         content_id: contentId,
         content_region_id: regionId,
         content_type: contentType,
@@ -136,12 +134,12 @@ function getSearchQuery(
           userLocation && userLocation.longitude && userLocation.latitude
             ? `${userLocation.longitude},${userLocation.latitude}`
             : undefined,
-      })
+      }
     case BannerTypes.ListTopBanner:
-      return qs.stringify({
+      return {
         content_type: contentType,
         region_id: regionId,
-      })
+      }
   }
 }
 
@@ -159,7 +157,7 @@ function getRequestBody(
 
   switch (bannerType) {
     case BannerTypes.ContentDetailsBanner:
-      return JSON.stringify({
+      return {
         content: {
           id: contentId,
           regionId,
@@ -170,11 +168,11 @@ function getRequestBody(
           userLocation && userLocation.longitude && userLocation.latitude
             ? [userLocation.longitude, userLocation.latitude]
             : undefined,
-      })
+      }
     case BannerTypes.ListTopBanner:
-      return JSON.stringify({
+      return {
         eventType,
         regionId,
-      })
+      }
   }
 }

--- a/packages/ad-banners/src/api.ts
+++ b/packages/ad-banners/src/api.ts
@@ -1,3 +1,5 @@
+import qs from 'querystring'
+
 import { get, post } from '@titicaca/fetcher'
 
 import { Banner } from './typing'
@@ -126,7 +128,7 @@ function getSearchQuery(
 
   switch (bannerType) {
     case BannerTypes.ContentDetailsBanner:
-      return {
+      return qs.stringify({
         content_id: contentId,
         content_region_id: regionId,
         content_type: contentType,
@@ -134,12 +136,12 @@ function getSearchQuery(
           userLocation && userLocation.longitude && userLocation.latitude
             ? `${userLocation.longitude},${userLocation.latitude}`
             : undefined,
-      }
+      })
     case BannerTypes.ListTopBanner:
-      return {
+      return qs.stringify({
         content_type: contentType,
         region_id: regionId,
-      }
+      })
   }
 }
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

`ad-banners` 패키지의 클릭 관련 이벤트 수집이 안되는 오류를 수정합니다.
- [관련 스레드](https://titicaca.slack.com/archives/C01CHRQBP1U/p1655445449851739)

### 원인 추정
[fetcher 안에서 직렬화](https://github.com/titicacadev/triple-frontend/blob/main/packages/fetcher/src/make-request-params.ts#L49)를 하고 `ad-banners` 안에서 또 한번 직렬화를 하다보니 그런 것으로 추정됩니다.
- [패키지 내 isomorphic-fetch를 제거하고 fetcher로 대체](https://github.com/titicacadev/triple-frontend/pull/2045)

### APM
- [정상요청](https://app.datadoghq.com/logs?event=AQAAAYFn5NqdkbNqGgAAAABBWUZuNVF2U0FBRFpha2hvT0F2NlE4T1c&from_ts=1655304460380&index=&live=false&query=trace_id%3A1446947008268632105&to_ts=1655306460533)
- [비정상요청](https://app.datadoghq.com/logs?event=AQAAAYFwYTjCp7UWuwAAAABBWUZ3WVZadUFBQUZLZ1RjM2s0MnlMQW0&from_ts=1655446828673&index=&live=false&query=trace_id%3A1342202844421033491&to_ts=1655448828713)

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- `qs.stringify` 제거
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->