### PR TITLE
nothing-to-commit 에러를 무시합니다.

### DIFF
--- a/.github/workflows/renovate-pr-fix.yaml
+++ b/.github/workflows/renovate-pr-fix.yaml
@@ -36,5 +36,4 @@ jobs:
         run: |
           git config --local user.email "${{ env.COMMIT_USER_EMAIL }}"
           git config --local user.name "${{ env.COMMIT_USER_NAME }}"
-          git commit --no-verify -a -m "Resolve dependency error"
-          git push
+          git commit --no-verify -a -m "Resolve dependency error" && git push || true


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

Renovate bot이 아니고 사람이 푸시하는 경우엔, 이 GHA에서 수정하려는 Broken dependency가 없을 수 있습니다. 그 상황에서 `git commit`의 exit status는 0이 아니게 되고, 그로 인해 GHA 실행이 실패하고, PR의 Branch Protection 룰이 Check Failure 상태에 놓이게 됩니다.

위 문제 우회를 위해 `git commit`의 오류를 무시하도록 합니다.

## 변경 내역

`git commit` 및 `push` 커맨드 이후 `|| true`를 추가합니다.
