### PR TITLE
[public-header] public-header props를 추가합니다.

### DIFF
--- a/packages/public-header/src/public-header.spec.tsx
+++ b/packages/public-header/src/public-header.spec.tsx
@@ -19,7 +19,9 @@ it('renders nothing inside triple client', () => {
     appName: 'Triple-iOS',
   })
 
-  const { container } = render(<PublicHeader />)
+  const mockFn = jest.fn()
+
+  const { container } = render(<PublicHeader onClick={mockFn} />)
 
   expect(container.childNodes.length).toBe(0)
 })
@@ -31,7 +33,9 @@ it('renders header outside triple client', () => {
     >
   ).mockReturnValue(null)
 
-  const { container } = render(<PublicHeader />)
+  const mockFn = jest.fn()
+
+  const { container } = render(<PublicHeader onClick={mockFn} />)
 
   expect(container.childNodes.length).toBe(1)
 })

--- a/packages/public-header/src/public-header.spec.tsx
+++ b/packages/public-header/src/public-header.spec.tsx
@@ -19,9 +19,7 @@ it('renders nothing inside triple client', () => {
     appName: 'Triple-iOS',
   })
 
-  const mockFn = jest.fn()
-
-  const { container } = render(<PublicHeader onClick={mockFn} />)
+  const { container } = render(<PublicHeader />)
 
   expect(container.childNodes.length).toBe(0)
 })
@@ -33,9 +31,7 @@ it('renders header outside triple client', () => {
     >
   ).mockReturnValue(null)
 
-  const mockFn = jest.fn()
-
-  const { container } = render(<PublicHeader onClick={mockFn} />)
+  const { container } = render(<PublicHeader />)
 
   expect(container.childNodes.length).toBe(1)
 })

--- a/packages/public-header/src/public-header.tsx
+++ b/packages/public-header/src/public-header.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import styled from 'styled-components'
 import { white, brightGray } from '@titicaca/color-palette'
 import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
