### PR TITLE
[triple-document] 디폴트 이미지 컨테이너 설정

### DIFF
--- a/packages/triple-document/src/elements/images.tsx
+++ b/packages/triple-document/src/elements/images.tsx
@@ -39,13 +39,11 @@ export default function Images({
   const ImageSource = useImageSource()
   const { videoAutoPlay, hideVideoControls, optimized } = useMediaConfig()
 
-  const ImagesContainer = display
-    ? IMAGES_CONTAINER_MAP[display]
-    : DocumentCarouselContainer
+  const ImagesContainer =
+    IMAGES_CONTAINER_MAP[display] || DocumentCarouselContainer
 
-  const ElementContainer = display
-    ? ELEMENT_CONTAINER_MAP[display]
-    : ImageCarouselElementContainer
+  const ElementContainer =
+    ELEMENT_CONTAINER_MAP[display] || ImageCarouselElementContainer
 
   const handleClick = generateClickHandler(onLinkClick, onImageClick)
   const isOnlyImage = ['gapless-block', 'grid'].includes(display)


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
센트리의 [#952 Error: Element type is invalid](https://github.com/titicacadev/triple-content-web/issues/952) 이슈를 해결합니다.
triple-doucment의 image에서 display가 존재하지 않거나 `IMAGE_CONTAINER_MAP`에 존재하지 않을 때 디폴트 컨테이너를 설정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
