### PR TITLE
TransitionModal props에 action click optional props를 추가합니다.

### DIFF
--- a/packages/modals/src/transition-modal.tsx
+++ b/packages/modals/src/transition-modal.tsx
@@ -69,7 +69,13 @@ const MODAL_CONTENT: {
   },
 }
 
-export function TransitionModal({ deepLink }: { deepLink: string }) {
+export function TransitionModal({
+  deepLink,
+  onClick,
+}: {
+  deepLink: string
+  onClick?: () => void
+}) {
   const uriHash = useUriHash()
   const { back } = useHistoryFunctions()
   const { trackEvent } = useEventTrackingContext()
@@ -105,6 +111,10 @@ export function TransitionModal({ deepLink }: { deepLink: string }) {
           positive={{
             text: '트리플 가기',
             onClick: () => {
+              if (onClick) {
+                onClick()
+              }
+
               trackEvent({
                 ga: [
                   '설치유도팝업',

--- a/packages/modals/src/transition-modal.tsx
+++ b/packages/modals/src/transition-modal.tsx
@@ -71,10 +71,10 @@ const MODAL_CONTENT: {
 
 export function TransitionModal({
   deepLink,
-  onClick,
+  onActionClick,
 }: {
   deepLink: string
-  onClick?: () => void
+  onActionClick?: () => void
 }) {
   const uriHash = useUriHash()
   const { back } = useHistoryFunctions()
@@ -111,9 +111,7 @@ export function TransitionModal({
           positive={{
             text: '트리플 가기',
             onClick: () => {
-              if (onClick) {
-                onClick()
-              }
+              onActionClick?.()
 
               trackEvent({
                 ga: [


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

TransitionModal props에 action click optional props를 추가합니다.
- 데이블 이벤트가 트리플 앱 설치 유도 모달의 `트리플 가기`를 클릭했을 때 수집되도록 하기 위함


<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

TransitionModal props에 onClick props를 추가합니다.

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
