### PR TITLE
[core-elements] 스타일 관련 prop을 css prop으로 대체 작업 

### DIFF
--- a/docs/stories/core-elements/flex-box.stories.tsx
+++ b/docs/stories/core-elements/flex-box.stories.tsx
@@ -43,9 +43,27 @@ export const FlexGrow = () => {
         flexGrow 는 컨테이너 요소 내부에서 할당 가능한 공간의 정도를 선언합니다.
       </Summary>
       <FlexBox flex>
-        <Item flexGrow={1}>Item1</Item>
-        <Item flexGrow={1}>Item2</Item>
-        <Item flexGrow={1}>Item3</Item>
+        <Item
+          css={{
+            flexGrow: 1,
+          }}
+        >
+          Item1
+        </Item>
+        <Item
+          css={{
+            flexGrow: 1,
+          }}
+        >
+          Item2
+        </Item>
+        <Item
+          css={{
+            flexGrow: 1,
+          }}
+        >
+          Item3
+        </Item>
       </FlexBox>
     </Section>
   )
@@ -56,9 +74,27 @@ export const Order = () => {
     <Section>
       <Summary>order를 이용하여 컴포넌트 순서를 조절 할 수 있습니다.</Summary>
       <FlexBox flex>
-        <Item order={3}>Item1</Item>
-        <Item order={2}>Item2</Item>
-        <Item order={1}>Item3</Item>
+        <Item
+          css={{
+            order: 3,
+          }}
+        >
+          Item1
+        </Item>
+        <Item
+          css={{
+            order: 2,
+          }}
+        >
+          Item2
+        </Item>
+        <Item
+          css={{
+            order: 1,
+          }}
+        >
+          Item3
+        </Item>
       </FlexBox>
     </Section>
   )
