### PR TITLE
[slider] Slider에 role, aria states 추가

### DIFF
--- a/packages/slider/src/slider-base.tsx
+++ b/packages/slider/src/slider-base.tsx
@@ -152,6 +152,7 @@ export default function SliderBase({
                     key={i}
                     percent={percent}
                     {...getHandleProps(id)}
+                    tabIndex={0}
                     role="slider"
                     aria-valuemax={i === 0 ? adjustedValues[1] - step : max}
                     aria-valuemin={i === 0 ? min : adjustedValues[0] + step}

--- a/packages/slider/src/slider-base.tsx
+++ b/packages/slider/src/slider-base.tsx
@@ -148,7 +148,16 @@ export default function SliderBase({
             {({ handles, getHandleProps }) => (
               <>
                 {handles.map(({ id, percent }, i) => (
-                  <Handle key={i} percent={percent} {...getHandleProps(id)} />
+                  <Handle
+                    key={i}
+                    percent={percent}
+                    {...getHandleProps(id)}
+                    role="slider"
+                    aria-valuemax={i === 0 ? adjustedValues[1] - step : max}
+                    aria-valuemin={i === 0 ? min : adjustedValues[0] + step}
+                    aria-valuenow={adjustedValues[i]}
+                    aria-orientation="horizontal"
+                  />
                 ))}
               </>
             )}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

[slider] Slider에 role, aria states 추가

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- Slider handle (=thumb?)에 role="slider"와 aria states를 추가합니다.
- tabIndex를 추가해서 키보드로 포커스 가능하도록 합니다.
- SingleSlider, RangerSlider 둘 다 지원됩니다.

react-compound-slider 관리 잘 안되는 라이브러리인 것 같아서 떼어내고 싶은데... 대안 찾기가 어렵네요


## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->

크로마틱