@@ -90,15 +91,28 @@ export interface PublicHeaderProps {
    */
   deeplinkPath?: string
   disableAutoHide?: boolean
+  onClick: () => void
+  linkLabel?: string
 }
 
 export function PublicHeader({
   category,
   deeplinkPath,
   disableAutoHide,
+  onClick,
+  linkLabel,
 }: PublicHeaderProps) {
   const app = useTripleClientMetadata()
   const visible = useAutoHide(disableAutoHide)
+
+  const handleClick = useCallback(() => {
+    if (onClick) {
+      onClick()
+    } else {
+      document.location.href = '/my-bookings'
+    }
+    return false
+  }, [onClick])
 
   if (app) {
     return null
@@ -121,7 +135,9 @@ export function PublicHeader({
         </Logo>
 
         <ExtraActionsContainer>
-          <ExtraActionItem href="/my-bookings">내 예약</ExtraActionItem>
+          <ExtraActionItem href="#" onClick={handleClick}>
+            {linkLabel || '내 예약'}
+          </ExtraActionItem>
           {deeplinkPath && <PublicHeaderDeeplink deeplinkPath={deeplinkPath} />}
         </ExtraActionsContainer>
       </HeaderFrame>

--- a/packages/public-header/src/public-header.tsx
+++ b/packages/public-header/src/public-header.tsx
@@ -91,6 +91,7 @@ export interface PublicHeaderProps {
   deeplinkPath?: string
   disableAutoHide?: boolean
   onClick?: () => void
+  linkHref?: string
   linkLabel?: string
 }
 
@@ -99,7 +100,8 @@ export function PublicHeader({
   deeplinkPath,
   disableAutoHide,
   onClick,
-  linkLabel,
+  linkHref = '/my-bookings',
+  linkLabel = '내 예약',
 }: PublicHeaderProps) {
   const app = useTripleClientMetadata()
   const visible = useAutoHide(disableAutoHide)
@@ -125,18 +127,8 @@ export function PublicHeader({
         </Logo>
 
         <ExtraActionsContainer>
-          <ExtraActionItem
-            href="#"
-            onClick={() => {
-              if (onClick) {
-                onClick()
-              } else {
-                document.location.href = '/my-bookings'
-              }
-              return false
-            }}
-          >
-            {linkLabel || '내 예약'}
+          <ExtraActionItem href={linkHref} onClick={onClick}>
+            {linkLabel}
           </ExtraActionItem>
           {deeplinkPath && <PublicHeaderDeeplink deeplinkPath={deeplinkPath} />}
         </ExtraActionsContainer>

--- a/packages/public-header/src/public-header.tsx
+++ b/packages/public-header/src/public-header.tsx
@@ -1,4 +1,3 @@
-import { PropsWithChildren } from 'react'
 import styled from 'styled-components'
 import { white, brightGray } from '@titicaca/color-palette'
 import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
@@ -97,8 +96,7 @@ export function PublicHeader({
   category,
   deeplinkPath,
   disableAutoHide,
-  children,
-}: PropsWithChildren<PublicHeaderProps>) {
+}: PublicHeaderProps) {
   const app = useTripleClientMetadata()
   const visible = useAutoHide(disableAutoHide)
 
@@ -122,14 +120,10 @@ export function PublicHeader({
           )}
         </Logo>
 
-        {children || (
-          <ExtraActionsContainer>
-            <ExtraActionItem href="/my-bookings">내 예약</ExtraActionItem>
-            {deeplinkPath && (
-              <PublicHeaderDeeplink deeplinkPath={deeplinkPath} />
-            )}
-          </ExtraActionsContainer>
-        )}
+        <ExtraActionsContainer>
+          <ExtraActionItem href="/my-bookings">내 예약</ExtraActionItem>
+          {deeplinkPath && <PublicHeaderDeeplink deeplinkPath={deeplinkPath} />}
+        </ExtraActionsContainer>
       </HeaderFrame>
     </Wrapper>
   )

--- a/packages/public-header/src/public-header.tsx
+++ b/packages/public-header/src/public-header.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react'
 import styled from 'styled-components'
 import { white, brightGray } from '@titicaca/color-palette'
 import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
@@ -105,15 +104,6 @@ export function PublicHeader({
   const app = useTripleClientMetadata()
   const visible = useAutoHide(disableAutoHide)
 
-  const handleClick = useCallback(() => {
-    if (onClick) {
-      onClick()
-    } else {
-      document.location.href = '/my-bookings'
-    }
-    return false
-  }, [onClick])
-
   if (app) {
     return null
   }
@@ -135,7 +125,17 @@ export function PublicHeader({
         </Logo>
 
         <ExtraActionsContainer>
-          <ExtraActionItem href="#" onClick={handleClick}>
+          <ExtraActionItem
+            href="#"
+            onClick={() => {
+              if (onClick) {
+                onClick()
+              } else {
+                document.location.href = '/my-bookings'
+              }
+              return false
+            }}
+          >
             {linkLabel || '내 예약'}
           </ExtraActionItem>
           {deeplinkPath && <PublicHeaderDeeplink deeplinkPath={deeplinkPath} />}

--- a/packages/public-header/src/public-header.tsx
+++ b/packages/public-header/src/public-header.tsx
@@ -1,3 +1,4 @@
+import { PropsWithChildren } from 'react'
 import styled from 'styled-components'
 import { white, brightGray } from '@titicaca/color-palette'
 import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
@@ -96,7 +97,8 @@ export function PublicHeader({
   category,
   deeplinkPath,
   disableAutoHide,
-}: PublicHeaderProps) {
+  children,
+}: PropsWithChildren<PublicHeaderProps>) {
   const app = useTripleClientMetadata()
   const visible = useAutoHide(disableAutoHide)
 
@@ -120,10 +122,14 @@ export function PublicHeader({
           )}
         </Logo>
 
-        <ExtraActionsContainer>
-          <ExtraActionItem href="/my-bookings">내 예약</ExtraActionItem>
-          {deeplinkPath && <PublicHeaderDeeplink deeplinkPath={deeplinkPath} />}
-        </ExtraActionsContainer>
+        {children || (
+          <ExtraActionsContainer>
+            <ExtraActionItem href="/my-bookings">내 예약</ExtraActionItem>
+            {deeplinkPath && (
+              <PublicHeaderDeeplink deeplinkPath={deeplinkPath} />
+            )}
+          </ExtraActionsContainer>
+        )}
       </HeaderFrame>
     </Wrapper>
   )

--- a/packages/public-header/src/public-header.tsx
+++ b/packages/public-header/src/public-header.tsx
@@ -91,7 +91,7 @@ export interface PublicHeaderProps {
    */
   deeplinkPath?: string
   disableAutoHide?: boolean
-  onClick: () => void
+  onClick?: () => void
   linkLabel?: string
 }
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
public-header가 마이그레이션전에는 children을 받을수 있었는데, 마이그레이션되면서 제거가 되었군요.
[my-booking-web](https://github.com/titicacadev/my-bookings-web/blob/main/src/components/index.tsx#L125-L145)에서는 children으로 처리하고 있는 상황이라서, children을 추가하도록 합니다.
변경된 [PR](https://github.com/titicacadev/triple-frontend/pull/1586/files#diff-5941651ebbc5266a34b0dabef0236c210cf1b68260a75c9b534e2ae3189e9954)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
