### PR TITLE
`renovate` PR에서 CI를 한 번만 동작하도록 변경합니다.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,16 @@
 name: CI
 on:
   workflow_call:
+    inputs:
+      skipShutdown:
+        required: false
+        type: boolean
+        default: false
+
   push:
     branches:
       - '**'
+      - '!renovate/**'
     tags-ignore:
       - '**'
 
@@ -42,7 +49,7 @@ jobs:
       - run: npm install
 
       - name: If working tree dirty, shutdown job
-        if: ${{ !startsWith( github.event.pull_request.base.ref, 'renovate/' )}}
+        if: ${{ !inputs.skipShutdown }}
         id: check-working-tree-clean
         run: |
           if [[ $(git diff --stat) != '' ]]; then
@@ -51,7 +58,7 @@ jobs:
           fi
 
       - name: Notify checking dependency failure
-        if: failure() && steps.check-working-tree-clean.outcome == 'failure'
+        if: ${{ !inputs.skipShutdown }} && failure() && steps.check-working-tree-clean.outcome == 'failure'
         env:
           SLACK_COLOR: fail
           SLACK_TITLE: ':pleading: Deps check FAILURE'

--- a/.github/workflows/renovate-pr-fix.yaml
+++ b/.github/workflows/renovate-pr-fix.yaml
@@ -12,6 +12,12 @@ env:
   COMMIT_USER_NAME: triple-frontend[bot]
 
 jobs:
+  CI:
+    uses: ./.github/workflows/ci.yaml
+    with:
+      skipShutdown: true
+    secrets: inherit
+
   fix-renovate-pr:
     runs-on: ubuntu-latest
 
@@ -35,7 +41,3 @@ jobs:
           git config --local user.name "${{ env.COMMIT_USER_NAME }}"
           git commit --no-verify -a -m "Resolve dependency error"
           git push
-
-  CI:
-    uses: ./.github/workflows/ci.yaml
-    secrets: inherit


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- 2번 실행되던 ci 액션을 1번으로 바꾸기 위해 renovate PR에서 실행되지 않도록 하고 renovate-pr-fix 액션에서만 실행되도록 변경합니다.
- workflow_call의 inputs을 이용하여 renovate-pr-fix에서 `If working tree dirty, shutdown job`이 실행되지 않도록 합니다.

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
