### PR TITLE
`KOREAN_REGEX`에서 "|"를 제거

### DIFF
--- a/packages/constants/src/regex.ts
+++ b/packages/constants/src/regex.ts
@@ -31,7 +31,7 @@ export const ZIP_CODE_REGEX = /^[0-9]{5}$/
 export const ADDRESS_REGEX = /^([a-zA-Z]|[0-9]|[ ]){1,35}$/
 
 export const SLASH_HYPHEN_REGEX = /(\/|-)/g
-export const KOREAN_REGEX = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]+/g
+export const KOREAN_REGEX = /[ㄱ-ㅎㅏ-ㅣ가-힣]+/g
 export const PASSPORT_NUMBER_REGEX = /[^A-Z0-9]+/g
 export const ALPHABET_REGEX = /([^a-zA-Z])+/g
 export const PASSPORT_NAME_REGEX = new RegExp(


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
`KOREAN_REGEX` 정규식에서 "|" 문자를 제거합니다. 그동안 한글과 | 문자를 포함한 정규식이었습니다.

## 예상되는 영향

triple-frontend 안에서는 사용하는 곳이 없었습니다.
triple-air-web에서 영문 필드에 한글을 제거하는데 쓰고 있었습니다.
[hotel-master에 같은 정규식](https://github.com/titicacadev/hotel-master/blob/9b23ef8601a5b69d70513dbdaceac248f6de75a0/src/main/kotlin/com/triple/hotel/master/Constants.kt#L7)이 있는데 괜찮은 걸까요?