### PR TITLE
/api/content/pois의 응답이 204인 경우 빈 배열을 반환하도록 합니다.

### DIFF
--- a/packages/nearby-pois/src/service.ts
+++ b/packages/nearby-pois/src/service.ts
@@ -39,6 +39,10 @@ export async function fetchPois({
     },
   })
 
+  if (response.status === 204) {
+    return []
+  }
+
   if (response.ok === true) {
     const { parsedBody: pois } = response
     return pois.map((poi) => ({


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

[TRIPLE-CONTENT-WEB-A8B](https://sentry.io/organizations/titicaca-corp/issues/3659320143/events/249a821baabc401e831b8c513fe6af37/?project=1319418&referrer=events-table%2F%3Fproject%3D1319418&statsPeriod=90d) Sentry 에러를 수정합니다.

`POST /api/content/pois` 요청에 대해 204 응답이 내려오는 경우 비어있는 body가 넘어와서 [이 부분](https://github.com/titicacadev/triple-frontend/blob/main/packages/fetcher/src/fetcher.ts#L86)을 거쳐 빈 문자열 `''`이 되고, 최종적으로 이 빈 문자열에 `map`을 돌리게 되어 Sentry에서 표시되는 `j.map is not a function` 에러가 발생하는듯 합니다..!

따라서 204 응답은 `if`문으로 미리 걸러내어 빈 배열을 리턴하도록 하였습니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
