### PR TITLE
아티클 어드민에 사용되는 이미지 가로배열(default) margin props 누락 수정

### DIFF
--- a/docs/stories/__mocks__/triple-document.sample.json
+++ b/docs/stories/__mocks__/triple-document.sample.json
@@ -1,5 +1,43 @@
 [
   {
+    "type": "images",
+    "value": {
+      "images": [
+        {
+          "id": "aedabd71-174b-40e2-95e0-b47d2d9f5132",
+          "frame": "small",
+          "sizes": {
+            "full": {
+              "url": "https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/c9ae4d27-b1b6-4842-9359-f4fd040da65f.jpeg"
+            },
+            "large": {
+              "url": "https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/c9ae4d27-b1b6-4842-9359-f4fd040da65f.jpeg"
+            },
+            "smallSquare": {
+              "url": "https://media.triple.guide/triple-cms/c_fill,f_auto,h_256,w_256/c9ae4d27-b1b6-4842-9359-f4fd040da65f.jpeg"
+            }
+          },
+          "title": "",
+          "width": 3072,
+          "height": 2048,
+          "description": ""
+        }
+      ]
+    }
+  },
+  {
+    "type": "heading3",
+    "value": {
+      "text": "상단 이미지는 가로 배열 테스트 이미지입니다."
+    }
+  },
+  {
+    "type": "text",
+    "value": {
+      "text": "상단 이미지는 가로 배열 테스트 이미지입니다. 상단 이미지는 가로 배열 테스트 이미지입니다. 상단 이미지는 가로 배열 테스트 이미지입니다. 상단 이미지는 가로 배열 테스트 이미지입니다."
+    }
+  },
+  {
     "type": "embedded",
     "value": {
       "entries": [

--- a/docs/stories/__mocks__/triple-document.sample.json
+++ b/docs/stories/__mocks__/triple-document.sample.json
@@ -1,43 +1,5 @@
 [
   {
-    "type": "images",
-    "value": {
-      "images": [
-        {
-          "id": "aedabd71-174b-40e2-95e0-b47d2d9f5132",
-          "frame": "small",
-          "sizes": {
-            "full": {
-              "url": "https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/c9ae4d27-b1b6-4842-9359-f4fd040da65f.jpeg"
-            },
-            "large": {
-              "url": "https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/c9ae4d27-b1b6-4842-9359-f4fd040da65f.jpeg"
-            },
-            "smallSquare": {
-              "url": "https://media.triple.guide/triple-cms/c_fill,f_auto,h_256,w_256/c9ae4d27-b1b6-4842-9359-f4fd040da65f.jpeg"
-            }
-          },
-          "title": "",
-          "width": 3072,
-          "height": 2048,
-          "description": ""
-        }
-      ]
-    }
-  },
-  {
-    "type": "heading3",
-    "value": {
-      "text": "상단 이미지는 가로 배열 테스트 이미지입니다."
-    }
-  },
-  {
-    "type": "text",
-    "value": {
-      "text": "상단 이미지는 가로 배열 테스트 이미지입니다. 상단 이미지는 가로 배열 테스트 이미지입니다. 상단 이미지는 가로 배열 테스트 이미지입니다. 상단 이미지는 가로 배열 테스트 이미지입니다."
-    }
-  },
-  {
     "type": "embedded",
     "value": {
       "entries": [

--- a/packages/triple-document/src/elements/images.tsx
+++ b/packages/triple-document/src/elements/images.tsx
@@ -11,9 +11,9 @@ import { useLinkClickHandler } from '../prop-context/link-click-handler'
 import { useImageSource } from '../prop-context/image-source'
 import { useMediaConfig } from '../prop-context/media-config'
 
-import DocumentCarousel from './shared/document-carousel'
 import generateClickHandler from './shared/generate-click-handler'
 import {
+  DocumentCarouselContainer,
   ELEMENT_CONTAINER_MAP,
   IMAGES_CONTAINER_MAP,
 } from './shared/display-containers'
@@ -41,7 +41,7 @@ export default function Images({
 
   const ImagesContainer = display
     ? IMAGES_CONTAINER_MAP[display]
-    : DocumentCarousel
+    : DocumentCarouselContainer
 
   const ElementContainer = display
     ? ELEMENT_CONTAINER_MAP[display]

--- a/packages/triple-document/src/elements/shared/display-containers.tsx
+++ b/packages/triple-document/src/elements/shared/display-containers.tsx
@@ -30,12 +30,28 @@ const GridContainer = styled.div`
   grid-template-columns: repeat(auto-fit, minmax(0, auto));
 `
 
+export function DocumentCarouselContainer({
+  children,
+  images,
+}: PropsWithChildren<{ images: ImageMeta[] }>) {
+  return (
+    <DocumentCarousel
+      margin={{
+        top: 40,
+        bottom: images.some(({ title }) => title) ? 10 : 30,
+      }}
+    >
+      {children}
+    </DocumentCarousel>
+  )
+}
+
 export const IMAGES_CONTAINER_MAP = {
   block: BlockContainer,
   'gapless-block': Container,
   grid: GridContainer,
-  default: DocumentCarousel,
-  'default-v2': DocumentCarousel,
+  default: DocumentCarouselContainer,
+  'default-v2': DocumentCarouselContainer,
 }
 
 export const ELEMENT_CONTAINER_MAP = {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- 어드민페이지에서 가로배열에 사용되는 `DocumentCarousel`의 `margin props`가 누락되는 이슈를 해결합니다.

## 변경 내역
- `DocumentCarousel`에 `margin`값을 적용하는 새로운 `Component`를 생성했습니다.

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
