### PR TITLE
[core-element] tabs에 rounded-tab 추가

### DIFF
--- a/docs/stories/core-elements/tabs.stories.tsx
+++ b/docs/stories/core-elements/tabs.stories.tsx
@@ -51,3 +51,21 @@ export const LineWithScroll: ComponentStoryObj<typeof Tabs> = {
     value: '투어티켓',
   },
 }
+export const RoundedTabWithScroll: ComponentStoryObj<typeof Tabs> = {
+  name: '둥근 탭 스크롤',
+  args: {
+    scroll: true,
+    type: 'rounded',
+    options: [
+      { label: '김포 - 제주', value: '김포 - 제주' },
+      { label: '김포 - 여수', value: '김포 - 여수' },
+      { label: '김포 - 동탄', value: '김포 - 동탄' },
+      { label: '김포 - 부평', value: '김포 - 부평' },
+      { label: '김포 - 부산', value: '김포 - 부산' },
+      { label: '김포 - 트리플', value: '김포 - 트리플' },
+      { label: '김포 - 백현동', value: '김포 - 백현동' },
+      { label: '김포 - 김파이브', value: '김포 - 김파이브' },
+    ],
+    value: '김포 - 제주',
+  },
+}

--- a/packages/core-elements/src/elements/tabs/index.tsx
+++ b/packages/core-elements/src/elements/tabs/index.tsx
@@ -4,13 +4,15 @@ import { MarginPadding } from '../../commons'
 
 import BasicTab from './basic-tab'
 import PointingTab from './pointing-tab'
+import RoundedTab from './rounded-tab'
 import { TabProps as TabPropsBase } from './types'
 
-type TabType = 'basic' | 'pointing'
+type TabType = 'basic' | 'pointing' | 'rounded'
 
 const TAB_TYPE: { [key in TabType]: ElementType } = {
   basic: BasicTab,
   pointing: PointingTab,
+  rounded: RoundedTab,
 }
 
 type TabsProps<Value> =
@@ -18,6 +20,7 @@ type TabsProps<Value> =
   | ({ type?: 'pointing' } & TabPropsBase<Value> & {
         labelPadding?: MarginPadding
       })
+  | ({ type?: 'rounded' } & TabPropsBase<Value>)
   | ({ type?: never } & TabPropsBase<Value> & {
         labelPadding?: MarginPadding
       })

--- a/packages/core-elements/src/elements/tabs/index.tsx
+++ b/packages/core-elements/src/elements/tabs/index.tsx
@@ -20,7 +20,9 @@ type TabsProps<Value> =
   | ({ type?: 'pointing' } & TabPropsBase<Value> & {
         labelPadding?: MarginPadding
       })
-  | ({ type?: 'rounded' } & TabPropsBase<Value>)
+  | ({ type?: 'rounded' } & TabPropsBase<Value> & {
+        containerPadding?: MarginPadding
+      })
   | ({ type?: never } & TabPropsBase<Value> & {
         labelPadding?: MarginPadding
       })

--- a/packages/core-elements/src/elements/tabs/rounded-tab.tsx
+++ b/packages/core-elements/src/elements/tabs/rounded-tab.tsx
@@ -1,19 +1,21 @@
 import styled, { css } from 'styled-components'
 
 import { MarginPadding } from '../../commons'
+import { paddingMixin } from '../../mixins'
 
 import TabContainer from './tab-container'
 import TabLabel from './tab-label'
 import { TabProps } from './types'
 
-const RoundedContainer = styled(TabContainer)`
+const RoundedContainer = styled(TabContainer)<{ padding?: MarginPadding }>`
   display: flex;
-  gap: 6px;
-  padding: 14px 30px;
+  gap: 5px;
+  padding: 10px 30px;
+  ${paddingMixin}
 `
 
 const RoundedLabel = styled(TabLabel)`
