### PR TITLE
Lint warning 수정

### DIFF
--- a/packages/i18n/src/i18next.ts
+++ b/packages/i18n/src/i18next.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-named-as-default
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 

--- a/packages/map/src/focus-tracker.tsx
+++ b/packages/map/src/focus-tracker.tsx
@@ -26,7 +26,7 @@ export function FocusTracker({
     }
 
     map.panTo({ lat, lng })
-  }, [focusGeolocation, map])
+  }, [activeAutoZoom, focusGeolocation, map])
 
   return null
 }

--- a/packages/map/src/map-view.tsx
+++ b/packages/map/src/map-view.tsx
@@ -12,7 +12,7 @@ import {
   useLoadScript,
 } from '@react-google-maps/api'
 
-import { getGeometry } from './utilities'
+import { getGeometry, literalToString } from './utilities'
 
 const MAX_LAT = (Math.atan(Math.sinh(Math.PI)) * 180) / Math.PI
 
@@ -119,7 +119,8 @@ export function MapView({
       return
     }
     map?.fitBounds(bounds, padding)
-  }, [map, padding, coordinateLength, bounds])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map, literalToString(bounds), padding, coordinateLength])
 
   return loadError ? (
     <div>Map cannot be loaded right now, sorry.</div>

--- a/packages/map/src/map-view.tsx
+++ b/packages/map/src/map-view.tsx
@@ -12,7 +12,7 @@ import {
   useLoadScript,
 } from '@react-google-maps/api'
 
-import { getGeometry, literalToString } from './utilities'
+import { getGeometry } from './utilities'
 
 const MAX_LAT = (Math.atan(Math.sinh(Math.PI)) * 180) / Math.PI
 
@@ -96,7 +96,7 @@ export function MapView({
       ...(coordinateLength === 1 && { zoom: 17 }),
       ...originOptions,
     }
-  }, [coordinates, coordinateLength, originOptions])
+  }, [center, coordinateLength, originOptions])
 
   const mapContainerStyle: CSSProperties = useMemo(
     () => ({
@@ -119,7 +119,7 @@ export function MapView({
       return
     }
     map?.fitBounds(bounds, padding)
-  }, [map, literalToString(bounds), padding, coordinateLength])
+  }, [map, padding, coordinateLength, bounds])
 
   return loadError ? (
     <div>Map cannot be loaded right now, sorry.</div>

--- a/packages/react-contexts/src/history-context/history-context.tsx
+++ b/packages/react-contexts/src/history-context/history-context.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
 } from 'react'
+// eslint-disable-next-line import/no-named-as-default
 import Router from 'next/router'
 import qs from 'qs'
 import {

--- a/packages/react-contexts/src/hooks.tsx
+++ b/packages/react-contexts/src/hooks.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-named-as-default
 import Router from 'next/router'
 import {
   closeWindow as _closeWindow,

--- a/packages/review/src/components/review-container.tsx
+++ b/packages/review/src/components/review-container.tsx
@@ -209,6 +209,7 @@ function ReviewContainer({
     sessionAvailable,
     subscribeReviewUpdateEvent,
     unsubscribeReviewUpdateEvent,
+    setMyReview,
   ])
 
   const handleWriteButtonClick = useAppCallback(


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

지속적으로 뜨는 린트 워닝 뜨지 않도록 수정했습니다 
close https://github.com/titicacadev/triple-frontend/issues/2203
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- import Router 부분 import router from 'next/client'로 변경해 보려고 했는데 참조하는 'react-dom/client'가 react 18부터 지원되서 disable 주석만 추가했습니다 
- i18n은 i18next로 수정하면 고쳐지긴 하는데 사용부에서 문제가 생길까봐 여기도 주석만 추가했습니다

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
