### PR TITLE
[resource-list-element] ExtendedResourceListElement의 tags를 Component타입으로 받을수 있도록 수정

### DIFF
--- a/packages/resource-list-element/src/extended-resource-list-element.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, PropsWithChildren } from 'react'
+import { Component, MouseEventHandler, PropsWithChildren } from 'react'
 import styled from 'styled-components'
 import { OverlayScrapButton } from '@titicaca/scrap-button'
 import {
@@ -32,11 +32,13 @@ export type ResourceListElementProps<R extends ResourceMeta> = {
   distance?: number | string
   distanceSuffix?: string
   note?: string
-  tags?: {
-    text?: string
-    color?: LabelColor
-    emphasized?: boolean
-  }[]
+  tags?:
+    | {
+        text?: string
+        color?: LabelColor
+        emphasized?: boolean
+      }[]
+    | Component
   scrapsCount?: number
   reviewsCount?: number
   reviewsRating?: number
@@ -89,7 +91,6 @@ export default function ExtendedResourceListElement<R extends ResourceMeta>({
   ...props
 }: PropsWithChildren<ResourceListElementProps<R>>) {
   const { id, type, scraped } = scrapResource || resource || {}
-  const labels = tags || []
   const formattedNames = [partnerName, areaName].filter(Boolean).join(' · ')
 
   return (
@@ -191,19 +192,24 @@ export default function ExtendedResourceListElement<R extends ResourceMeta>({
           </Container>
         </Container>
       </FlexBox>
+
       {children}
 
-      {labels.length > 0 ? (
-        <LabelContainer>
-          <Label.Group horizontalGap={5}>
-            {labels.map(({ text, color, emphasized }, index) => (
-              <Label key={index} promo color={color} emphasized={emphasized}>
-                {text}
-              </Label>
-            ))}
-          </Label.Group>
-        </LabelContainer>
-      ) : null}
+      {Array.isArray(tags) ? (
+        tags.length > 0 ? (
+          <LabelContainer>
+            <Label.Group horizontalGap={5}>
+              {tags.map(({ text, color, emphasized }, index) => (
+                <Label key={index} promo color={color} emphasized={emphasized}>
+                  {text}
+                </Label>
+              ))}
+            </Label.Group>
+          </LabelContainer>
+        ) : null
+      ) : (
+        <LabelContainer>{tags}</LabelContainer>
+      )}
     </ResourceListItem>
   )
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
투어티켓에서 resource-list-element 컴포넌트를 사용중이고, 해당 컴포넌트의 뱃지 컬러의 의존도가 TF에 있었는데, 비즈니스쪽에서는 컬러 변경에 대한 니즈가 계속 발생하고 있는 상황
투어티켓에서는 컬러를 서버사이드에서 관리되도록 협의됨에 따라서 해당 컴포넌트의 tags를 Component 타입으로 받아서 처리되도록 수정
투어티켓 관련 지라 : [https://titicaca.atlassian.net/browse/TNA-4987](https://titicaca.atlassian.net/browse/TNA-4987)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- tags Props의 타입을 Component도 받을수 있도록 확장
- Array.isArray() 메서드로 tags의 array여부를 판단후 분기 처리
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
