### PR TITLE
[common] 블랙프라이데이 대응 black 컬러 추가

### DIFF
--- a/packages/core-elements/src/elements/label.tsx
+++ b/packages/core-elements/src/elements/label.tsx
@@ -17,6 +17,7 @@ export type LabelColor =
   | 'orange'
   | 'skyblue'
   | 'lightpurple'
+  | 'black'
 
 const LABEL_COLORS: {
   [key in LabelColor]: {
@@ -80,6 +81,12 @@ const LABEL_COLORS: {
     color: 'var(--color-white)',
     emphasizedColor: 'var(--color-white)',
     emphasizedBackground: 'var(--color-lightpurple)',
+  },
+  black: {
+    background: 'var(--color-black)',
+    color: 'var(--color-white)',
+    emphasizedColor: 'var(--color-white)',
+    emphasizedBackground: 'var(--color-black)',
   },
 }
 

--- a/packages/core-elements/src/global-style.ts
+++ b/packages/core-elements/src/global-style.ts
@@ -37,7 +37,7 @@ export const GlobalStyle = createGlobalStyle`
     --color-white900: rgba(255, 255, 255, 0.9);
     --color-skyblue: rgba(55, 168, 255, 1);
     --color-lightpurple: rgba(151, 95, 254, 1);
-    --color-black: rgba(0, 0, 0, 1);
+    --color-black: rgba(34, 34, 34, 1);
 
     /** genie */
     --color-azul: rgba(31, 87, 250, 1);

--- a/packages/core-elements/src/global-style.ts
+++ b/packages/core-elements/src/global-style.ts
@@ -37,6 +37,7 @@ export const GlobalStyle = createGlobalStyle`
     --color-white900: rgba(255, 255, 255, 0.9);
     --color-skyblue: rgba(55, 168, 255, 1);
     --color-lightpurple: rgba(151, 95, 254, 1);
+    --color-black: rgba(0, 0, 0, 1);
 
     /** genie */
     --color-azul: rgba(31, 87, 250, 1);


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
블랙프라이데이 대응합니다.
rgba 코드는 #222222이고, 컬러명은 black으로 진행합니다.

관련 쓰레드 : [https://titicaca.slack.com/archives/C0263JTN4DS/p1668494074232759?thread_ts=1666666650.565229&cid=C0263JTN4DS](https://titicaca.slack.com/archives/C0263JTN4DS/p1668494074232759?thread_ts=1666666650.565229&cid=C0263JTN4DS)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