@@ -71,8 +107,18 @@ export const FlexShrink = () => {
         컨테이너에 속한 아이템 크기가 컨테이너 보다 클 때 flexShrink 를 이용하면
         값에 따라 컨테이너에 맞게 축소됩니다.
       </Summary>
-      <FlexBox flex width={300}>
-        <Item flexBasis="500px" flexShrink={1}>
+      <FlexBox
+        flex
+        css={{
+          width: 300,
+        }}
+      >
+        <Item
+          css={{
+            flexBasis: '500px',
+            flexShrink: 1,
+          }}
+        >
           Item1
         </Item>
         <Item>Item2</Item>
@@ -88,7 +134,12 @@ export const FlexDirection = () => {
       <Summary>
         아이템을 배치할 때 사용할 주축 및 방향(정방향, 역방향)을 지정합니다.
       </Summary>
-      <FlexBox flex flexDirection="row">
+      <FlexBox
+        flex
+        css={{
+          flexDirection: 'row',
+        }}
+      >
         <Item>Item1</Item>
         <Item>Item2</Item>
         <Item>Item3</Item>
@@ -105,10 +156,34 @@ export const FlexWrap = () => {
         영역 내에서 벗어나지 않고 여러행으로 나누어 표현 할 것인지 결정하는
         속성입니다.
       </Summary>
-      <FlexBox flex width={200} flexWrap="wrap">
-        <Item width={100}>Item1</Item>
-        <Item width={100}>Item2</Item>
-        <Item width={100}>Item3</Item>
+      <FlexBox
+        flex
+        css={{
+          width: 200,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Item
+          css={{
+            width: 100,
+          }}
+        >
+          Item1
+        </Item>
+        <Item
+          css={{
+            width: 100,
+          }}
+        >
+          Item2
+        </Item>
+        <Item
+          css={{
+            width: 100,
+          }}
+        >
+          Item3
+        </Item>
       </FlexBox>
     </Section>
   )
@@ -118,7 +193,13 @@ export const JustifyContent = () => {
   return (
     <Section>
       <Summary>JustifyContent 는 주축 정렬을 제어합니다.</Summary>
-      <FlexBox flex flexDirection="row" justifyContent="space-between">
+      <FlexBox
+        flex
+        css={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+        }}
+      >
         <Item>Item1</Item>
         <Item>Item2</Item>
         <Item>Item3</Item>
@@ -131,7 +212,13 @@ export const AlignItems = () => {
   return (
     <Section>
       <Summary>align-items 는 교차축 정렬을 제어합니다.</Summary>
-      <FlexBox flex flexDirection="column" alignItems="center">
+      <FlexBox
+        flex
+        css={{
+          flexDirection: 'column',
+          alignItems: 'center',
+        }}
+      >
         <Item>Item1</Item>
         <Item>Item2</Item>
         <Item>Item3</Item>
@@ -144,7 +231,12 @@ export const Gap = () => {
   return (
     <Section>
       <Summary>Gap은 행과 열 사이의 간격(거터)을 설정합니다.</Summary>
-      <FlexBox flex gap="10px">
+      <FlexBox
+        flex
+        css={{
+          gap: '10px',
+        }}
+      >
         <Item>Item1</Item>
         <Item>Item2</Item>
         <Item>Item3</Item>

--- a/docs/stories/core-elements/skeleton.stories.tsx
+++ b/docs/stories/core-elements/skeleton.stories.tsx
@@ -12,17 +12,38 @@ export default {
 
 export function BaseSkeleton() {
   return (
-    <Container width="400px" margin={{ top: 20, left: 20 }}>
+    <Container
+      margin={{ top: 20, left: 20 }}
+      css={{
+        width: '400px',
+      }}
+    >
       <Container margin={{ bottom: 50 }}>
-        <Skeleton height="150px" margin={{ bottom: 15 }} borderRadius={4} />
+        <Skeleton
+          margin={{ bottom: 15 }}
+          borderRadius={4}
+          css={{
+            height: '150px',
+          }}
+        />
         <SkeletonText margin={{ bottom: 10 }} />
-        <SkeletonText width="80%" margin={{ bottom: 10 }} />
+        <SkeletonText
+          margin={{ bottom: 10 }}
+          css={{
+            width: '80%',
+          }}
+        />
         <SkeletonButton />
       </Container>
       <Container>
         <SkeletonCircle margin={{ bottom: 15 }} />
         <SkeletonText margin={{ bottom: 10 }} />
-        <SkeletonText width="80%" margin={{ bottom: 10 }} />
+        <SkeletonText
+          margin={{ bottom: 10 }}
+          css={{
+            width: '80%',
+          }}
+        />
       </Container>
     </Container>
   )

--- a/docs/stories/map/map.stories.tsx
+++ b/docs/stories/map/map.stories.tsx
@@ -31,7 +31,12 @@ export default {
 
 export const Basic: ComponentStory<typeof MapView> = (args) => {
   return (
-    <Container width="100vw" height="100vh">
+    <Container
+      css={{
+        width: '100vw',
+        height: '100vh',
+      }}
+    >
       <MapView {...args} />
     </Container>
   )
@@ -52,7 +57,12 @@ Basic.parameters = {
 
 export const WithProps: ComponentStory<typeof MapView> = (args) => {
   return (
-    <Container width="50%" height={200}>
+    <Container
+      css={{
+        width: '50%',
+        height: 200,
+      }}
+    >
       <MapView {...args} />
     </Container>
   )
@@ -79,7 +89,12 @@ WithProps.parameters = {
 
 export const WithPolyline: ComponentStory<typeof MapView> = (args) => {
   return (
-    <Container width="100vw" height={200}>
+    <Container
+      css={{
+        width: '100vw',
+        height: 200,
+      }}
+    >
       <MapView {...args}>
         <Polyline path={polylinePaths} strokeColor="#000000" />
       </MapView>
@@ -101,7 +116,12 @@ WithPolyline.parameters = {
 
 export const WithMarker: ComponentStory<typeof MapView> = (args) => {
   return (
-    <Container width="100vw" height={200}>
+    <Container
+      css={{
+        width: '100vw',
+        height: 200,
+      }}
+    >
       <MapView {...args}>
         {polylinePaths.map((path, i) => (
           <HotelCircleMarker
@@ -136,7 +156,12 @@ WithMarker.parameters = {
 
 export const WithCircleMarker: ComponentStory<typeof MapView> = (args) => {
   return (
-    <Container width="50%" height={300}>
+    <Container
+      css={{
+        width: '50%',
+        height: 300,
+      }}
+    >
       <MapView {...args}>
         <Polygon paths={polygonPaths} strokeColor="#000000" />
       </MapView>
@@ -159,7 +184,11 @@ WithCircleMarker.parameters = {
 
 export const WithWithPolyline: ComponentStory<typeof MapView> = (args) => {
   return (
-    <Container height={300}>
+    <Container
+      css={{
+        height: 300,
+      }}
+    >
       <MapView {...args}>
         <DotPolyline path={polygonLinePath} strokeColor="#000000" />
         <Polygon paths={polygonPaths} fillColor="#000000" fillOpacity={0.2} />
@@ -182,7 +211,11 @@ WithWithPolyline.parameters = {
 
 export const WithPolylineAndMarker: ComponentStory<typeof MapView> = (args) => {
   return (
-    <Container height={300}>
+    <Container
+      css={{
+        height: 300,
+      }}
+    >
       <MapView {...args}>
         {polygonPaths.map((path, i) => (
           <HotelCircleMarker

--- a/packages/action-sheet/src/components/action-sheet.tsx
+++ b/packages/action-sheet/src/components/action-sheet.tsx
@@ -215,7 +215,12 @@ export default function ActionSheet({
 
   const actionSheetTitle = title ? (
     typeof title === 'string' ? (
-      <Container height="16px" margin={{ bottom: 10, left: 27 }}>
+      <Container
+        margin={{ bottom: 10, left: 27 }}
+        css={{
+          height: '16px',
+        }}
+      >
         <Text size="tiny" bold color="gray700">
           {title}
         </Text>
@@ -282,10 +287,12 @@ export default function ActionSheet({
             {actionSheetTitle}
 
             <ContentContainer
-              maxHeight={maxContentHeight}
               padding={{
                 left: paddingValue.left,
                 right: paddingValue.right,
+              }}
+              css={{
+                maxHeight: maxContentHeight,
               }}
             >
               {children}

--- a/packages/ad-banners/src/horizontal-list-view.tsx
+++ b/packages/ad-banners/src/horizontal-list-view.tsx
@@ -86,9 +86,11 @@ const HorizontalListView: FC<HorizontalListViewProps> = ({
     >
       <div>
         <ListSection
-          minWidth={0}
           padding={{ top: padding.top, bottom: padding.bottom }}
           margin={margin}
+          css={{
+            minWidth: 0,
+          }}
         >
           <Flicking
             {...FLICKING_CONFIG}

--- a/packages/ad-banners/src/vertical-list-view.tsx
+++ b/packages/ad-banners/src/vertical-list-view.tsx
@@ -40,7 +40,13 @@ const VerticalListView: FC<VerticalListViewProps> = ({
   }
 
   return (
-    <ListSection minWidth={0} padding={padding} margin={margin}>
+    <ListSection
+      padding={padding}
+      margin={margin}
+      css={{
+        minWidth: 0,
+      }}
+    >
       {banners.map((banner, index) => (
         <VerticalEntity
           key={banner.id}

--- a/packages/app-installation-cta/src/floating-button-cta.tsx
+++ b/packages/app-installation-cta/src/floating-button-cta.tsx
@@ -153,7 +153,11 @@ export default function FloatingButtonCta({
         zIndex={zIndex}
       >
         <FloatingButton>
-          <Container width="100%">
+          <Container
+            css={{
+              width: '100%',
+            }}
+          >
             <InstallAnchor href={appInstallLink} onClick={handleClick}>
               <Text size={18} lineHeight="21px" bold color="white">
                 <Text floated="left" color="white">
@@ -171,7 +175,12 @@ export default function FloatingButtonCta({
               </Text>
             </InstallAnchor>
           </Container>
-          <Container width={46} onClick={handleDismiss}>
+          <Container
+            onClick={handleDismiss}
+            css={{
+              width: 46,
+            }}
+          >
             <CloseButton src="https://assets.triple.guide/images/btn-closebanner@3x.png" />
           </Container>
         </FloatingButton>

--- a/packages/carousel/src/carousel.tsx
+++ b/packages/carousel/src/carousel.tsx
@@ -118,7 +118,13 @@ function Carousel({
   }, [carouselRef])
 
   return !isMobile && scrollable ? (
-    <Container position="relative" margin={margin} padding={containerPadding}>
+    <Container
+      margin={margin}
+      padding={containerPadding}
+      css={{
+        position: 'relative',
+      }}
+    >
       <FlickingScrollButton
         containerPadding={containerPadding}
         direction="left"

--- a/packages/content-sharing/src/index.tsx
+++ b/packages/content-sharing/src/index.tsx
@@ -21,7 +21,12 @@ export default function ContentSharing({
   label: string
 }) {
   return (
-    <Container textAlign="center" margin={{ top: 50, bottom: 50 }}>
+    <Container
+      margin={{ top: 50, bottom: 50 }}
+      css={{
+        textAlign: 'center',
+      }}
+    >
       <ShareIcon
         src="https://assets.triple.guide/images/btn-end-invite-kakao@3x.png"
         onClick={() => onShareClick({ method: Method.Kakao })}

--- a/packages/core-elements/src/elements/container.test.tsx
+++ b/packages/core-elements/src/elements/container.test.tsx
@@ -14,14 +14,16 @@ it('should accept style shortcut props', () => {
   const tree = renderer
     .create(
       <Container
-        position="absolute"
-        textAlign="center"
-        whiteSpace="pre"
-        userSelect="none"
-        display="inline-block"
-        cursor="pointer"
         floated="none"
         backgroundColor="white"
+        css={{
+          position: 'absolute',
+          textAlign: 'center',
+          whiteSpace: 'pre',
+          userSelect: 'none',
+          display: 'inline-block',
+          cursor: 'pointer',
+        }}
       />,
     )
     .toJSON()
@@ -54,12 +56,14 @@ it('should accept sizing props', () => {
   const tree = renderer
     .create(
       <Container
-        width={10}
-        height={20}
-        minWidth={30}
-        minHeight={40}
-        maxWidth={50}
-        maxHeight={60}
+        css={{
+          width: 10,
+          height: 20,
+          minWidth: 30,
+          minHeight: 40,
+          maxWidth: 50,
+          maxHeight: 60,
+        }}
       />,
     )
     .toJSON()
@@ -109,7 +113,13 @@ it('should accept shadow mixin', () => {
 
 it('should override style with css prop', () => {
   const tree = renderer
-    .create(<Container position="absolute" css={{ position: 'fixed' }} />)
+    .create(
+      <Container
+        css={{
+          position: 'fixed',
+        }}
+      />,
+    )
     .toJSON()
 
   expect(tree).toHaveStyleRule('position', 'fixed')

--- a/packages/core-elements/src/elements/container.tsx
+++ b/packages/core-elements/src/elements/container.tsx
@@ -17,19 +17,6 @@ import {
 } from '../mixins'
 
 export type ContainerProps = PropsWithChildren<{
-  position?: Property.Position
-  textAlign?: Property.TextAlign
-  whiteSpace?: Property.WhiteSpace
-  userSelect?: Property.UserSelect
-  display?: Property.Display
-  cursor?: Property.Cursor
-  width?: number | string
-  height?: number | string
-  minWidth?: number | string
-  maxWidth?: number | string
-  minHeight?: number | string
-  maxHeight?: number | string
-
   margin?: MarginPadding
   padding?: MarginPadding
   positioning?: MarginPadding
@@ -47,19 +34,7 @@ export type ContainerProps = PropsWithChildren<{
 const Container = styled.div<ContainerProps>(
   (props) => ({
     boxSizing: 'border-box',
-    position: props.position,
-    textAlign: props.textAlign,
-    whiteSpace: props.whiteSpace,
-    userSelect: props.userSelect,
-    display: props.display,
-    cursor: props.cursor,
     float: props.floated ?? 'none',
-    width: props.width,
-    height: props.height,
-    minWidth: props.minWidth,
-    maxWidth: props.maxWidth,
-    minHeight: props.minHeight,
-    maxHeight: props.maxHeight,
     backgroundColor: props.backgroundColor
       ? `rgba(${getColor(props.backgroundColor)})`
       : undefined,

--- a/packages/core-elements/src/elements/drawer.tsx
+++ b/packages/core-elements/src/elements/drawer.tsx
@@ -100,7 +100,12 @@ export default function Drawer({
         zTier={zTier}
         zIndex={zIndex}
       >
-        <Container maxWidth={768} centered>
+        <Container
+          centered
+          css={{
+            maxWidth: 768,
+          }}
+        >
           {children}
         </Container>
       </DrawerContainer>

--- a/packages/core-elements/src/elements/flex-box.test.tsx
+++ b/packages/core-elements/src/elements/flex-box.test.tsx
@@ -9,17 +9,19 @@ it('should accept style shortcut props', () => {
     .create(
       <FlexBox
         flex
-        flexGrow={1}
-        flexShrink={1}
-        flexBasis="auto"
-        flexDirection="column"
-        flexWrap="wrap"
-        justifyContent="center"
-        alignItems="center"
-        alignContent="center"
-        alignSelf="center"
-        order={1}
-        gap="10px"
+        css={{
+          flexGrow: 1,
+          flexShrink: 1,
+          flexBasis: 'auto',
+          flexDirection: 'column',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+          alignItems: 'center',
+          alignContent: 'center',
+          alignSelf: 'center',
+          order: 1,
+          gap: '10px',
+        }}
       />,
     )
     .toJSON()
@@ -40,9 +42,7 @@ it('should accept style shortcut props', () => {
 
 it('should override style with css prop', () => {
   const tree = renderer
-    .create(
-      <FlexBox justifyContent="center" css={{ justifyContent: 'flex-end' }} />,
-    )
+    .create(<FlexBox css={{ justifyContent: 'flex-end' }} />)
     .toJSON()
 
   expect(tree).toHaveStyleRule('justify-content', 'flex-end')

--- a/packages/core-elements/src/elements/flex-box.tsx
+++ b/packages/core-elements/src/elements/flex-box.tsx
@@ -1,41 +1,14 @@
 import styled from 'styled-components'
-import { Property } from 'csstype'
 
 import Container, { ContainerProps } from './container'
 
 export interface FlexBoxProps extends ContainerProps {
   flex?: boolean
-  flexGrow?: Property.FlexGrow
-  flexShrink?: Property.FlexShrink
-  flexBasis?: Property.FlexBasis
-  flexDirection?: Property.FlexDirection
-  flexWrap?: Property.FlexWrap
-  justifyContent?: Property.JustifyContent
-  alignItems?: Property.AlignItems
-  alignContent?: Property.AlignContent
-  alignSelf?: Property.AlignSelf
-  order?: Property.Order
-  gap?: Property.Gap
-  columnGap?: Property.ColumnGap
-  rowGap?: Property.RowGap
 }
 
 const FlexBox = styled(Container)<FlexBoxProps>(
   (props) => ({
     display: props.flex ? 'flex' : undefined,
-    flexGrow: props.flexGrow,
-    flexShrink: props.flexShrink,
-    flexBasis: props.flexBasis,
-    flexDirection: props.flexDirection,
-    flexWrap: props.flexWrap,
-    justifyContent: props.justifyContent,
-    alignItems: props.alignItems,
-    alignContent: props.alignContent,
-    alignSelf: props.alignSelf,
-    order: props.order,
-    gap: props.gap,
-    columnGap: props.columnGap,
-    rowGap: props.rowGap,
   }),
   (props) => props.css,
 )

--- a/packages/core-elements/src/elements/section.test.tsx
+++ b/packages/core-elements/src/elements/section.test.tsx
@@ -40,11 +40,7 @@ it('should show bottom divider', () => {
 
 it('should override style with css prop', () => {
   const tree = renderer
-    .create(
-      <Section position="absolute" css={{ position: 'fixed' }}>
-        Section
-      </Section>,
-    )
+    .create(<Section css={{ position: 'fixed' }}>Section</Section>)
     .toJSON()
 
   expect(tree).toHaveStyleRule('position', 'fixed')

--- a/packages/core-elements/src/elements/section.tsx
+++ b/packages/core-elements/src/elements/section.tsx
@@ -6,8 +6,6 @@ import { HR2 } from './hr'
 export interface SectionProps extends ContainerProps {
   divider?: string
   anchor?: string
-  minWidth?: number | string
-  maxWidth?: number | string
 }
 
 function Section({
@@ -15,8 +13,6 @@ function Section({
   children,
   divider,
   anchor,
-  minWidth = 320,
-  maxWidth = 768,
   padding = { left: 30, right: 30 },
   ...props
 }: SectionProps) {
@@ -33,16 +29,12 @@ function Section({
         clearing
         padding={padding}
         {...props}
-        css={
-          {
-            minWidth,
-            maxWidth,
-            position: 'relative',
-          } &&
-          css`
-            ${_css}
-          `
-        }
+        css={css`
+          position: relative;
+          min-width: 320px;
+          max-width: 768px;
+          ${_css};
+        `}
       >
         {children}
       </Container>

--- a/packages/core-elements/src/elements/section.tsx
+++ b/packages/core-elements/src/elements/section.tsx
@@ -1,13 +1,17 @@
+import { css } from 'styled-components'
+
 import Container, { ContainerProps } from './container'
 import { HR2 } from './hr'
 
 export interface SectionProps extends ContainerProps {
   divider?: string
   anchor?: string
+  minWidth?: number | string
+  maxWidth?: number | string
 }
 
 function Section({
-  css,
+  css: _css,
   children,
   divider,
   anchor,
@@ -25,14 +29,20 @@ function Section({
       {divider === 'top' && <HR2 compact />}
       <Container
         id={anchor}
-        css={css}
         centered
         clearing
-        minWidth={minWidth}
-        maxWidth={maxWidth}
         padding={padding}
-        position="relative"
         {...props}
+        css={
+          {
+            minWidth,
+            maxWidth,
+            position: 'relative',
+          } &&
+          css`
+            ${_css}
+          `
+        }
       >
         {children}
       </Container>

--- a/packages/core-elements/src/elements/skeleton.tsx
+++ b/packages/core-elements/src/elements/skeleton.tsx
@@ -27,6 +27,8 @@ const waveAnimation = keyframes`
   }
 `
 
+type SkeletonProps = ContainerProps & { height?: number | string }
+
 export const Skeleton = styled(Container)`
   position: relative;
   overflow: hidden;
@@ -46,24 +48,48 @@ export const Skeleton = styled(Container)`
   }
 `
 
-export function SkeletonText({ height = 16, ...props }: ContainerProps) {
-  return <Skeleton height={height} {...props} />
+export function SkeletonText({ height = 16, ...props }: SkeletonProps) {
+  return (
+    <Skeleton
+      {...props}
+      css={{
+        height,
+      }}
+    />
+  )
 }
 
 export function SkeletonCircle({
   size = 50,
   ...props
 }: { size?: number } & Omit<
-  ContainerProps,
+  SkeletonProps,
   'width' | 'height' | 'borderRadius'
 >) {
-  return <Skeleton width={size} height={size} borderRadius={size} {...props} />
+  return (
+    <Skeleton
+      borderRadius={size}
+      {...props}
+      css={{
+        width: size,
+        height: size,
+      }}
+    />
+  )
 }
 
 export function SkeletonButton({
   height = 45,
   borderRadius = 4,
   ...props
-}: ContainerProps) {
-  return <Skeleton height={height} borderRadius={borderRadius} {...props} />
+}: SkeletonProps) {
+  return (
+    <Skeleton
+      borderRadius={borderRadius}
+      {...props}
+      css={{
+        height,
+      }}
+    />
+  )
 }

--- a/packages/core-elements/src/elements/stack.test.tsx
+++ b/packages/core-elements/src/elements/stack.test.tsx
@@ -5,9 +5,7 @@ import Stack from './stack'
 import 'jest-styled-components'
 
 it('should override style with css prop', () => {
-  const tree = renderer
-    .create(<Stack position="absolute" css={{ position: 'fixed' }} />)
-    .toJSON()
+  const tree = renderer.create(<Stack css={{ position: 'fixed' }} />).toJSON()
 
   expect(tree).toHaveStyleRule('position', 'fixed')
 })

--- a/packages/core-elements/src/elements/typography.tsx
+++ b/packages/core-elements/src/elements/typography.tsx
@@ -28,7 +28,13 @@ export function H1({
   ...props
 }: H1Props) {
   return (
-    <Container id={href} margin={margin} textAlign={textAlign}>
+    <Container
+      id={href}
+      margin={margin}
+      css={{
+        textAlign,
+      }}
+    >
       {headline && (
         <Text bold size="tiny" color="blue" margin={{ bottom: 3 }}>
           {headline}

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -105,16 +105,20 @@ export default function DefaultFooter({
   return (
     <FooterFrame>
       <Container
-        minWidth={280}
-        maxWidth={768}
         centered
         padding={{ top: 30, left: 30, right: 30, bottom: 40 }}
+        css={{
+          minWidth: 280,
+          maxWidth: 768,
+        }}
       >
         <Accordion>
           <AccordionHeader
             flex
-            alignItems="center"
-            justifyContent="space-between"
+            css={{
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
           >
             <Title
               active={businessExpanded}

--- a/packages/form/src/action-sheet-selector/index.tsx
+++ b/packages/form/src/action-sheet-selector/index.tsx
@@ -59,7 +59,11 @@ function ActionSheetSelector({
   const selected = options.find((option) => option.value === value)
 
   return (
-    <Container position="relative">
+    <Container
+      css={{
+        position: 'relative',
+      }}
+    >
       <Container onClick={onOpen}>
         <FieldContainer error={!!error}>
           <Text size="large" alpha={selected ? 1 : 0.5}>

--- a/packages/form/src/checkbox/index.tsx
+++ b/packages/form/src/checkbox/index.tsx
@@ -102,7 +102,13 @@ export function CheckboxItem<T>({
   const id = `${key}_${label}_${name}`
 
   return (
-    <Container margin={margin} position="relative" padding={{ right: 29 }}>
+    <Container
+      margin={margin}
+      padding={{ right: 29 }}
+      css={{
+        position: 'relative',
+      }}
+    >
       <Label htmlFor={id} disabled={disabled}>
         {label}
       </Label>

--- a/packages/form/src/with-field.tsx
+++ b/packages/form/src/with-field.tsx
@@ -57,7 +57,12 @@ export default function withField<T>(WrappedComponent: ComponentType<T>) {
           {...(props as T)}
         />
         {hasError ? (
-          <Container position="relative" padding={{ top: 6 }}>
+          <Container
+            padding={{ top: 6 }}
+            css={{
+              position: 'relative',
+            }}
+          >
             <Label absolute={!help} error>
               {error}
             </Label>
@@ -65,7 +70,12 @@ export default function withField<T>(WrappedComponent: ComponentType<T>) {
         ) : null}
 
         {!hasError && help ? (
-          <Container position="relative" padding={{ top: 6 }}>
+          <Container
+            padding={{ top: 6 }}
+            css={{
+              position: 'relative',
+            }}
+          >
             <Label alpha={0.5}>{help}</Label>
           </Container>
         ) : null}

--- a/packages/image-carousel/src/carousel.tsx
+++ b/packages/image-carousel/src/carousel.tsx
@@ -106,9 +106,11 @@ export default class Carousel extends PureComponent<
 
     return (
       <CarouselContainer
-        position="relative"
         margin={margin}
         borderRadius={borderRadius}
+        css={{
+          position: 'relative',
+        }}
       >
         <Flicking ref={flickingRef} {...this.flickingProps}>
           {children}

--- a/packages/location-properties/src/property-item.tsx
+++ b/packages/location-properties/src/property-item.tsx
@@ -44,9 +44,11 @@ export default function PropertyItem({
     <List.Item>
       <LongClickableItemContainer
         flex
-        alignItems="flex-start"
         onLongClick={app ? handleLongClick : undefined}
         onClick={onClick}
+        css={{
+          alignItems: 'flex-start',
+        }}
       >
         <Text bold size="small" css={{ flexShrink: 1, lineHeight: 1.43 }}>
           {title}

--- a/packages/nearby-pois/src/nearby-pois.tsx
+++ b/packages/nearby-pois/src/nearby-pois.tsx
@@ -143,7 +143,13 @@ export default function NearbyPois({
   )
 
   return (
-    <Section anchor="nearby-pois" minHeight={404} {...props}>
+    <Section
+      anchor="nearby-pois"
+      {...props}
+      css={{
+        minHeight: 404,
+      }}
+    >
       <H1 margin={{ bottom: 20 }}>
         {t('common:nearbyPois', '근처의 추천 장소')}
       </H1>

--- a/packages/poi-detail/src/detail-header/business-hours-note.tsx
+++ b/packages/poi-detail/src/detail-header/business-hours-note.tsx
@@ -17,7 +17,12 @@ export default function BusinessHoursNote({
 }) {
   return (
     <Container margin={{ top: 10 }}>
-      <FlexBox flex alignItems="center">
+      <FlexBox
+        flex
+        css={{
+          alignItems: 'center',
+        }}
+      >
         <IconBox>
           <TimeIcon />
         </IconBox>

--- a/packages/poi-detail/src/image-carousel/carousel-section.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel-section.tsx
@@ -30,7 +30,14 @@ export default function CarouselSection({
   height?: number
 } & Parameters<typeof Carousel>['0']) {
   return (
-    <Section minWidth={320} maxWidth={768} padding={padding} margin={margin}>
+    <Section
+      padding={padding}
+      margin={margin}
+      css={{
+        minWidth: 320,
+        maxWidth: 768,
+      }}
+    >
       <Container
         css={{
           position: 'relative',

--- a/packages/poi-detail/src/image-carousel/carousel-section.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel-section.tsx
@@ -31,7 +31,11 @@ export default function CarouselSection({
 } & Parameters<typeof Carousel>['0']) {
   return (
     <Section minWidth={320} maxWidth={768} padding={padding} margin={margin}>
-      <Container position="relative">
+      <Container
+        css={{
+          position: 'relative',
+        }}
+      >
         {images.length > 0 ? (
           <Carousel images={images} borderRadius={borderRadius} {...props} />
         ) : (

--- a/packages/poi-detail/src/image-carousel/carousel.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel.tsx
@@ -136,7 +136,11 @@ export default function Carousel({
         </FixedRatio>
       </Responsive>
       <Responsive minWidth={707}>
-        <Container minHeight={400}>
+        <Container
+          css={{
+            minHeight: 400,
+          }}
+        >
           <ImageCarousel
             images={visibleImages}
             currentPage={currentPage}

--- a/packages/poi-list-elements/src/carousel-element.tsx
+++ b/packages/poi-list-elements/src/carousel-element.tsx
@@ -91,7 +91,12 @@ export default function PoiCarouselElement<T extends PoiListElementType>({
       </Text>
 
       {actionButtonElement || (
-        <Container position="absolute" positioning={{ top: 3, right: 3 }}>
+        <Container
+          positioning={{ top: 3, right: 3 }}
+          css={{
+            position: 'absolute',
+          }}
+        >
           <OverlayScrapButton resource={poi} size={36} />
         </Container>
       )}

--- a/packages/poi-list-elements/src/compact-poi-list-element.tsx
+++ b/packages/poi-list-elements/src/compact-poi-list-element.tsx
@@ -89,7 +89,12 @@ export function CompactPoiListElement<T extends PoiListElementType>({
       {actionButtonElement ? (
         <div ref={actionButtonRef}>{actionButtonElement}</div>
       ) : (
-        <Container position="absolute" positioning={{ top: 0, right: 0 }}>
+        <Container
+          positioning={{ top: 0, right: 0 }}
+          css={{
+            position: 'absolute',
+          }}
+        >
           <OutlineScrapButton resource={poi} size={34} />
         </Container>
       )}

--- a/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
+++ b/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
@@ -113,10 +113,12 @@ export default function PoiCardElement({
       padding={{ top: 18, right: 18, bottom: 18, left: 18 }}
     >
       <PoiCardBody
-        position="relative"
-        display="block"
-        textAlign="left"
         onClick={onClick}
+        css={{
+          position: 'relative',
+          display: 'block',
+          textAlign: 'left',
+        }}
       >
         <ImageContainer clearing>
           <Image>

--- a/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
+++ b/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
@@ -148,10 +148,12 @@ export default function PoiCardElement({
         </ImageContainer>
 
         <Container
-          maxWidth={190}
           margin={{
             left: IMAGE_WIDTH + 14,
             right: DIRECTION_BUTTON_WIDTH + 13,
+          }}
+          css={{
+            maxWidth: 190,
           }}
         >
           <Text size="large" bold ellipsis>

--- a/packages/pricing/src/fixed-pricing-v2/index.tsx
+++ b/packages/pricing/src/fixed-pricing-v2/index.tsx
@@ -170,7 +170,11 @@ export default function FixedPricingV2({
                 )}
               </FloatedPricingContainer>
 
-              <PurchaseButtonContainer position="absolute">
+              <PurchaseButtonContainer
+                css={{
+                  position: 'absolute',
+                }}
+              >
                 <PurchaseButton
                   loading={loading}
                   disabled={buttonDisabled}

--- a/packages/pricing/src/fixed-pricing-v2/index.tsx
+++ b/packages/pricing/src/fixed-pricing-v2/index.tsx
@@ -56,13 +56,34 @@ function LoadingSkeleton() {
   return (
     <>
       <Container clearing>
-        <Skeleton borderRadius={2} floated="left" width="40%" height={20} />
+        <Skeleton
+          borderRadius={2}
+          floated="left"
+          css={{
+            width: '40%',
+            height: 20,
+          }}
+        />
       </Container>
       <Container clearing margin={{ top: 5 }}>
-        <Skeleton borderRadius={2} floated="left" width="60%" height={22} />
+        <Skeleton
+          borderRadius={2}
+          floated="left"
+          css={{
+            width: '60%',
+            height: 22,
+          }}
+        />
       </Container>
       <Container clearing margin={{ top: 5 }}>
-        <Skeleton borderRadius={2} floated="left" width="100%" height={15} />
+        <Skeleton
+          borderRadius={2}
+          floated="left"
+          css={{
+            width: '100%',
+            height: 15,
+          }}
+        />
       </Container>
     </>
   )
@@ -111,10 +132,12 @@ export default function FixedPricingV2({
     <Drawer active={active} overflow="visible">
       <FloatedFrame padding={padding}>
         <Container
-          position="relative"
           clearing
-          maxWidth={maxWidth}
           centered={!!maxWidth}
+          css={{
+            position: 'relative',
+            maxWidth,
+          }}
         >
           {emptyOverride || (
             <>

--- a/packages/pricing/src/fixed-pricing-v2/purchase-button-loading-indicator.tsx
+++ b/packages/pricing/src/fixed-pricing-v2/purchase-button-loading-indicator.tsx
@@ -45,7 +45,13 @@ export default function PurchaseButtonLoadingIndicator({
   speedMultiplier = 0.75,
 }: IndicatorProps) {
   return loading ? (
-    <FlexBox flex alignItems="center" justifyContent="center">
+    <FlexBox
+      flex
+      css={{
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
       {[...new Array(indicatorCount)].map((_, index) => {
         return (
           <Indicator

--- a/packages/pricing/src/fixed-pricing.tsx
+++ b/packages/pricing/src/fixed-pricing.tsx
@@ -100,10 +100,12 @@ export default function FixedPricing({
     <Drawer active={active} overflow="visible">
       <FloatedFrame padding={padding}>
         <Container
-          position="relative"
           clearing
-          maxWidth={maxWidth}
           centered={!!maxWidth}
+          css={{
+            position: 'relative',
+            maxWidth,
+          }}
         >
           {active && tooltipLabel && (
             <Tooltip

--- a/packages/pricing/src/fixed-pricing.tsx
+++ b/packages/pricing/src/fixed-pricing.tsx
@@ -130,7 +130,11 @@ export default function FixedPricing({
             {pricingDescription}
           </FloatedPricingContainer>
 
-          <PurchaseButtonContainer position="absolute">
+          <PurchaseButtonContainer
+            css={{
+              position: 'absolute',
+            }}
+          >
             <Button
               as="button"
               fluid

--- a/packages/pricing/src/index.tsx
+++ b/packages/pricing/src/index.tsx
@@ -136,7 +136,11 @@ function RichPricing({
     typeof basePrice === 'number' && basePrice > 0 && basePrice > salePrice
 
   return (
-    <Container textAlign="right">
+    <Container
+      css={{
+        textAlign: 'right',
+      }}
+    >
       <PricingContainer>
         {label ? <Label> {label} </Label> : null}
 

--- a/packages/replies/src/guide-text.tsx
+++ b/packages/replies/src/guide-text.tsx
@@ -26,9 +26,11 @@ export default function GuideText() {
         <FlexBox
           flex
           padding={{ top: 10, bottom: 10, left: 20, right: 20 }}
-          alignItems="center"
-          justifyContent="space-between"
           backgroundColor="gray50"
+          css={{
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
         >
           <Text size={12} lineHeight="19px" bold color="gray700">
             {!currentMessageId

--- a/packages/replies/src/list/not-exist-replies.tsx
+++ b/packages/replies/src/list/not-exist-replies.tsx
@@ -8,7 +8,12 @@ export default function NotExistReplies() {
         color="var(--color-gray50)"
       />
 
-      <Container padding={{ top: 40, bottom: 50 }} textAlign="center">
+      <Container
+        padding={{ top: 40, bottom: 50 }}
+        css={{
+          textAlign: 'center',
+        }}
+      >
         <Text size={14} lineHeight={1.2} color="gray300">
           아직 댓글이 없어요. <br />
           가장 먼저 댓글을 작성해보세요!

--- a/packages/replies/src/list/reply.tsx
+++ b/packages/replies/src/list/reply.tsx
@@ -231,8 +231,19 @@ export default function Reply({
       />
 
       <Container padding={{ left: 50, bottom: 3 }} margin={{ bottom: 20 }}>
-        <FlexBox flex justifyContent="space-between" alignItems="start">
-          <Container minWidth={80} maxWidth={135}>
+        <FlexBox
+          flex
+          css={{
+            justifyContent: 'space-between',
+            alignItems: 'start',
+          }}
+        >
+          <Container
+            css={{
+              minWidth: 80,
+              maxWidth: 135,
+            }}
+          >
             <Text
               size={15}
               bold
@@ -243,7 +254,13 @@ export default function Reply({
             </Text>
           </Container>
 
-          <FlexBox padding={{ top: 3, left: 5 }} flex alignItems="start">
+          <FlexBox
+            padding={{ top: 3, left: 5 }}
+            flex
+            css={{
+              alignItems: 'start',
+            }}
+          >
             <Text size={12} padding={{ right: 5 }} bold color="gray300">
               {formatTimestamp(createdAt)}
             </Text>
@@ -265,8 +282,10 @@ export default function Reply({
           <ReactionBox
             padding={{ top: 7 }}
             flex
-            alignItems="center"
-            cursor="pointer"
+            css={{
+              alignItems: 'center',
+              cursor: 'pointer',
+            }}
           >
             {likeReaction?.haveMine ? (
               <ThanksButton

--- a/packages/replies/src/register.tsx
+++ b/packages/replies/src/register.tsx
@@ -82,15 +82,19 @@ function Register(
 
   return (
     <Container
-      cursor="pointer"
       onClick={!sessionAvailable ? () => showLoginCta() : undefined}
+      css={{
+        cursor: 'pointer',
+      }}
     >
       <HR1 margin={{ top: 0 }} />
 
       <FlexBox
         flex
         padding={{ top: 20, bottom: 20, left: 20, right: 20 }}
-        justifyContent="space-between"
+        css={{
+          justifyContent: 'space-between',
+        }}
       >
         <AutoResizingTextarea
           placeholder={placeholder}

--- a/packages/resource-list-element/src/extended-resource-list-element.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.tsx
@@ -94,7 +94,12 @@ export default function ExtendedResourceListElement<R extends ResourceMeta>({
 
   return (
     <ResourceListItem onClick={onClick} {...props}>
-      <FlexBox flex justifyContent="space-between">
+      <FlexBox
+        flex
+        css={{
+          justifyContent: 'space-between',
+        }}
+      >
         <ContentContainer>
           <Text bold maxLines={2} size="large">
             {name}
@@ -152,7 +157,11 @@ export default function ExtendedResourceListElement<R extends ResourceMeta>({
           ) : null}
         </ContentContainer>
 
-        <Container position="relative">
+        <Container
+          css={{
+            position: 'relative',
+          }}
+        >
           <Container clearing>
             <Image>
               <Image.FixedDimensionsFrame size="small" width={90}>
@@ -181,7 +190,12 @@ export default function ExtendedResourceListElement<R extends ResourceMeta>({
             </Image>
 
             {!hideScrapButton && id && type ? (
-              <Container position="absolute" positioning={{ top: 3, right: 3 }}>
+              <Container
+                positioning={{ top: 3, right: 3 }}
+                css={{
+                  position: 'absolute',
+                }}
+              >
                 <OverlayScrapButton
                   resource={{ id, type, scraped }}
                   size={36}

--- a/packages/review/src/components/recent-checkbox.tsx
+++ b/packages/review/src/components/recent-checkbox.tsx
@@ -70,8 +70,21 @@ export default function RecentCheckBox({
   onRecentReviewChange,
 }: RecentCheckboxProps) {
   return (
-    <FlexBox flex alignItems="center" position="relative" cursor="pointer">
-      <FlexBox flex alignItems="center" onClick={onRecentReviewChange}>
+    <FlexBox
+      flex
+      css={{
+        alignItems: 'center',
+        position: 'relative',
+        cursor: 'pointer',
+      }}
+    >
+      <FlexBox
+        flex
+        onClick={onRecentReviewChange}
+        css={{
+          alignItems: 'center',
+        }}
+      >
         <CheckBox readOnly type="checkbox" checked={isRecentReview} />
         <Text size={14}>최근 여행</Text>
       </FlexBox>

--- a/packages/review/src/components/review-container.tsx
+++ b/packages/review/src/components/review-container.tsx
@@ -357,9 +357,11 @@ function ReviewContainer({
 
       <FlexBox
         flex
-        justifyContent="space-between"
-        alignItems="center"
         margin={{ top: 23 }}
+        css={{
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
       >
         <SortingOptions
           selected={sortingOption}

--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -345,7 +345,13 @@ function RecentReviewInfo({
   const [visitYear, visitMonth] = visitDate?.split('-') || []
 
   return (
-    <FlexBox flex alignItems="center" padding={{ top: 8 }}>
+    <FlexBox
+      flex
+      padding={{ top: 8 }}
+      css={{
+        alignItems: 'center',
+      }}
+    >
       {recentTrip && !isOldReview ? (
         <>
           <img

--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -233,27 +233,31 @@ export default function ReviewElement({
         <Meta>
           {!blindedAt ? (
             <LikeButton
-              display="inline-block"
               margin={{ top: 5 }}
               padding={{ top: 2, bottom: 2, right: 10, left: 20 }}
-              height={18}
               liked={liked}
               onClick={handleLikeButtonClick}
+              css={{
+                display: 'inline-block',
+                height: 18,
+              }}
             >
               {likesCount}
             </LikeButton>
           ) : null}
 
           <MessageCount
-            display="inline-block"
-            position="relative"
-            height={18}
             margin={{ top: 5 }}
             padding={{ top: 2, bottom: 2, left: 20, right: 0 }}
             isCommaVisible={!blindedAt}
             onClick={(e: SyntheticEvent) =>
               onMessageCountClick(e, review.id, resourceType)
             }
+            css={{
+              display: 'inline-block',
+              position: 'relative',
+              height: 18,
+            }}
           >
             {replyBoard
               ? replyBoard.rootMessagesCount + replyBoard.childMessagesCount

--- a/packages/review/src/components/review-element/user.tsx
+++ b/packages/review/src/components/review-element/user.tsx
@@ -33,7 +33,12 @@ export default function User({
   const { badges = [], level } = mileage || {}
 
   return (
-    <Container padding={{ bottom: 2 }} display="flex">
+    <Container
+      padding={{ bottom: 2 }}
+      css={{
+        display: 'flex',
+      }}
+    >
       <UserPhoto src={photo} onClick={onClick} />
       {badges.length > 0 ? <Badge src={badges[0].icon.image_url} /> : null}
       <div>

--- a/packages/review/src/components/sorting-options.tsx
+++ b/packages/review/src/components/sorting-options.tsx
@@ -28,7 +28,12 @@ export default function SortingOptions({
   selected,
 }: SortingOptionsProps) {
   return (
-    <OptionsContainer flex alignItems="center">
+    <OptionsContainer
+      flex
+      css={{
+        alignItems: 'center',
+      }}
+    >
       {SORTING_OPTIONS.map(({ key, text }) => (
         <Label key={key} radio selected={selected === key}>
           {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}

--- a/packages/search/src/index.tsx
+++ b/packages/search/src/index.tsx
@@ -156,7 +156,12 @@ export default function FullScreenSearchView({
         inputRef={inputRef}
         {...rest}
       />
-      <ContentsContainer isIos={isIos} userSelect="none">
+      <ContentsContainer
+        isIos={isIos}
+        css={{
+          userSelect: 'none',
+        }}
+      >
         <div ref={contentsDivRef}>{children}</div>
       </ContentsContainer>
     </>

--- a/packages/social-reviews/src/external-links.tsx
+++ b/packages/social-reviews/src/external-links.tsx
@@ -41,8 +41,19 @@ function ExternalLinkItem<Data>({
       minHeight={106}
       onClick={onItemClick ? (e) => onItemClick(e, externalLink) : undefined}
     >
-      <FlexBox padding={{ top: 20, bottom: 20 }} flex gap="20px">
-        <FlexBox minWidth={0} flexGrow={1}>
+      <FlexBox
+        padding={{ top: 20, bottom: 20 }}
+        flex
+        css={{
+          gap: '20px',
+        }}
+      >
+        <FlexBox
+          css={{
+            minWidth: 0,
+            flexGrow: 1,
+          }}
+        >
           <H3 maxLines={2}>{title}</H3>
           {summary && (
             <Text size="small" alpha={0.7} margin={{ top: 6 }} ellipsis>
@@ -57,7 +68,12 @@ function ExternalLinkItem<Data>({
         </FlexBox>
 
         {imageUrl && (
-          <FlexBox width={60} flexShrink={0}>
+          <FlexBox
+            css={{
+              width: 60,
+              flexShrink: 0,
+            }}
+          >
             <Image borderRadius={4}>
               <Image.FixedRatioFrame frame="big">
                 <Image.Img src={imageUrl} alt={`${title} 썸네일`} />

--- a/packages/static-map/src/index.tsx
+++ b/packages/static-map/src/index.tsx
@@ -113,7 +113,12 @@ export default function StaticMap({
     .join(', ')
 
   return (
-    <Container position="relative" onClick={onClick}>
+    <Container
+      onClick={onClick}
+      css={{
+        position: 'relative',
+      }}
+    >
       <StaticMapContainer frame={srcSet ? undefined : frame}>
         <StaticMapPicture>
           {srcSet ? (

--- a/packages/triple-document/src/elements/itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary.tsx
@@ -142,17 +142,21 @@ export default function ItineraryElement({ value }: Props) {
                 <Timeline flex>
                   <FlexBox
                     flex
-                    flexGrow={1}
-                    justifyContent="center"
-                    alignItems="center"
-                    flexDirection="column"
+                    css={{
+                      flexGrow: 1,
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      flexDirection: 'column',
+                    }}
                   >
                     <FlexBox
                       flex
-                      flexGrow={1}
-                      alignItems="center"
-                      flexDirection="column"
                       padding={{ top: 20 }}
+                      css={{
+                        flexGrow: 1,
+                        alignItems: 'center',
+                        flexDirection: 'column',
+                      }}
                     >
                       <CircleBadge>{index + 1}</CircleBadge>
                       {schedule ? (
@@ -178,9 +182,11 @@ export default function ItineraryElement({ value }: Props) {
                   </FlexBox>
                 </Timeline>
                 <CardWrapper
-                  flexGrow={1}
                   as="a"
                   onClick={generatePoiClickHandler(regionId, type, id)}
+                  css={{
+                    flexGrow: 1,
+                  }}
                 >
                   <PoiCard
                     shadow="medium"

--- a/packages/triple-document/src/elements/itinerary/itinerary-map.tsx
+++ b/packages/triple-document/src/elements/itinerary/itinerary-map.tsx
@@ -40,7 +40,13 @@ export default function ItineraryMap({ onClickMarker, items }: Props) {
   )
 
   return (
-    <Container width="100%" height={180} className="chromatic-ignore">
+    <Container
+      className="chromatic-ignore"
+      css={{
+        width: '100%',
+        height: 180,
+      }}
+    >
       {googleMapsApiKey ? (
         <MapView
           coordinates={coordinates}

--- a/packages/triple-document/src/elements/tna/product.tsx
+++ b/packages/triple-document/src/elements/tna/product.tsx
@@ -127,7 +127,12 @@ export function TnaProductWithPrice({
           </Image.FixedDimensionsFrame>
         </Image>
         {isPublic ? (
-          <Container position="absolute" positioning={{ top: 3, left: 51 }}>
+          <Container
+            positioning={{ top: 3, left: 51 }}
+            css={{
+              position: 'absolute',
+            }}
+          >
             <OverlayScrapButton
               resource={{ id, scraped, type: 'tna' }}
               size={36}

--- a/packages/triple-email-document/src/elements/links.tsx
+++ b/packages/triple-email-document/src/elements/links.tsx
@@ -105,7 +105,11 @@ export default function LinksView({
         {links.map((link, index) => (
           <tr key={index}>
             <Box>
-              <Container textAlign="center">
+              <Container
+                css={{
+                  textAlign: 'center',
+                }}
+              >
                 <Element href={link.href} ses:tags={`link:${link.id}`}>
                   {link.label}
                 </Element>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
스타일 관련 prop을 css prop으로 대체 작업을 진행했습니다
피드백을 받으면 좋을것 같아서 우선 Draft로 올려봅니다.
지라: https://titicaca.atlassian.net/wiki/spaces/dev/pages/3172237448/triple-frontend+DX+UX
깃헙 이슈: https://github.com/titicacadev/triple-frontend/issues/1582
## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- codemod canary 배포 버전으로 우선 적용하여 changes가 많습니다. 🙏🏻
- 3171d4c8829715835f0efddf1568b258fb0cc649, 7991e375230739c1247a9f31c228d87c8cf2748b 주요 변경 내역은 두 커밋으로 볼수있고, `Container, FlexBox, Section, Skeleton` 컴포넌트입니다.
- codemod 관련 내용은 아래 PR에 있으며, 변경 대상은 Container, FlexBox 및 두 컴포넌트를 styled로 래핑하여 쓰고 있는 TF내의 컴포넌트들입니다. 
  https://github.com/titicacadev/triple-frontend-codemod/pull/32

## 체크리스트

- [ ] 크로마틱으로 UI 깨지는 부분 확인해보니 prop을 바꾼 컴포넌트에 attr로 prop을 넘겨주는 곳들이 있네요 ..` 1. 이부분도 변경하는 스크립트를 짜거나 2. 기존 prop을 지우지 않거나` 해야 할 것 같습니다.. 
![Screen Shot 2022-09-22 at 4 09 28 PM](https://user-images.githubusercontent.com/30427711/191681328-2ed08505-ce29-433c-81a2-7c1a833caf27.png)
- [ ] 그 외 예상되는 문제는 TF 외부 프로젝트에서 styled(Container) 등으로 래핑해서 다른 이름(리스팅되지 않은)으로 사용하고 있는 경우 등이 있고 사소한 코드 이슈는 수기로도 체크해주어야 할 것 같습니다 
- [ ] 생각보다 기존 사용법이 다양해서 UI 변경점 없도록 체크해야겠습니다

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
Chromatic: https://www.chromatic.com/build?appId=617b7c4431c922004a42c7cc&number=1959
storybook: https://617b7c4431c922004a42c7cc-plorpvkaob.chromatic.com/?path=/story/poi-list-elements-poicardelement--hotel 