### PR TITLE
[react-contexts] 세션 고정을 방지할 수 있도록 합니다.

### DIFF
--- a/integration-test/src/router-modal.test.tsx
+++ b/integration-test/src/router-modal.test.tsx
@@ -132,6 +132,7 @@ function createSessionContextProvider({
         props: {
           initialSessionId: sessionAvailable ? 'FAKE_SESSION_ID' : undefined,
           initialUser,
+          preventSessionFixation: false,
         },
       }
     }

--- a/packages/react-contexts/src/session-context/app.tsx
+++ b/packages/react-contexts/src/session-context/app.tsx
@@ -68,20 +68,15 @@ export function InAppSessionContextProvider({
 
 InAppSessionContextProvider.getInitialProps = async function ({
   req,
-}: NextPageContext): Promise<InAppSessionContextProviderProps> {
+}: NextPageContext): Promise<
+  Omit<InAppSessionContextProviderProps, 'preventSessionFixation'>
+> {
   const initialSessionId = getSessionIdFromRequest(req)
-  const userAgent = req?.headers.userAgent
-
-  const preventSessionFixation =
-    userAgent && typeof userAgent === 'string'
-      ? !!userAgent.match(/Triple-iOS/)
-      : false
 
   if (!initialSessionId) {
     return {
       initialSessionId,
       initialUser: undefined,
-      preventSessionFixation,
     }
   }
 
@@ -105,12 +100,12 @@ InAppSessionContextProvider.getInitialProps = async function ({
   }
 
   if (response.ok === false) {
-    return { initialSessionId, initialUser: undefined, preventSessionFixation }
+    return { initialSessionId, initialUser: undefined }
   }
 
   const { parsedBody: initialUser } = response
 
-  return { initialSessionId, initialUser, preventSessionFixation }
+  return { initialSessionId, initialUser }
 }
 
 function createSessionIdSaver() {

--- a/packages/react-contexts/src/session-context/app.tsx
+++ b/packages/react-contexts/src/session-context/app.tsx
@@ -25,14 +25,18 @@ const saveSessionIdToCookie = createSessionIdSaver()
 export interface InAppSessionContextProviderProps {
   initialSessionId: string | undefined
   initialUser: User | undefined
+  preventSessionFixation: boolean | undefined
 }
 
 export function InAppSessionContextProvider({
   initialSessionId,
   initialUser,
+  preventSessionFixation,
   children,
 }: PropsWithChildren<InAppSessionContextProviderProps>) {
-  saveSessionIdToCookie(initialSessionId)
+  if (!preventSessionFixation) {
+    saveSessionIdToCookie(initialSessionId)
+  }
 
   const { appUrlScheme } = useEnv()
   const { user, clear: clearUserState } = useUserState(initialUser)

--- a/packages/react-contexts/src/session-context/app.tsx
+++ b/packages/react-contexts/src/session-context/app.tsx
@@ -70,11 +70,18 @@ InAppSessionContextProvider.getInitialProps = async function ({
   req,
 }: NextPageContext): Promise<InAppSessionContextProviderProps> {
   const initialSessionId = getSessionIdFromRequest(req)
+  const userAgent = req?.headers.userAgent
+
+  const preventSessionFixation =
+    userAgent && typeof userAgent === 'string'
+      ? !!userAgent.match(/Triple-iOS/)
+      : false
 
   if (!initialSessionId) {
     return {
       initialSessionId,
       initialUser: undefined,
+      preventSessionFixation,
     }
   }
 
@@ -98,12 +105,12 @@ InAppSessionContextProvider.getInitialProps = async function ({
   }
 
   if (response.ok === false) {
-    return { initialSessionId, initialUser: undefined }
+    return { initialSessionId, initialUser: undefined, preventSessionFixation }
   }
 
   const { parsedBody: initialUser } = response
 
-  return { initialSessionId, initialUser }
+  return { initialSessionId, initialUser, preventSessionFixation }
 }
 
 function createSessionIdSaver() {

--- a/packages/react-contexts/src/session-context/provider.tsx
+++ b/packages/react-contexts/src/session-context/provider.tsx
@@ -53,7 +53,7 @@ SessionContextProvider.getInitialProps = async function (
     req !== undefined
       ? req.headers['user-agent'] || ''
       : window.navigator.userAgent
-  const { isPublic } = generateUserAgentValues(userAgent)
+  const { app, isPublic } = generateUserAgentValues(userAgent)
 
   if (isPublic === true) {
     const props = await InBrowserSessionContextProvider.getInitialProps(context)
@@ -63,5 +63,8 @@ SessionContextProvider.getInitialProps = async function (
 
   const props = await InAppSessionContextProvider.getInitialProps(context)
 
-  return { type: 'app', props }
+  return {
+    type: 'app',
+    props: { ...props, preventSessionFixation: app?.name !== 'Triple-iOS' },
+  }
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

일부 인앱브라우저에서만 필요한 세션 고정 기능이 전체 인앱브라우저 환경에서 실행되고 있습니다. 지금까지는 큰 문제가 없었지만, 쿠키가 유실될 수 있는 상황을 발견했습니다: https://developer.android.com/about/versions/12/behavior-changes-12?hl=ko#samesite

## 변경 내역

`InAppSessionContextProvider`의 props에 `preventSessionFixation`이라는 prop을 추가합니다. 이 prop의 값이 `true`이면 쿠키 변경을 하지 않습니다.

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
