### PR TITLE
`triple-document`의 `dependencies`를 수정합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41648,7 +41648,7 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^9.3.0",
-        "@titicaca/content-type-definitions": "4.21.0",
+        "@titicaca/content-type-definitions": "^4.21.0",
         "@titicaca/core-elements": "^9.3.0",
         "@titicaca/fetcher": "^9.3.0",
         "@titicaca/intersection-observer": "^9.3.0",
@@ -53063,7 +53063,7 @@
       "version": "file:packages/triple-document",
       "requires": {
         "@titicaca/color-palette": "^9.3.0",
-        "@titicaca/content-type-definitions": "4.21.0",
+        "@titicaca/content-type-definitions": "^4.21.0",
         "@titicaca/core-elements": "^9.3.0",
         "@titicaca/fetcher": "^9.3.0",
         "@titicaca/intersection-observer": "^9.3.0",

--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@titicaca/color-palette": "^9.3.0",
-    "@titicaca/content-type-definitions": "4.21.0",
+    "@titicaca/content-type-definitions": "^4.21.0",
     "@titicaca/core-elements": "^9.3.0",
     "@titicaca/fetcher": "^9.3.0",
     "@titicaca/intersection-observer": "^9.3.0",


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- renovate PR의 CI 과정에서 발생하는 dependency 오류를 해결하고자 합니다.
- `triple-document`의 dependency 중 `@titicaca/content-type-definitions`에 캐럿을 추가합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
