### PR TITLE
ci 에러 수정

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
@@ -199,7 +199,7 @@ jobs:
 
     steps:
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get released version
         run: echo "TAG_NAME=v$(cat ./lerna.json | jq -r '.version')" >> $GITHUB_ENV
@@ -204,7 +204,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,8 @@ jobs:
           registry-url: ${{ env.NPM_REGISTRY_URL }}
           cache: 'npm'
 
+      - run: npm ci
+
       - name: Install @titicaca/eslint-config-triple
         run: npm i -E @titicaca/eslint-config-triple
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
@@ -95,7 +95,7 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
@@ -157,7 +157,7 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@storybook/manager-webpack5": "^6.5.12",
         "@storybook/react": "^6.5.12",
         "@swc/cli": "0.1.57",
-        "@swc/core": "1.3.4",
+        "@swc/core": "1.3.9",
         "@testing-library/jest-dom": "^5.11.5",
         "@testing-library/react": "^11.1.0",
         "@testing-library/react-hooks": "^3.4.2",
@@ -17412,8 +17412,9 @@
     },
     "node_modules/@swc/cli": {
       "version": "0.1.57",
+      "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.1.57.tgz",
+      "integrity": "sha512-HxM8TqYHhAg+zp7+RdTU69bnkl4MWdt1ygyp6BDIPjTiaJVH6Dizn2ezbgDS8mnFZI1FyhKvxU/bbaUs8XhzQg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "^7.1.0",
         "fast-glob": "^3.2.5",
@@ -17439,33 +17440,37 @@
     },
     "node_modules/@swc/cli/node_modules/commander": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@swc/cli/node_modules/slash": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@swc/cli/node_modules/source-map": {
       "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.4",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.9.tgz",
+      "integrity": "sha512-PCRCO9vIoEX3FyS3z/FkWVYJzuspUq0LLaWdK3L30+KQDtH29K+LQdRc2Dzin2MU5MpY4bSHydAwl9M6cmZ9OA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "bin": {
         "swcx": "run_swcx.js"
       },