-  padding: 9px 16px;
+  padding: 8px 14px;
   border: 1px solid var(--color-gray100);
   border-radius: 100px;
   background: var(--color-white);
@@ -42,11 +44,12 @@ export default function RoundedTab<Value>({
   value: currentValue,
   onChange,
   scroll,
+  containerPadding,
 }: TabProps<Value> & {
-  labelPadding?: MarginPadding
+  containerPadding?: MarginPadding
 }) {
   return (
-    <RoundedContainer scroll={scroll}>
+    <RoundedContainer scroll={scroll} padding={containerPadding}>
       {options.map(({ label, value }, idx) => (
         <RoundedLabel
           scroll={scroll}

--- a/packages/core-elements/src/elements/tabs/rounded-tab.tsx
+++ b/packages/core-elements/src/elements/tabs/rounded-tab.tsx
@@ -1,0 +1,64 @@
+import styled, { css } from 'styled-components'
+
+import { MarginPadding } from '../../commons'
+
+import TabContainer from './tab-container'
+import TabLabel from './tab-label'
+import { TabProps } from './types'
+
+const RoundedContainer = styled(TabContainer)`
+  display: flex;
+  gap: 6px;
+  padding: 14px 30px;
+`
+
+const RoundedLabel = styled(TabLabel)`
+  padding: 9px 16px;
+  border: 1px solid var(--color-gray100);
+  border-radius: 100px;
+  background: var(--color-white);
+  font-size: 13px;
+  font-weight: bold;
+  line-height: 16px;
+  color: var(--color-gray300);
+
+  ${({ active }) =>
+    active &&
+    css`
+      color: var(--color-white);
+      background: var(--color-blue);
+      border: 1px solid var(--color-blue);
+    `}
+
+  ${({ scroll }) =>
+    scroll &&
+    css`
+      display: inline-block;
+    `};
+`
+
+export default function RoundedTab<Value>({
+  options,
+  value: currentValue,
+  onChange,
+  scroll,
+}: TabProps<Value> & {
+  labelPadding?: MarginPadding
+}) {
+  return (
+    <RoundedContainer scroll={scroll}>
+      {options.map(({ label, value }, idx) => (
+        <RoundedLabel
+          scroll={scroll}
+          key={idx}
+          active={value === currentValue}
+          onClick={(e) => {
+            onChange(e, value)
+          }}
+        >
+          {label}
+        </RoundedLabel>
+      ))}
+    </RoundedContainer>
+  )
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- Tabs 패키지에 rounded 모양을 추가합니다.

## 변경 내역
- `RoundedTab` 컴포넌트 추가
- `TabType`에 `rounded` 타입 추가
- `StoryBook`에 `roundedTab` 샘플 데이터 추가

## URL
- [hotels](https://triple-staging.titicaca-corp.com/hotels/curation/product-listing-deal/855ea355-cde8-4357-a3c1-7d793446934d?checkIn=2022-11-13&checkOut=2022-11-14&numberOfAdults=2&categoryGroupFilter%5B0%5D=5f913a0edc0e8200016da34e&_triple_no_navbar=true)
- [air](https://triple-staging.titicaca-corp.com/air/curation/air-theme-highlighting-deal/a2897afd-318a-40b0-b06b-6552e7902fd3?_triple_no_navbar)
- [tna](https://triple-staging.titicaca-corp.com/tna/curation/product-listing-deal/4ae9f7b8-2af9-41ba-8c63-ec6ec86c75e4)

## Reference
- [스레드](https://titicaca.slack.com/archives/C0J3TT1H8/p1657701375633549?thread_ts=1655102310.388119&cid=C0J3TT1H8)
- [Hotels #2763](https://github.com/titicacadev/triple-hotels-web/pull/2763)
- [Air #1661](https://github.com/titicacadev/triple-air-web/pull/1661)
- [TNA #1092](https://github.com/titicacadev/tna-web-v2/pull/1092)
