### PR TITLE
[core-elements] Props 타입과 HTMLAttributes 타입 분리 

### DIFF
--- a/packages/core-elements/src/elements/flex-box/flex-box.tsx
+++ b/packages/core-elements/src/elements/flex-box/flex-box.tsx
@@ -4,7 +4,9 @@ import { HTMLAttributes } from 'react'
 
 import { Container, ContainerProps } from '../container'
 
-export interface FlexBoxProps extends Omit<FlexItemProps, 'flex'> {
+export interface FlexBoxProps
+  extends Omit<FlexItemOwnProps, 'flex'>,
+    HTMLAttributes<Element> {
   flex?: boolean
   flexDirection?: Property.FlexDirection
   flexWrap?: Property.FlexWrap
@@ -16,7 +18,7 @@ export interface FlexBoxProps extends Omit<FlexItemProps, 'flex'> {
   rowGap?: Property.RowGap
 }
 
-export interface FlexItemProps extends ContainerProps, HTMLAttributes<Element> {
+export interface FlexItemOwnProps extends ContainerProps {
   flex?: Property.Flex
   flexGrow?: Property.FlexGrow
   flexShrink?: Property.FlexShrink
@@ -36,6 +38,7 @@ const FlexItem = styled(Container)<FlexItemProps>(
   }),
   (props) => props.css,
 )
+export type FlexItemProps = FlexItemOwnProps & HTMLAttributes<Element>
 
 const StyledFlexBox = styled(Container)<FlexBoxProps>(
   (props) => ({

--- a/packages/core-elements/src/elements/select/select.tsx
+++ b/packages/core-elements/src/elements/select/select.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler } from 'react'
+import { ChangeEventHandler, SelectHTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { getColor } from '@titicaca/color-palette'
 
@@ -40,16 +40,14 @@ const Svg = styled.svg`
   right: 16px;
 `
 
-export interface SelectOption<
-  Value extends string | number | readonly string[],
-> {
+export type OptionValueType = string | number | readonly string[]
+
+export interface SelectOption<Value extends OptionValueType> {
   label: string
   value: Value
 }
 
-export interface SelectProps<
-  Value extends string | number | readonly string[],
-> {
+export interface SelectOwnProps<Value extends OptionValueType> {
   name?: string
   value?: Value
   options?: SelectOption<Value>[]
@@ -62,7 +60,10 @@ export interface SelectProps<
   onChange?: ChangeEventHandler<HTMLSelectElement>
 }
 
-export const Select = <Value extends string | number | readonly string[]>({
+type SelectProps<Value extends OptionValueType> = SelectOwnProps<Value> &
+  SelectHTMLAttributes<HTMLSelectElement>
+
+export const Select = <Value extends OptionValueType>({
   name,
   value,
   placeholder,
@@ -73,6 +74,7 @@ export const Select = <Value extends string | number | readonly string[]>({
   error,
   help,
   onChange,
+  ...props
 }: SelectProps<Value>) => {
   const formFieldState = useFormFieldState()
 
@@ -100,6 +102,7 @@ export const Select = <Value extends string | number | readonly string[]>({
           aria-errormessage={isError ? formFieldState.errorId : undefined}
           aria-invalid={isError}
           onChange={onChange}
+          {...props}
         >
           {placeholder ? <option value="">{placeholder}</option> : null}
           {options?.map(({ label, value }, idx) => (

--- a/packages/form/src/checkbox/index.tsx
+++ b/packages/form/src/checkbox/index.tsx
@@ -1,11 +1,6 @@
 import { InputHTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
-import {
-  Container,
-  GetGlobalColor,
-  MarginPadding,
-  CSSProps,
-} from '@titicaca/core-elements'
+import { Container, GetGlobalColor, CSSProps } from '@titicaca/core-elements'
 
 const Label = styled.label<{ disabled?: boolean }>`
   color: rgb(${GetGlobalColor('gray')});
@@ -77,9 +72,9 @@ interface Item<T> {
 }
 
 export interface CheckboxItemProps<T>
-  extends InputHTMLAttributes<HTMLInputElement> {
+  extends InputHTMLAttributes<HTMLInputElement>,
+    CSSProps {
   option: Item<T>
-  margin?: MarginPadding
 }
 
 export interface CheckboxWrapperProps<T> {
@@ -96,7 +91,7 @@ export function CheckboxItem<T>({
   name,
   option: { key, label },
   css: cssProp,
-}: CheckboxItemProps<T> & CSSProps) {
+}: CheckboxItemProps<T>) {
   const id = `${key}_${label}_${name}`
 
   return (


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
prop 타입과 attr 타입을 분리해 구분지어 사용 가능하도록 합니다. 
- https://github.com/titicacadev/triple-frontend/pull/2264#discussion_r1024870573

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
-  flexbox item 타입을 분리합니다
- select 타입을 분리하고 HTMLAttributes 타입을 추가합니다
- checkbox 타입 오류를 수정합니다 

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