@@ -17477,31 +17482,277 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-android-arm-eabi": "1.3.4",
-        "@swc/core-android-arm64": "1.3.4",
-        "@swc/core-darwin-arm64": "1.3.4",
-        "@swc/core-darwin-x64": "1.3.4",
-        "@swc/core-freebsd-x64": "1.3.4",
-        "@swc/core-linux-arm-gnueabihf": "1.3.4",
-        "@swc/core-linux-arm64-gnu": "1.3.4",
-        "@swc/core-linux-arm64-musl": "1.3.4",
-        "@swc/core-linux-x64-gnu": "1.3.4",
-        "@swc/core-linux-x64-musl": "1.3.4",
-        "@swc/core-win32-arm64-msvc": "1.3.4",
-        "@swc/core-win32-ia32-msvc": "1.3.4",
-        "@swc/core-win32-x64-msvc": "1.3.4"
+        "@swc/core-android-arm-eabi": "1.3.9",
+        "@swc/core-android-arm64": "1.3.9",
+        "@swc/core-darwin-arm64": "1.3.9",
+        "@swc/core-darwin-x64": "1.3.9",
+        "@swc/core-freebsd-x64": "1.3.9",
+        "@swc/core-linux-arm-gnueabihf": "1.3.9",
+        "@swc/core-linux-arm64-gnu": "1.3.9",
+        "@swc/core-linux-arm64-musl": "1.3.9",
+        "@swc/core-linux-x64-gnu": "1.3.9",
+        "@swc/core-linux-x64-musl": "1.3.9",
+        "@swc/core-win32-arm64-msvc": "1.3.9",
+        "@swc/core-win32-ia32-msvc": "1.3.9",
+        "@swc/core-win32-x64-msvc": "1.3.9"
+      }
+    },
+    "node_modules/@swc/core-android-arm-eabi": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.9.tgz",
+      "integrity": "sha512-+F+sU2l49Po4tJoNtIpFwt0k1sspymvPMM+DCpnkHF1idzRiOU5NGgVzmLDjoO9AnxHa7EBJ3itN+PP2Dd06+A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.122"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-android-arm64": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.3.9.tgz",
+      "integrity": "sha512-HSWdex3yd4CRefkM2WVz0nTKjpirNZnwSlghqe4ct9QAYGMiiPesYgWPAnq/PpnYfmjQse4yvEclamGiek6zDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.130"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-android-arm64/node_modules/@swc/wasm": {
+      "version": "1.2.130",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+      "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.9.tgz",
+      "integrity": "sha512-E7WJY1LsMJtOtUYc/JXl8qlt6USnzodWmdO1eAAOSAODEdX9AjgG3fRT94o3UcmvMrto7sxBXVExj8wG7Cxeng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.4",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.9.tgz",
+      "integrity": "sha512-0+dFCAcLEBxwIO+0Nt+OT8mjPpvBMBWIuFWB1DNiUu2K73+OB0i+llzsCJFoasISHR+YJD0bGyv+8AtVuUdFAw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-freebsd-x64": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.9.tgz",
+      "integrity": "sha512-JbHIeklQPRBEZUfKAKt/IB/ayi7dJZ9tEGu/fDxNfk8Znu1Md+YOKRyN5FPMXfYrL5yFUXnlFOb2LX6wjNhhjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.130"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-freebsd-x64/node_modules/@swc/wasm": {
+      "version": "1.2.130",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+      "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.9.tgz",
+      "integrity": "sha512-Yc1G8FGXmq6yGKtu5wYCcvVWBtqU0/3FUk6zJM+7pFiivKsVHJcgWrkgLO1u6h7bgEdQIYwfM3/BbRNE5CtdnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.130"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf/node_modules/@swc/wasm": {
+      "version": "1.2.130",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+      "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.9.tgz",
+      "integrity": "sha512-PrBjmPIMhoQLCpfaZl2b1cCXnaNPddQB/ssMVqQ6eXChBJfcv14M5BjxtI2ORi4HoEDlsbX+k50sL666M3lnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.9.tgz",
+      "integrity": "sha512-jJT56vt81o2N3O2nXp+MZGM6mbgkNx6lvvRT6yISW29fLM6NHBXmkGcjaWOD9VFJDRmu/MtFxbElPxr6ikrFYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.9.tgz",
+      "integrity": "sha512-60ZreTvrJk3N7xvPzQeQJDePsXUmSUZkKD6lc0xzug4bv53NyUIQ8gH8nzVsV++D9NZeVxXp6WqqFLcgt7yEDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.9.tgz",
+      "integrity": "sha512-UBApPfUSP+w6ye6V1oT4EGh3LFCFrZaQsC1CkTuiYXXSmQMzkYE0Jzegn3R7MHWCJSneRwXRTKrkdhrNBUqWKA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.9.tgz",
+      "integrity": "sha512-4FQSalXbbnqTLVGRljRnw/bJ99Jwj1WnXz/aJM/SVL8S9Zbc82+3v+wXL/9NGwaAndu2QUkb2KPYNAHvB7PCdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.130"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc/node_modules/@swc/wasm": {
+      "version": "1.2.130",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+      "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.9.tgz",
+      "integrity": "sha512-ZkTw1Cm+b2QBf/NjkJJbocvgT0NWdfPQL0OyMkuTAinRzfrMmq/lmshjnqj3ysFVeI4uuJTNemiT6mivpLmuBw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.130"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc/node_modules/@swc/wasm": {
+      "version": "1.2.130",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+      "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.9.tgz",
+      "integrity": "sha512-moKi2prCKzYnXXlrLf5nwAN4uGSm4YpsW2xzYiZWJJDRqu74VoUWoDkG25jalHTfN/PSBQg4dkFWhhUe89JJVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -17513,6 +17764,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@swc/wasm": {
+      "version": "1.2.122",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.122.tgz",
+      "integrity": "sha512-sM1VCWQxmNhFtdxME+8UXNyPNhxNu7zdb6ikWpz0YKAQQFRGT5ThZgJrubEpah335SUToNg8pkdDF7ibVCjxbQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -56515,6 +56773,8 @@
     },
     "@swc/cli": {
       "version": "0.1.57",
+      "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.1.57.tgz",
+      "integrity": "sha512-HxM8TqYHhAg+zp7+RdTU69bnkl4MWdt1ygyp6BDIPjTiaJVH6Dizn2ezbgDS8mnFZI1FyhKvxU/bbaUs8XhzQg==",
       "dev": true,
       "requires": {
         "commander": "^7.1.0",
@@ -56525,39 +56785,196 @@
       "dependencies": {
         "commander": {
           "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
         },
         "slash": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         },
         "source-map": {
           "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
           "dev": true
         }
       }
     },
     "@swc/core": {
-      "version": "1.3.4",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.9.tgz",
+      "integrity": "sha512-PCRCO9vIoEX3FyS3z/FkWVYJzuspUq0LLaWdK3L30+KQDtH29K+LQdRc2Dzin2MU5MpY4bSHydAwl9M6cmZ9OA==",
       "dev": true,
       "requires": {
-        "@swc/core-android-arm-eabi": "1.3.4",
-        "@swc/core-android-arm64": "1.3.4",
-        "@swc/core-darwin-arm64": "1.3.4",
-        "@swc/core-darwin-x64": "1.3.4",
-        "@swc/core-freebsd-x64": "1.3.4",
-        "@swc/core-linux-arm-gnueabihf": "1.3.4",
-        "@swc/core-linux-arm64-gnu": "1.3.4",
-        "@swc/core-linux-arm64-musl": "1.3.4",
-        "@swc/core-linux-x64-gnu": "1.3.4",
-        "@swc/core-linux-x64-musl": "1.3.4",
-        "@swc/core-win32-arm64-msvc": "1.3.4",
-        "@swc/core-win32-ia32-msvc": "1.3.4",
-        "@swc/core-win32-x64-msvc": "1.3.4"
+        "@swc/core-android-arm-eabi": "1.3.9",
+        "@swc/core-android-arm64": "1.3.9",
+        "@swc/core-darwin-arm64": "1.3.9",
+        "@swc/core-darwin-x64": "1.3.9",
+        "@swc/core-freebsd-x64": "1.3.9",
+        "@swc/core-linux-arm-gnueabihf": "1.3.9",
+        "@swc/core-linux-arm64-gnu": "1.3.9",
+        "@swc/core-linux-arm64-musl": "1.3.9",
+        "@swc/core-linux-x64-gnu": "1.3.9",
+        "@swc/core-linux-x64-musl": "1.3.9",
+        "@swc/core-win32-arm64-msvc": "1.3.9",
+        "@swc/core-win32-ia32-msvc": "1.3.9",
+        "@swc/core-win32-x64-msvc": "1.3.9"
       }
     },
