### PR TITLE
i18next triple-web-assets backend를 추가합니다.

### DIFF
--- a/packages/i18n/src/backend.ts
+++ b/packages/i18n/src/backend.ts
@@ -48,7 +48,7 @@ async function fetchLocaleAsset({
     ? DEV_TRIPLE_WEB_ASSETS_URL
     : PRODUCTION_TRIPLE_WEB_ASSETS_URL
   const assetUrl = `${urlBase}/locales/${language}/${namespace}.json`
-  const response = await get(assetUrl)
+  const response = await get<Record<string, string>>(assetUrl)
 
   if (response.ok === true) {
     const { parsedBody } = response

--- a/packages/i18n/src/backend.ts
+++ b/packages/i18n/src/backend.ts
@@ -1,3 +1,5 @@
+/* eslint-disable promise/no-callback-in-promise */
+/* eslint-disable promise/prefer-await-to-then */
 /* eslint-disable promise/prefer-await-to-callbacks */
 
 import { get } from '@titicaca/fetcher'
@@ -12,23 +14,28 @@ export default class I18nextTripleWebAssetsBackend {
     namespace: string,
     callback: (error: Error | null, data: unknown) => void,
   ) {
-    return this.loadUrl(
-      `https://assets.triple.guide/locales/${language}/${namespace}.json`,
-      callback,
-    )
+    fetchLocaleAsset({ language, namespace })
+      .then((asset) => callback(null, asset))
+      .catch((error) => {
+        callback(error, null)
+      })
+  }
+}
+
+async function fetchLocaleAsset({
+  language,
+  namespace,
+}: {
+  language: string
+  namespace: string
+}) {
+  const assetUrl = `https://assets.triple.guide/locales/${language}/${namespace}.json`
+  const response = await get(assetUrl)
+
+  if (response.ok === true) {
+    const { parsedBody } = response
+    return parsedBody
   }
 
-  public async loadUrl(
-    url: string,
-    callback: (error: Error | null, data: unknown) => void,
-  ) {
-    const response = await get(url)
-
-    if (response.ok === true) {
-      const { parsedBody } = response
-      callback(null, parsedBody)
-    } else {
-      callback(new Error(`Failed to fetch ${url}`), false)
-    }
-  }
+  throw new Error(`Fail to fetch ${assetUrl}`)
 }

--- a/packages/i18n/src/backend.ts
+++ b/packages/i18n/src/backend.ts
@@ -2,7 +2,7 @@
 
 import { get } from '@titicaca/fetcher'
 
-export default class I18nextFetchBackend {
+export default class I18nextTripleWebAssetsBackend {
   public type: 'backend' = 'backend'
 
   public static type: 'backend' = 'backend'

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,2 +1,3 @@
 export { default as useI18n } from './use-i18n'
 export { default as withI18n } from './with-i18n'
+export { default as I18nextTripleWebAssetsBackend } from './backend'


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
`@titicaca/i18n`에서 사용하던 backend 모듈을 외부에서 사용할 수 있도록 내보냅니다.
이름은 `I18nextTripleWebAssetsBackend`로 설정합니다.
`dev` 옵션을 통해 개발 환경 web assets에 접근할 수 있는 기능을 추가합니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- `I18nextTripleWebAssetsBackend` 클래스 내보내기
- `dev` 옵션 추가