### PR TITLE
[web-storage, poi-deatail] web-storage 오류 처리 함수 추가

### DIFF
--- a/packages/poi-detail/src/actions.tsx
+++ b/packages/poi-detail/src/actions.tsx
@@ -55,7 +55,7 @@ export default function Actions({
   const [isReviewTooltipExposed, setIsReviewTooltipExposed] = useState(true)
 
   useEffect(() => {
-    const webStorage = getWebStorage()
+    const webStorage = getWebStorage('localStorage', { unavailable: () => {} })
     setIsReviewTooltipExposed(
       JSON.parse(
         webStorage.getItem(REVIEW_TOOLTIP_EXPOSED) || 'false',

--- a/packages/web-storage/README.md
+++ b/packages/web-storage/README.md
@@ -13,7 +13,14 @@ Web Storage API에서 발생할 수 있는 오류를 명확히 정의하고 이�
 ### `getWebStorage` 함수
 
 window의 `localStorage`, `sessionStorage` 대신 사용할 수 있는 객체를 반환하는 함수입니다.
-파라미터로 storage의 종류를 받습니다. 기본값은 `localStorage`입니다.
+파라미터
+
+- storage의 종류
+  - 기본값 : `localStorage`
+- Web Storage API 관련 오류를 처리하는 onError
+  - 기본값 : `undefined`
+  - onError에 함수가 정의 되어있는 `WebStorageError`의 경우 `WebStorageError`을 throw하지 않고 해당 함수를 실행합니다.
+
 Web Storage API와 거의 동일한 인터페이스를 제공합니다.
 `length`, `key`, `getItem`, `setItem`, `removeItem`, `clear` 속성을 제공합니다.
 단, 기존 storage와 달리 Index signature로 값에 접근하는 방식은 제공하지 않습니다.
@@ -31,5 +38,16 @@ storage['my-awesome-key'] = '42' // X
 ### `WebStorageErrorBoundary`
 
 자식 컴포넌트 트리에서 Web Storage API 관련 오류가 발생하면 Alert를 표시하는 컴포넌트입니다. 다른 에러를 만났을 때는 그대로 throw 합니다.
+
+따라서 `onError`에 정의된 함수에서 오류를 throw하면 `WebStorageErrorBoundary`를 거치지 않습니다.
+
+```ts
+const storage = getWebStorage('sessionStorage', {
+  unavailable: () => {
+    throw new Error('레포지토리에서 에러를 처리')
+  },
+})
+// 위의 Error가 발생 시 WebStorageErrorBoundary를 거치지 않음
+```
 
 `onConfirm` prop을 통해 Alert를 확인했을 때 행동을 정의해야 합니다.

--- a/packages/web-storage/src/error.ts
+++ b/packages/web-storage/src/error.ts
@@ -1,8 +1,6 @@
 import { CustomError } from 'ts-custom-error'
 
-import { WebStorageType } from './types'
-
-type ErrorType = 'notBrowser' | 'unavailable' | 'quotaExceeded'
+import { ErrorType, WebStorageType } from './types'
 
 export class WebStorageError extends CustomError {
   private type: ErrorType
@@ -42,4 +40,27 @@ export class WebStorageError extends CustomError {
         return '알 수 없는 에러가 발생했습니다. 잠시 후 다시 시도해 주세요.'
     }
   }
+
+  public get errorType(): ErrorType {
+    return this.type
+  }
+}
+
+export function handleError({
+  errorType,
+  storageType,
+  onError,
+}: {
+  errorType: ErrorType
+  storageType: WebStorageType
+  onError?: { [key in ErrorType]?: () => unknown }
+}) {
+  if (onError) {
+    const onErrorType = onError[errorType]
+    if (onErrorType) {
+      onErrorType()
+      return
+    }
+  }
+  throw new WebStorageError({ type: errorType, storageType })
 }

--- a/packages/web-storage/src/types.ts
+++ b/packages/web-storage/src/types.ts
@@ -1,1 +1,3 @@
 export type WebStorageType = 'localStorage' | 'sessionStorage'
+
+export type ErrorType = 'notBrowser' | 'unavailable' | 'quotaExceeded'


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

[TRIPLE-CONTENT-WEB-A7F](https://sentry.io/organizations/titicaca-corp/issues/3650396944/?query=is%3Aunresolved+assigned%3Amia%40triple-corp.com&referrer=issue-stream&statsPeriod=14d), [TRIPLE-CONTENT-WEB-A7K](https://sentry.io/organizations/titicaca-corp/issues/3651947573/?query=is%3Aunresolved+assigned%3Amia%40triple-corp.com&referrer=issue-stream&statsPeriod=14d) 오류를 해결하기 위해 `web-storage`의 인자를 추가합니다.

`web-storage` 패키지를 사용하는 각 레포지토리가 window의 web storage를 접근하면서 발생하는 오류를 각자 처리할 수 있는 옵션을 제공하기 위해 `onError` 인자를 추가합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- `onError` 인자를 추가
  - `webStorage`의 `error type(unavailable, notBrowser, quotaExceeded)`에 해당하는 오류들을 처리하기 위한 함수를 받을 수 있습니다. 
- README 업데이트
  - `onError` 인자에 대한 설명
  - `onError` 인자 사용 시 `WebStorageErrorBoundary`에 미치는 영향

- poi-detail에 web-storage 에러 처리 추가
  - poi-detail에서는 [#2240 ]을 위해 `web-stroage`를 사용하고 있습니다. 툴팁이 뜨지 않아도 사용자에게 편의성을 제공하는 데 문제가 없기 때문에 `unavailble` 발생 시 아무 동작도 하지 않도록 추가했습니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