+    "@swc/core-android-arm-eabi": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.9.tgz",
+      "integrity": "sha512-+F+sU2l49Po4tJoNtIpFwt0k1sspymvPMM+DCpnkHF1idzRiOU5NGgVzmLDjoO9AnxHa7EBJ3itN+PP2Dd06+A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.122"
+      }
+    },
+    "@swc/core-android-arm64": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.3.9.tgz",
+      "integrity": "sha512-HSWdex3yd4CRefkM2WVz0nTKjpirNZnwSlghqe4ct9QAYGMiiPesYgWPAnq/PpnYfmjQse4yvEclamGiek6zDA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.130"
+      },
+      "dependencies": {
+        "@swc/wasm": {
+          "version": "1.2.130",
+          "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+          "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@swc/core-darwin-arm64": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.9.tgz",
+      "integrity": "sha512-E7WJY1LsMJtOtUYc/JXl8qlt6USnzodWmdO1eAAOSAODEdX9AjgG3fRT94o3UcmvMrto7sxBXVExj8wG7Cxeng==",
+      "dev": true,
+      "optional": true
+    },
     "@swc/core-darwin-x64": {
-      "version": "1.3.4",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.9.tgz",
+      "integrity": "sha512-0+dFCAcLEBxwIO+0Nt+OT8mjPpvBMBWIuFWB1DNiUu2K73+OB0i+llzsCJFoasISHR+YJD0bGyv+8AtVuUdFAw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-freebsd-x64": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.9.tgz",
+      "integrity": "sha512-JbHIeklQPRBEZUfKAKt/IB/ayi7dJZ9tEGu/fDxNfk8Znu1Md+YOKRyN5FPMXfYrL5yFUXnlFOb2LX6wjNhhjQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.130"
+      },
+      "dependencies": {
+        "@swc/wasm": {
+          "version": "1.2.130",
+          "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+          "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.9.tgz",
+      "integrity": "sha512-Yc1G8FGXmq6yGKtu5wYCcvVWBtqU0/3FUk6zJM+7pFiivKsVHJcgWrkgLO1u6h7bgEdQIYwfM3/BbRNE5CtdnA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.130"
+      },
+      "dependencies": {
+        "@swc/wasm": {
+          "version": "1.2.130",
+          "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+          "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.9.tgz",
+      "integrity": "sha512-PrBjmPIMhoQLCpfaZl2b1cCXnaNPddQB/ssMVqQ6eXChBJfcv14M5BjxtI2ORi4HoEDlsbX+k50sL666M3lnBw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.9.tgz",
+      "integrity": "sha512-jJT56vt81o2N3O2nXp+MZGM6mbgkNx6lvvRT6yISW29fLM6NHBXmkGcjaWOD9VFJDRmu/MtFxbElPxr6ikrFYQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.9.tgz",
+      "integrity": "sha512-60ZreTvrJk3N7xvPzQeQJDePsXUmSUZkKD6lc0xzug4bv53NyUIQ8gH8nzVsV++D9NZeVxXp6WqqFLcgt7yEDQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.9.tgz",
+      "integrity": "sha512-UBApPfUSP+w6ye6V1oT4EGh3LFCFrZaQsC1CkTuiYXXSmQMzkYE0Jzegn3R7MHWCJSneRwXRTKrkdhrNBUqWKA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.9.tgz",
+      "integrity": "sha512-4FQSalXbbnqTLVGRljRnw/bJ99Jwj1WnXz/aJM/SVL8S9Zbc82+3v+wXL/9NGwaAndu2QUkb2KPYNAHvB7PCdw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.130"
+      },
+      "dependencies": {
+        "@swc/wasm": {
+          "version": "1.2.130",
+          "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+          "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.9.tgz",
+      "integrity": "sha512-ZkTw1Cm+b2QBf/NjkJJbocvgT0NWdfPQL0OyMkuTAinRzfrMmq/lmshjnqj3ysFVeI4uuJTNemiT6mivpLmuBw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.130"
+      },
+      "dependencies": {
+        "@swc/wasm": {
+          "version": "1.2.130",
+          "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+          "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.9.tgz",
+      "integrity": "sha512-moKi2prCKzYnXXlrLf5nwAN4uGSm4YpsW2xzYiZWJJDRqu74VoUWoDkG25jalHTfN/PSBQg4dkFWhhUe89JJVw==",
       "dev": true,
       "optional": true
     },
@@ -56566,6 +56983,13 @@
       "requires": {
         "tslib": "^2.4.0"
       }
+    },
+    "@swc/wasm": {
+      "version": "1.2.122",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.122.tgz",
+      "integrity": "sha512-sM1VCWQxmNhFtdxME+8UXNyPNhxNu7zdb6ikWpz0YKAQQFRGT5ThZgJrubEpah335SUToNg8pkdDF7ibVCjxbQ==",
+      "dev": true,
+      "optional": true
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "styled-components": "^5.3.3",
         "ts-jest": "^27.1.2",
         "tsconfig-paths-webpack-plugin": "^4.0.0",
-        "turbo": "^1.2.1",
+        "turbo": "^1.5.6",
         "typescript": "4.3.5",
         "utility-types": "^3.10.0",
         "webpack": "^5.74.0"
@@ -41472,32 +41472,99 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.5.5",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.5.6.tgz",
+      "integrity": "sha512-xJO/fhiMo4lI62iGR9OgUfJTC9tnnuoMwNC52IfvvBDEPlA8RWGMS8SFpDVG9bNCXvVRrtUTNJXMe6pJWBiOTA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MPL-2.0",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.5.5",
-        "turbo-darwin-arm64": "1.5.5",
-        "turbo-linux-64": "1.5.5",
-        "turbo-linux-arm64": "1.5.5",
-        "turbo-windows-64": "1.5.5",
-        "turbo-windows-arm64": "1.5.5"
+        "turbo-darwin-64": "1.5.6",
+        "turbo-darwin-arm64": "1.5.6",
+        "turbo-linux-64": "1.5.6",
+        "turbo-linux-arm64": "1.5.6",
+        "turbo-windows-64": "1.5.6",
+        "turbo-windows-arm64": "1.5.6"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.5.5",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.5.6.tgz",
+      "integrity": "sha512-CWdXMwenBS2+QXIR2Czx7JPnAcoMzWx/QwTDcHVxZyeayMHgz8Oq5AHCtfaHDSfV8YhD3xa0GLSk6+cFt+W8BQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.5.6.tgz",
+      "integrity": "sha512-c/aXgW9JuXT2bJSKf01pdSDQKnrdcdj3WFKmKiVldb9We6eqFzI0fLHBK97k5LM/OesmRMfCMQ2Cv2DU8RqBAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.5.6.tgz",
+      "integrity": "sha512-y/jNF7SG+XJEwk2GxIqy3g4dj/a0PgZKDGyOkp24qp4KBRcHBl6dI1ZEfNed30EhEqmW4F5Dr7IpeCZoqgbrMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.5.6.tgz",
+      "integrity": "sha512-FRcxPtW7eFrbR3QaYBVX8cK7i+2Cerqi6F0t5ulcq+d1OGSdSW3l35rPPyJdwCzCy+k/S9sBcyCV0RtbS6RKCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.5.6.tgz",
+      "integrity": "sha512-/5KIExY7zbrbeL5fhKGuO85u5VtJ3Ue4kI0MbYCNnTGe7a10yTYkwswgtGihsgEF4AW0Nm0159aHmXZS2Le8IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.5.6.tgz",
+      "integrity": "sha512-p+LQN9O39+rZuOAyc6BzyVGvdEKo+v+XmtdeyZsZpfj4xuOLtsEptW1w6cUD439u0YcPknuccGq1MQ0lXQ6Xuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/tweetnacl": {
@@ -72911,19 +72978,58 @@
       }
     },
     "turbo": {
-      "version": "1.5.5",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.5.6.tgz",
+      "integrity": "sha512-xJO/fhiMo4lI62iGR9OgUfJTC9tnnuoMwNC52IfvvBDEPlA8RWGMS8SFpDVG9bNCXvVRrtUTNJXMe6pJWBiOTA==",
       "dev": true,
       "requires": {
-        "turbo-darwin-64": "1.5.5",
-        "turbo-darwin-arm64": "1.5.5",
-        "turbo-linux-64": "1.5.5",
-        "turbo-linux-arm64": "1.5.5",
-        "turbo-windows-64": "1.5.5",
-        "turbo-windows-arm64": "1.5.5"
+        "turbo-darwin-64": "1.5.6",
+        "turbo-darwin-arm64": "1.5.6",
+        "turbo-linux-64": "1.5.6",
+        "turbo-linux-arm64": "1.5.6",
+        "turbo-windows-64": "1.5.6",
+        "turbo-windows-arm64": "1.5.6"
       }
     },
     "turbo-darwin-64": {
-      "version": "1.5.5",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.5.6.tgz",
+      "integrity": "sha512-CWdXMwenBS2+QXIR2Czx7JPnAcoMzWx/QwTDcHVxZyeayMHgz8Oq5AHCtfaHDSfV8YhD3xa0GLSk6+cFt+W8BQ==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-darwin-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.5.6.tgz",
+      "integrity": "sha512-c/aXgW9JuXT2bJSKf01pdSDQKnrdcdj3WFKmKiVldb9We6eqFzI0fLHBK97k5LM/OesmRMfCMQ2Cv2DU8RqBAA==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.5.6.tgz",
+      "integrity": "sha512-y/jNF7SG+XJEwk2GxIqy3g4dj/a0PgZKDGyOkp24qp4KBRcHBl6dI1ZEfNed30EhEqmW4F5Dr7IpeCZoqgbrMg==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-linux-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.5.6.tgz",
+      "integrity": "sha512-FRcxPtW7eFrbR3QaYBVX8cK7i+2Cerqi6F0t5ulcq+d1OGSdSW3l35rPPyJdwCzCy+k/S9sBcyCV0RtbS6RKCQ==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-windows-64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.5.6.tgz",
+      "integrity": "sha512-/5KIExY7zbrbeL5fhKGuO85u5VtJ3Ue4kI0MbYCNnTGe7a10yTYkwswgtGihsgEF4AW0Nm0159aHmXZS2Le8IA==",
+      "dev": true,
+      "optional": true
+    },
+    "turbo-windows-arm64": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.5.6.tgz",
+      "integrity": "sha512-p+LQN9O39+rZuOAyc6BzyVGvdEKo+v+XmtdeyZsZpfj4xuOLtsEptW1w6cUD439u0YcPknuccGq1MQ0lXQ6Xuw==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@storybook/manager-webpack5": "^6.5.12",
     "@storybook/react": "^6.5.12",
     "@swc/cli": "0.1.57",
-    "@swc/core": "1.3.4",
+    "@swc/core": "1.3.9",
     "@testing-library/jest-dom": "^5.11.5",
     "@testing-library/react": "^11.1.0",
     "@testing-library/react-hooks": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "styled-components": "^5.3.3",
     "ts-jest": "^27.1.2",
     "tsconfig-paths-webpack-plugin": "^4.0.0",
-    "turbo": "^1.2.1",
+    "turbo": "^1.5.6",
     "typescript": "4.3.5",
     "utility-types": "^3.10.0",
     "webpack": "^5.74.0"


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

CI 실패하는 에러를 고칩니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

package-lock.json에 turbo와 swc의 바이너리가 darwin만 존재했어서 리눅스인 CI 환경에서 빌드가 실패하는 에러가 있었습니다. 
turbo, swc를 재설치하니 모든 os의 바이너리 패키지 의존성이 추가되었습니다. 
기존에 없었던 이유는 잘 모르겠습니다. 아마 npm 버전 문제가 아닐지...

github action checkout, setup-node 버전을 올립니다. (node 최소 버전 16 사용)

lint job에 npm ci를 추가합니다.