### PR TITLE
[map] `Mapview` zoom이 제대로 잡히지 않는 오류를 수정합니다.

### DIFF
--- a/docs/stories/map/mock.ts
+++ b/docs/stories/map/mock.ts
@@ -16,7 +16,7 @@ export const coordinates: [number, number][] = (
     }) => coordinates as [number, number],
   )
 
-export const { center, bounds, zoom } = getGeometry(coordinates)
+export const { center, bounds } = getGeometry(coordinates)
 export const polylinePaths = [
   { lat: 16.0563348, lng: 108.2025533 },
   { lat: 16.0131183, lng: 108.2637083 },

--- a/packages/map/src/map-view.tsx
+++ b/packages/map/src/map-view.tsx
@@ -85,16 +85,18 @@ export function MapView({
   })
 
   const [map, setMap] = useState<google.maps.Map>()
-  const { center, zoom, bounds } = getGeometry(coordinates)
+  const { center, bounds } = getGeometry(coordinates)
+
+  const coordinateLength = coordinates.length
 
   const options = useMemo(() => {
     return {
       ...DEFAULT_MAP_OPTIONS,
       center,
-      zoom,
+      ...(coordinateLength === 1 && { zoom: 17 }),
       ...originOptions,
     }
-  }, [coordinates, originOptions])
+  }, [coordinates, coordinateLength, originOptions])
 
   const mapContainerStyle: CSSProperties = useMemo(
     () => ({
@@ -113,7 +115,7 @@ export function MapView({
   )
 
   useEffect(() => {
-    if (!bounds || coordinates.length === 0) {
+    if (!bounds || coordinateLength === 0) {
       return
     }
     map?.fitBounds(bounds, padding)

--- a/packages/map/src/map-view.tsx
+++ b/packages/map/src/map-view.tsx
@@ -119,7 +119,7 @@ export function MapView({
       return
     }
     map?.fitBounds(bounds, padding)
-  }, [map, literalToString(bounds), padding])
+  }, [map, literalToString(bounds), padding, coordinateLength])
 
   return loadError ? (
     <div>Map cannot be loaded right now, sorry.</div>

--- a/packages/map/src/utilities.ts
+++ b/packages/map/src/utilities.ts
@@ -18,7 +18,6 @@ export function getGeometry(coordinates: [number, number][]) {
       lat: (north + south) / 2,
       lng: (west + east) / 2,
     } as google.maps.LatLngLiteral,
-    zoom: coordinatesLength === 1 ? 17 : 13,
     bounds:
       coordinatesLength !== 1
         ? ({


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- 해당이슈 [PR](https://github.com/titicacadev/tna-partners-web/pull/477#issuecomment-1160096938)
- 기존에는 zoom이 undefined => 13으로 바뀌어 13으로 고정되어서 undefined으로 1차 수정 
=> zoom 값 자체가 undefined으로 들어가다 보니 처음 로드시 인식으로 못해서 구글맵 BG 색상이 회색으로 나오는 2차 오류 발견
=> poi가 1개인 경우 줌레벨은 17로 고정하고 2개부터는 bounds에 의존하여 보여지도록 수정

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- `getGeometry`의 `zoom`을 제거합니다
   현재 `getGeometry`의 `zoom`은 파트너센터에서만 사용하고 있고 또한 이 작업으로 인해 사용하지 않으므로 제거합니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
