### PR TITLE
비디오 자동재생 문제 해결

### DIFF
--- a/packages/core-elements/src/elements/video/play-pause-button.tsx
+++ b/packages/core-elements/src/elements/video/play-pause-button.tsx
@@ -49,12 +49,14 @@ export default function PlayPauseButton({
   onPlayPause,
 }: Props) {
   const handlePlayPause = useCallback(
-    (e) => {
-      if (videoRef.current && visible) {
-        playing ? videoRef.current.pause() : videoRef.current.play()
-        e.stopPropagation()
-        onPlayPause()
-      }
+    (e: SyntheticEvent) => {
+      try {
+        if (videoRef.current && visible) {
+          playing ? videoRef.current.pause() : videoRef.current.play()
+          e.stopPropagation()
+          onPlayPause()
+        }
+      } catch {}
     },
     [videoRef, playing, visible, onPlayPause],
   )

--- a/packages/image-carousel/src/video-content.tsx
+++ b/packages/image-carousel/src/video-content.tsx
@@ -88,15 +88,24 @@ function VideoContent({
     (autoplay === 'wifi_only' && networkType === 'wifi')
 
   useEffect(() => {
-    if (!videoAutoplay) {
-      return
+    async function togglePlay() {
+      if (!videoAutoplay || !ref.current) {
+        return
+      }
+
+      ref.current.playsInline = true
+      ref.current.muted = true
+
+      try {
+        if (isIntersecting) {
+          ref.current.play()
+        } else {
+          ref.current.pause()
+        }
+      } catch {}
     }
 
-    if (isIntersecting) {
-      ref.current?.play()
-    } else {
-      ref.current?.pause()
-    }
+    togglePlay()
   }, [isIntersecting, ref, videoAutoplay])
 
   const { frame: imageFrame, size: imageSize } = medium

--- a/packages/image-carousel/src/video-content.tsx
+++ b/packages/image-carousel/src/video-content.tsx
@@ -1,6 +1,6 @@
 import { Container } from '@titicaca/core-elements'
 import { FrameRatioAndSizes, GlobalSizes } from '@titicaca/type-definitions'
-import { MouseEventHandler, ReactNode, useEffect } from 'react'
+import { MouseEventHandler, ReactNode, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { useDeviceContext } from '@titicaca/react-contexts'
 import { useIntersection } from '@titicaca/intersection-observer'
@@ -35,6 +35,18 @@ const Frame = styled(Container)<{
     (height && `${height}px`) || (size ? HEIGHT_OPTIONS[size] : '')};
 `
 
+const Poster = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+`
+
 const Video = styled.video`
   position: absolute;
   top: 0;
@@ -44,6 +56,7 @@ const Video = styled.video`
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transition: opacity 0.3s;
 `
 
 const PLAY_BUTTON_IMAGE_URL =
@@ -75,6 +88,7 @@ function VideoContent({
   overlay,
   onClick,
 }: Props) {
+  const [isOncePlayed, setIsOncePlayed] = useState(false)
   const { ref, isIntersecting } = useIntersection<HTMLVideoElement>({
     threshold: 0.5,
   })
@@ -114,6 +128,7 @@ function VideoContent({
 
   return (
     <Frame size={size} height={height} frame={frame} onClick={onClick}>
+      <Poster style={{ backgroundImage: `url("${medium.sizes.large.url}")` }} />
       <Video
         ref={ref}
         src={medium.video?.large.url}
@@ -121,7 +136,8 @@ function VideoContent({
         loop
         muted
         playsInline
-        poster={medium.sizes.large.url}
+        style={{ opacity: isOncePlayed ? 1 : 0 }}
+        onTimeUpdate={isOncePlayed ? undefined : () => setIsOncePlayed(true)}
       />
       {!videoAutoplay && <PlayPauseButtonBase />}
       {overlay || null}

--- a/packages/image-carousel/src/video-content.tsx
+++ b/packages/image-carousel/src/video-content.tsx
@@ -137,7 +137,7 @@ function VideoContent({
         loop
         muted
         playsInline
-        isOncePlayed
+        isOncePlayed={isOncePlayed}
         onTimeUpdate={isOncePlayed ? undefined : () => setIsOncePlayed(true)}
       />
       {!videoAutoplay && <PlayPauseButtonBase />}

--- a/packages/image-carousel/src/video-content.tsx
+++ b/packages/image-carousel/src/video-content.tsx
@@ -47,7 +47,7 @@ const Poster = styled.div`
   background-position: center;
 `
 
-const Video = styled.video`
+const Video = styled.video<{ isOncePlayed: boolean }>`
   position: absolute;
   top: 0;
   left: 0;
@@ -57,6 +57,7 @@ const Video = styled.video`
   height: 100%;
   object-fit: cover;
   transition: opacity 0.3s;
+  opacity: ${({ isOncePlayed }) => (isOncePlayed ? 1 : 0)};
 `
 
 const PLAY_BUTTON_IMAGE_URL =
@@ -136,7 +137,7 @@ function VideoContent({
         loop
         muted
         playsInline
-        style={{ opacity: isOncePlayed ? 1 : 0 }}
+        isOncePlayed
         onTimeUpdate={isOncePlayed ? undefined : () => setIsOncePlayed(true)}
       />
       {!videoAutoplay && <PlayPauseButtonBase />}

--- a/packages/review/src/components/review-element/media/video.tsx
+++ b/packages/review/src/components/review-element/media/video.tsx
@@ -55,15 +55,24 @@ function Video({ medium }: Props) {
     (autoplay === 'wifi_only' && networkType === 'wifi')
 
   useEffect(() => {
-    if (!videoAutoplay) {
-      return
+    async function togglePlay() {
+      if (!videoAutoplay || !ref.current) {
+        return
+      }
+
+      ref.current.playsInline = true
+      ref.current.muted = true
+
+      try {
+        if (isIntersecting) {
+          ref.current.play()
+        } else {
+          ref.current.pause()
+        }
+      } catch {}
     }
 
-    if (isIntersecting) {
-      ref.current?.play()
-    } else {
-      ref.current?.pause()
-    }
+    togglePlay()
   }, [isIntersecting, ref, videoAutoplay])
 
   return (

--- a/packages/review/src/components/review-element/media/video.tsx
+++ b/packages/review/src/components/review-element/media/video.tsx
@@ -21,7 +21,7 @@ const StyledPoster = styled.div`
   background-position: center;
 `
 
-const StyledVideo = styled.video`
+const StyledVideo = styled.video<{ isOncePlayed: boolean }>`
   position: absolute;
   top: 0;
   left: 0;
@@ -31,6 +31,7 @@ const StyledVideo = styled.video`
   height: 100%;
   object-fit: cover;
   transition: opacity 0.3s;
+  opacity: ${({ isOncePlayed }) => (isOncePlayed ? 1 : 0)};
 `
 
 const PLAY_BUTTON_IMAGE_URL =
@@ -101,7 +102,7 @@ function Video({ medium }: Props) {
         loop
         muted
         playsInline
-        style={{ opacity: isOncePlayed ? 1 : 0 }}
+        isOncePlayed
         onTimeUpdate={isOncePlayed ? undefined : () => setIsOncePlayed(true)}
       />
       {!videoAutoplay && <PlayPauseButtonBase />}

--- a/packages/review/src/components/review-element/media/video.tsx
+++ b/packages/review/src/components/review-element/media/video.tsx
@@ -102,7 +102,7 @@ function Video({ medium }: Props) {
         loop
         muted
         playsInline
-        isOncePlayed
+        isOncePlayed={isOncePlayed}
         onTimeUpdate={isOncePlayed ? undefined : () => setIsOncePlayed(true)}
       />
       {!videoAutoplay && <PlayPauseButtonBase />}

--- a/packages/review/src/components/review-element/media/video.tsx
+++ b/packages/review/src/components/review-element/media/video.tsx
@@ -1,13 +1,25 @@
 import { ImageMeta } from '@titicaca/type-definitions'
 import { Container } from '@titicaca/core-elements'
 import { useIntersection } from '@titicaca/intersection-observer'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useDeviceContext } from '@titicaca/react-contexts'
 import styled from 'styled-components'
 
 interface Props {
   medium: ImageMeta
 }
+
+const StyledPoster = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+`
 
 const StyledVideo = styled.video`
   position: absolute;
@@ -18,6 +30,7 @@ const StyledVideo = styled.video`
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transition: opacity 0.3s;
 `
 
 const PLAY_BUTTON_IMAGE_URL =
@@ -42,6 +55,7 @@ const PlayPauseButtonBase = styled.span`
 `
 
 function Video({ medium }: Props) {
+  const [isOncePlayed, setIsOncePlayed] = useState(false)
   const { ref, isIntersecting } = useIntersection<HTMLVideoElement>({
     threshold: 0.5,
   })
@@ -77,6 +91,9 @@ function Video({ medium }: Props) {
 
   return (
     <Container borderRadius={6}>
+      <StyledPoster
+        style={{ backgroundImage: `url("${medium.sizes.large.url}")` }}
+      />
       <StyledVideo
         ref={ref}
         src={medium.video?.large.url}
@@ -84,7 +101,8 @@ function Video({ medium }: Props) {
         loop
         muted
         playsInline
-        poster={medium.sizes.large.url}
+        style={{ opacity: isOncePlayed ? 1 : 0 }}
+        onTimeUpdate={isOncePlayed ? undefined : () => setIsOncePlayed(true)}
       />
       {!videoAutoplay && <PlayPauseButtonBase />}
     </Container>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

비디오 자동재생 문제 해결

[TRIPLE-CONTENT-WEB-A4B
](https://sentry.io/organizations/titicaca-corp/issues/3627285063/?query=is%3Aunresolved+assigned%3Ame&referrer=issue-stream&statsPeriod=14d)
[TRIPLE-CONTENT-WEB-A76
](https://sentry.io/organizations/titicaca-corp/issues/3649174441/?query=is%3Aunresolved+assigned%3Ame&referrer=issue-stream&statsPeriod=14d)
https://titicaca.slack.com/files/URE6H1L01/F042U71PNA3/3.mp4

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- 모바일 기기 배터리 절전모드에서는 비디오 자동재생이 불가능하고 에러를 던집니다. 이 에러를 센트리에 리포트 되지 않도록 에러를 무시합니다.
- iOS에서 `object-fit: cover` 스타일의 비디오를 처음 재생할 때 레이아웃이 깨지는 현상이 있습니다. 비디오를 처음에 숨기고 있다가 첫 timeUpdate 이벤트가 발생했을 때 비디오를 보여주어서 우회합니다. 
- 비디오와 poster를 분리해서 비디오에 opacity transition을 줄 수 있게 만듭니다.

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->

before

https://user-images.githubusercontent.com/11497500/199685770-4964565d-c1a2-4b4f-b480-aad54ee5bb13.MP4



after

https://user-images.githubusercontent.com/11497500/199685643-320b7c8e-9aff-4c9d-9ee5-55882315e1c3.mov
