### PR TITLE
feat: input, textarea에 font 초기화

### DIFF
--- a/packages/core-elements/src/global-style.ts
+++ b/packages/core-elements/src/global-style.ts
@@ -189,11 +189,12 @@ export const GlobalStyle = createGlobalStyle`
   strong {
     font-weight: bold;
   }
-
   a:any-link {
     text-decoration: none;
   }
-
+  input, textarea{
+    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  }
   @media (prefers-color-scheme: dark) {
     body {
       background-color: var(--color-white);

--- a/packages/core-elements/src/global-style.ts
+++ b/packages/core-elements/src/global-style.ts
@@ -192,8 +192,8 @@ export const GlobalStyle = createGlobalStyle`
   a:any-link {
     text-decoration: none;
   }
-  input, textarea{
-    font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+  input, textarea {
+    font-family: inherit;
   }
   @media (prefers-color-scheme: dark) {
     body {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
input, textarea의 폰트 스타일을 동일하게 처리되도록 수정
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- global-style에 input, textarea에 font-family를 추가
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->



## 스크린샷 & URL
<img width="635" alt="스크린샷 2022-06-28 오전 10 21 56" src="https://user-images.githubusercontent.com/1519159/176066624-093fdfba-6008-4ffe-92bd-774b129b3a38.png">

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
