### PR TITLE
[app-installation-cta] 배너 CTA의 Dimmed 영역을 제거합니다.

### DIFF
--- a/docs/stories/app-installation-cta/banner-cta.stories.tsx
+++ b/docs/stories/app-installation-cta/banner-cta.stories.tsx
@@ -11,5 +11,6 @@ export const Basic: ComponentStoryObj<typeof BannerCTA> = {
   args: {
     inventoryId: 'app-install-cta-tna-v1',
     installUrl: 'https://triple-dev.titicaca-corp.com',
+    disableTextBanner: true,
   },
 }

--- a/docs/stories/app-installation-cta/banner-cta.stories.tsx
+++ b/docs/stories/app-installation-cta/banner-cta.stories.tsx
@@ -9,7 +9,7 @@ export default {
 export const Basic: ComponentStoryObj<typeof BannerCTA> = {
   name: '배너 CTA',
   args: {
-    inventoryId: 'app-install-cta-poi-v1',
+    inventoryId: 'app-install-cta-tna-v1',
     installUrl: 'https://triple-dev.titicaca-corp.com',
   },
 }

--- a/packages/app-installation-cta/src/app-installation-cta.tsx
+++ b/packages/app-installation-cta/src/app-installation-cta.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { LayeringMixinProps } from '@titicaca/core-elements'
 
-import { Overlay, BottomFixedContainer } from './elements'
+import { BottomFixedContainer } from './elements'
 import ImageBanner from './image-banner'
 import TextBanner from './text-banner'
 
@@ -18,22 +18,18 @@ export default function AppInstallationCta({
   imgUrl,
   installUrl,
   message,
-  zTier,
-  zIndex,
 }: AppInstallationCtaProps & LayeringMixinProps) {
   const [isImageBannerOpen, setIsImageBannerOpen] = useState(true)
 
   if (isImageBannerOpen) {
     return (
-      <Overlay zTier={zTier} zIndex={zIndex}>
-        <BottomFixedContainer>
-          <ImageBanner
-            imgUrl={imgUrl}
-            installUrl={installUrl}
-            onDismiss={() => setIsImageBannerOpen(false)}
-          />
-        </BottomFixedContainer>
-      </Overlay>
+      <BottomFixedContainer>
+        <ImageBanner
+          imgUrl={imgUrl}
+          installUrl={installUrl}
+          onDismiss={() => setIsImageBannerOpen(false)}
+        />
+      </BottomFixedContainer>
     )
   }
 

--- a/packages/app-installation-cta/src/banner-cta.tsx
+++ b/packages/app-installation-cta/src/banner-cta.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react'
-import { LayeringMixinProps } from '@titicaca/core-elements'
 import { InventoryItemMeta } from '@titicaca/type-definitions'
 
-import { Overlay, BottomFixedContainer } from './elements'
+import { BottomFixedContainer } from './elements'
 import ImageBanner from './image-banner'
 import TextBanner from './text-banner'
 import { CtaProps } from './interfaces'
@@ -31,9 +30,7 @@ export default function BannerCta({
   installText,
   dismissText,
   disableTextBanner,
-  zTier,
-  zIndex,
-}: BannerCtaProps & LayeringMixinProps) {
+}: BannerCtaProps) {
   const [inventoryItem, setInventoryItem] = useState<InventoryItemMeta>()
   const [isImageBannerOpen, setIsImageBannerOpen] = useState(true)
   const { image = '', desc = '' } = inventoryItem || {}
@@ -61,22 +58,20 @@ export default function BannerCta({
 
   return inventoryItem ? (
     isImageBannerOpen && image ? (
-      <Overlay zTier={zTier} zIndex={zIndex}>
-        <BottomFixedContainer>
-          <ImageBanner
-            imgUrl={image}
-            installUrl={installUrl}
-            installText={installText}
-            dismissText={dismissText}
-            onShow={onShow}
-            onClick={onClick}
-            onDismiss={() => {
-              setIsImageBannerOpen(false)
-              onDismiss && onDismiss(inventoryItem)
-            }}
-          />
-        </BottomFixedContainer>
-      </Overlay>
+      <BottomFixedContainer>
+        <ImageBanner
+          imgUrl={image}
+          installUrl={installUrl}
+          installText={installText}
+          dismissText={dismissText}
+          onShow={onShow}
+          onClick={onClick}
+          onDismiss={() => {
+            setIsImageBannerOpen(false)
+            onDismiss && onDismiss(inventoryItem)
+          }}
+        />
+      </BottomFixedContainer>
     ) : !disableTextBanner ? (
       <TextBanner
         message={desc}

--- a/packages/app-installation-cta/src/banner-cta.tsx
+++ b/packages/app-installation-cta/src/banner-cta.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react'
-import { LayeringMixinProps } from '@titicaca/core-elements'
 import { InventoryItemMeta } from '@titicaca/type-definitions'
 
-import { Overlay, BottomFixedContainer } from './elements'
+import { BottomFixedContainer } from './elements'
 import ImageBanner from './image-banner'
 import TextBanner from './text-banner'
 import { CtaProps } from './interfaces'
@@ -31,9 +30,7 @@ export default function BannerCta({
   installText,
   dismissText,
   disableTextBanner,
-  zTier,
-  zIndex,
-}: BannerCtaProps & LayeringMixinProps) {
+}: BannerCtaProps) {
   const [inventoryItem, setInventoryItem] = useState<InventoryItemMeta>()
   const [isImageBannerOpen, setIsImageBannerOpen] = useState(true)
   const { image = '', desc = '' } = inventoryItem || {}
@@ -61,29 +58,20 @@ export default function BannerCta({
 
   return inventoryItem ? (
     isImageBannerOpen && image ? (
-      <Overlay
-        zTier={zTier}
-        zIndex={zIndex}
-        onClick={() => {
-          setIsImageBannerOpen(false)
-          onDismiss && onDismiss(inventoryItem)
-        }}
-      >
-        <BottomFixedContainer>
-          <ImageBanner
-            imgUrl={image}
-            installUrl={installUrl}
-            installText={installText}
-            dismissText={dismissText}
-            onShow={onShow}
-            onClick={onClick}
-            onDismiss={() => {
-              setIsImageBannerOpen(false)
-              onDismiss && onDismiss(inventoryItem)
-            }}
-          />
-        </BottomFixedContainer>
-      </Overlay>
+      <BottomFixedContainer>
+        <ImageBanner
+          imgUrl={image}
+          installUrl={installUrl}
+          installText={installText}
+          dismissText={dismissText}
+          onShow={onShow}
+          onClick={onClick}
+          onDismiss={() => {
+            setIsImageBannerOpen(false)
+            onDismiss && onDismiss(inventoryItem)
+          }}
+        />
+      </BottomFixedContainer>
     ) : !disableTextBanner ? (
       <TextBanner
         message={desc}

--- a/packages/app-installation-cta/src/banner-cta.tsx
+++ b/packages/app-installation-cta/src/banner-cta.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react'
+import { LayeringMixinProps } from '@titicaca/core-elements'
 import { InventoryItemMeta } from '@titicaca/type-definitions'
 
-import { BottomFixedContainer } from './elements'
+import { Overlay, BottomFixedContainer } from './elements'
 import ImageBanner from './image-banner'
 import TextBanner from './text-banner'
 import { CtaProps } from './interfaces'
@@ -30,7 +31,9 @@ export default function BannerCta({
   installText,
   dismissText,
   disableTextBanner,
-}: BannerCtaProps) {
+  zTier,
+  zIndex,
+}: BannerCtaProps & LayeringMixinProps) {
   const [inventoryItem, setInventoryItem] = useState<InventoryItemMeta>()
   const [isImageBannerOpen, setIsImageBannerOpen] = useState(true)
   const { image = '', desc = '' } = inventoryItem || {}
@@ -58,20 +61,22 @@ export default function BannerCta({
 
   return inventoryItem ? (
     isImageBannerOpen && image ? (
-      <BottomFixedContainer>
-        <ImageBanner
-          imgUrl={image}
-          installUrl={installUrl}
-          installText={installText}
-          dismissText={dismissText}
-          onShow={onShow}
-          onClick={onClick}
-          onDismiss={() => {
-            setIsImageBannerOpen(false)
-            onDismiss && onDismiss(inventoryItem)
-          }}
-        />
-      </BottomFixedContainer>
+      <Overlay zTier={zTier} zIndex={zIndex}>
+        <BottomFixedContainer>
+          <ImageBanner
+            imgUrl={image}
+            installUrl={installUrl}
+            installText={installText}
+            dismissText={dismissText}
+            onShow={onShow}
+            onClick={onClick}
+            onDismiss={() => {
+              setIsImageBannerOpen(false)
+              onDismiss && onDismiss(inventoryItem)
+            }}
+          />
+        </BottomFixedContainer>
+      </Overlay>
     ) : !disableTextBanner ? (
       <TextBanner
         message={desc}

--- a/packages/app-installation-cta/src/elements.tsx
+++ b/packages/app-installation-cta/src/elements.tsx
@@ -7,23 +7,13 @@ import {
 } from '@titicaca/core-elements'
 import { white, blue980 } from '@titicaca/color-palette'
 
-export const Overlay = styled.div<LayeringMixinProps>`
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-
-  ${layeringMixin(1)}
-`
-
 export const BottomFixedContainer = styled.div<LayeringMixinProps>`
-  position: absolute;
+  position: fixed;
   left: 0;
   bottom: 0;
   width: 100%;
 
-  ${layeringMixin(0)}
+  ${layeringMixin(1)}
 
   > * {
     margin: 0 auto;

--- a/packages/app-installation-cta/src/elements.tsx
+++ b/packages/app-installation-cta/src/elements.tsx
@@ -5,7 +5,7 @@ import {
   layeringMixin,
   LayeringMixinProps,
 } from '@titicaca/core-elements'
-import { white, blue980, gray500 } from '@titicaca/color-palette'
+import { white, blue980 } from '@titicaca/color-palette'
 
 export const Overlay = styled.div<LayeringMixinProps>`
   position: fixed;
@@ -13,8 +13,6 @@ export const Overlay = styled.div<LayeringMixinProps>`
   bottom: 0;
   left: 0;
   right: 0;
-  box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.07);
-  background-color: ${gray500};
 
   ${layeringMixin(1)}
 `

--- a/packages/app-installation-cta/src/image-banner.tsx
+++ b/packages/app-installation-cta/src/image-banner.tsx
@@ -64,7 +64,7 @@ export default function ImageBanner({
         <span role="img" aria-label="eyes">
           👀
         </span>
-        <span>&nbsp;&nbsp;{installText || '편하게 앱에서 보기'}</span>
+        <span>&nbsp;&nbsp;{installText || '편하게 앱에서 보기'}</span>
       </InstallLink>
 
       <DismissButton onClick={handleDismiss}>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

호텔, TNA에서 사용할 배너 형식의 CTA에서 Dimmed 처리된 영역(= overlay)를 제거합니다.

[관련 스레드](https://titicaca.slack.com/archives/C0J3TT1H8/p1668496511081169?thread_ts=1667888668.839489&cid=C0J3TT1H8)

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- Dimmed 영역 제거
- 스토리북 이미지가 안나오는 이슈 수정
  - 인벤토리 어드민 (dev)에서 해당 인벤토리가 제거되서 수정했습니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
