### PR TITLE
[core-elements] FormField에 isFocused 상태와 핸들러 추가

### DIFF
--- a/packages/core-elements/src/elements/checkbox/checkbox-group.tsx
+++ b/packages/core-elements/src/elements/checkbox/checkbox-group.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react'
+import { HTMLAttributes, PropsWithChildren } from 'react'
 
 import {
   FormFieldContext,
@@ -15,7 +15,8 @@ import {
 
 export interface CheckboxGroupProps
   extends PropsWithChildren,
-    CheckboxGroupContextValue {
+    CheckboxGroupContextValue,
+    Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   label?: string
   error?: string
   help?: string
@@ -28,9 +29,12 @@ export const CheckboxGroup = ({
   label,
   error,
   help,
+  onBlur,
   onChange,
+  onFocus,
+  ...props
 }: CheckboxGroupProps) => {
-  const formFieldState = useFormFieldState()
+  const formFieldState = useFormFieldState({ onBlur, onFocus })
 
   const hasLabel = !!label
   const hasHelp = !!help
@@ -57,6 +61,9 @@ export const CheckboxGroup = ({
               ? formFieldState.errorId
               : undefined
           }
+          onBlur={formFieldState.handleBlur}
+          onFocus={formFieldState.handleFocus}
+          {...props}
         >
           {children}
         </div>

--- a/packages/core-elements/src/elements/form-field/form-field-context.tsx
+++ b/packages/core-elements/src/elements/form-field/form-field-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react'
+import { createContext, FocusEventHandler, useContext } from 'react'
 
 export interface FormFieldContextValue {
   inputId: string
@@ -8,6 +8,9 @@ export interface FormFieldContextValue {
   isError: boolean
   isDisabled: boolean
   isRequired: boolean
+  isFocused: boolean
+  handleBlur: FocusEventHandler
+  handleFocus: FocusEventHandler
 }
 
 export const FormFieldContext = createContext<

--- a/packages/core-elements/src/elements/form-field/form-field-label.tsx
+++ b/packages/core-elements/src/elements/form-field/form-field-label.tsx
@@ -7,8 +7,21 @@ import { Text } from '../text'
 
 import { useFormField } from './form-field-context'
 
-const Label = styled(Text)<{ isError: boolean; isRequired: boolean }>`
+interface LabelProps {
+  isError: boolean
+  isRequired: boolean
+  isFocused: boolean
+}
+
+const Label = styled(Text)<LabelProps>`
+  display: inline-block;
   margin-bottom: 6px;
+
+  ${({ isFocused }) =>
+    isFocused &&
+    css`
+      color: rgba(${getColor('blue')});
+    `}
 
   ${({ isError }) =>
     isError &&
@@ -29,9 +42,9 @@ const Label = styled(Text)<{ isError: boolean; isRequired: boolean }>`
     `}
 `
 
-export type Props = PropsWithChildren
+export type FormFieldLabelProps = PropsWithChildren
 
-export const FormFieldLabel = ({ children }: Props) => {
+export const FormFieldLabel = ({ children }: FormFieldLabelProps) => {
   const formField = useFormField()
 
   return (
@@ -42,6 +55,7 @@ export const FormFieldLabel = ({ children }: Props) => {
         htmlFor={formField.inputId}
         isError={formField.isError}
         isRequired={formField.isRequired}
+        isFocused={formField.isFocused}
       >
         {children}
       </Label>

--- a/packages/core-elements/src/elements/form-field/form-field.tsx
+++ b/packages/core-elements/src/elements/form-field/form-field.tsx
@@ -1,9 +1,14 @@
 import { PropsWithChildren } from 'react'
 
 import { FormFieldContext } from './form-field-context'
-import { useFormFieldState } from './use-form-field-state'
+import {
+  useFormFieldState,
+  UseFormFieldStateParams,
+} from './use-form-field-state'
 
-export interface FormFieldProps extends PropsWithChildren {
+export interface FormFieldProps
+  extends UseFormFieldStateParams,
+    PropsWithChildren {
   isError?: boolean
   isDisabled?: boolean
   isRequired?: boolean
@@ -14,8 +19,10 @@ export const FormField = ({
   isError = false,
   isDisabled = false,
   isRequired = false,
+  onBlur,
+  onFocus,
 }: FormFieldProps) => {
-  const state = useFormFieldState()
+  const state = useFormFieldState({ onBlur, onFocus })
 
   return (
     <FormFieldContext.Provider

--- a/packages/core-elements/src/elements/form-field/use-form-field-state.ts
+++ b/packages/core-elements/src/elements/form-field/use-form-field-state.ts
@@ -1,15 +1,34 @@
-import { useId } from 'react'
+import { FocusEventHandler, useId, useState } from 'react'
 
-export function useFormFieldState() {
+export interface UseFormFieldStateParams {
+  onBlur?: FocusEventHandler
+  onFocus?: FocusEventHandler
+}
+
+export function useFormFieldState(params: UseFormFieldStateParams) {
   const inputId = useId()
   const labelId = useId()
   const descriptionId = useId()
   const errorId = useId()
+  const [isFocused, setIsFocused] = useState(false)
+
+  const handleBlur: FocusEventHandler = (event) => {
+    setIsFocused(false)
+    params.onBlur?.(event)
+  }
+
+  const handleFocus: FocusEventHandler = (event) => {
+    setIsFocused(true)
+    params.onFocus?.(event)
+  }
 
   return {
     inputId,
     labelId,
     descriptionId,
     errorId,
+    isFocused,
+    handleBlur,
+    handleFocus,
   }
 }

--- a/packages/core-elements/src/elements/radio/radio-group.tsx
+++ b/packages/core-elements/src/elements/radio/radio-group.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react'
+import { HTMLAttributes, PropsWithChildren } from 'react'
 
 import {
   FormFieldContext,
@@ -15,7 +15,8 @@ import {
 
 export interface RadioGroupProps
   extends PropsWithChildren,
-    RadioGroupContextValue {
+    RadioGroupContextValue,
+    Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
   required?: boolean
   label?: string
   error?: string
@@ -30,9 +31,12 @@ export const RadioGroup = ({
   label,
   error,
   help,
+  onBlur,
   onChange,
+  onFocus,
+  ...props
 }: RadioGroupProps) => {
-  const formFieldState = useFormFieldState()
+  const formFieldState = useFormFieldState({ onBlur, onFocus })
 
   const hasLabel = !!label
   const hasHelp = !!help
@@ -64,6 +68,9 @@ export const RadioGroup = ({
           aria-errormessage={isError ? formFieldState?.errorId : undefined}
           aria-invalid={isError}
           aria-required={required}
+          onBlur={formFieldState.handleBlur}
+          onFocus={formFieldState.handleFocus}
+          {...props}
         >
           {children}
         </div>

--- a/packages/core-elements/src/elements/select/select.tsx
+++ b/packages/core-elements/src/elements/select/select.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, SelectHTMLAttributes } from 'react'
+import { SelectHTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { getColor } from '@titicaca/color-palette'
 
@@ -48,35 +48,29 @@ export interface SelectOption<Value extends OptionValueType> {
 }
 
 export interface SelectOwnProps<Value extends OptionValueType> {
-  name?: string
   value?: Value
   options?: SelectOption<Value>[]
   placeholder?: string
-  disabled?: boolean
-  required?: boolean
   label?: string
-  error?: string
+  error?: string | boolean
   help?: string
-  onChange?: ChangeEventHandler<HTMLSelectElement>
 }
 
-type SelectProps<Value extends OptionValueType> = SelectOwnProps<Value> &
+export type SelectProps<Value extends OptionValueType> = SelectOwnProps<Value> &
   SelectHTMLAttributes<HTMLSelectElement>
 
 export const Select = <Value extends OptionValueType>({
-  name,
   value,
   placeholder,
   options,
-  disabled = false,
-  required = false,
   label,
   error,
   help,
-  onChange,
+  onBlur,
+  onFocus,
   ...props
 }: SelectProps<Value>) => {
-  const formFieldState = useFormFieldState()
+  const formFieldState = useFormFieldState({ onBlur, onFocus })
 
   const hasHelp = !!help
   const isError = !!error
@@ -85,23 +79,19 @@ export const Select = <Value extends OptionValueType>({
     <FormFieldContext.Provider
       value={{
         ...formFieldState,
-        isDisabled: disabled,
+        isDisabled: !!props.disabled,
         isError,
-        isRequired: required,
+        isRequired: !!props.required,
       }}
     >
       {label ? <FormFieldLabel>{label}</FormFieldLabel> : null}
       <Container position="relative">
         <BaseSelect
           id={formFieldState.inputId}
-          name={name}
           value={value}
-          disabled={disabled}
-          required={required}
           aria-describedby={hasHelp ? formFieldState.descriptionId : undefined}
           aria-errormessage={isError ? formFieldState.errorId : undefined}
           aria-invalid={isError}
-          onChange={onChange}
           {...props}
         >
           {placeholder ? <option value="">{placeholder}</option> : null}

--- a/packages/core-elements/src/elements/textarea/textarea.tsx
+++ b/packages/core-elements/src/elements/textarea/textarea.tsx
@@ -49,8 +49,11 @@ interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
 }
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  function Textarea({ required = false, label, error, help, ...props }, ref) {
-    const formFieldState = useFormFieldState()
+  function Textarea(
+    { required = false, label, error, help, onBlur, onFocus, ...props },
+    ref,
+  ) {
+    const formFieldState = useFormFieldState({ onBlur, onFocus })
 
     const hasLabel = !!label
     const hasHelp = !!help
@@ -75,6 +78,8 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           aria-errormessage={isError ? formFieldState.errorId : undefined}
           aria-invalid={isError}
           aria-multiline
+          onBlur={formFieldState.handleBlur}
+          onFocus={formFieldState.handleFocus}
           {...props}
         />
         {error ? (


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

[core-elements] FormField에 isFocused 상태와 핸들러 추가

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- input에 focus 되었을 때 Label의 컬러를 변경해야 하는데 css만으로는 Label에서 focus 상태를 알 수 있는 방법이 없어서 FormField가 isFocused 상태를 관리할 수 있게 합니다.
- FormField 사용하는 컴포넌트를 업데이트 합니다.
- Label에 display: inline-block을 추가해서 margin-bottom이 제대로 보이도록 합니다.