### PR TITLE
color-palette 대신 css variable 사용

### DIFF
--- a/packages/action-sheet/src/action-sheet-body.tsx
+++ b/packages/action-sheet/src/action-sheet-body.tsx
@@ -1,5 +1,4 @@
 import { FocusScope } from '@react-aria/focus'
-import { white } from '@titicaca/color-palette'
 import {
   Container,
   CSSProps,
@@ -46,7 +45,7 @@ const Sheet = styled.div<SheetProps>`
   right: 0;
   margin: 0 auto;
   max-width: 768px;
-  background-color: ${white};
+  background-color: var(--color-white);
 
   padding-bottom: ${({ from, bottomSpacing }) =>
     from === 'top' ? 30 : bottomSpacing}px;

--- a/packages/app-installation-cta/src/elements.tsx
+++ b/packages/app-installation-cta/src/elements.tsx
@@ -5,7 +5,6 @@ import {
   layeringMixin,
   LayeringMixinProps,
 } from '@titicaca/core-elements'
-import { white, blue980, gray500 } from '@titicaca/color-palette'
 
 export const Overlay = styled.div<LayeringMixinProps>`
   position: fixed;
@@ -14,7 +13,7 @@ export const Overlay = styled.div<LayeringMixinProps>`
   left: 0;
   right: 0;
   box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.07);
-  background-color: ${gray500};
+  background-color: var(--color-gray500);
 
   ${layeringMixin(1)}
 `
@@ -111,7 +110,7 @@ export const InstallDescription = styled(Text)`
   height: 21px;
   font-size: 18px;
   font-weight: bold;
-  color: ${white};
+  color: var(--color-white);
 `
 
 export const InstallAnchor = styled.a`
@@ -215,7 +214,7 @@ export const FloatingButton = styled.div`
   display: flex;
   border-radius: 42px;
   box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.07);
-  background-color: ${blue980};
+  background-color: var(--color-blue980);
   overflow: hidden;
   margin-left: auto;
   margin-right: auto;
@@ -239,7 +238,7 @@ export const ChatbotAction = styled.a`
   font-weight: bold;
   text-decoration: none;
   line-height: 16px;
-  color: ${blue980};
+  color: var(--color-blue980);
   padding-right: 14px;
   background-size: 14px 14px;
   background-image: url('https://assets.triple.guide/images/ico-right-blue-arrow-s@3x.png');

--- a/packages/author/src/author-intro.tsx
+++ b/packages/author/src/author-intro.tsx
@@ -1,16 +1,15 @@
 import styled from 'styled-components'
 import { Text } from '@titicaca/core-elements'
-import { getColor } from '@titicaca/color-palette'
 
 const Html = styled.div`
   line-height: 1.43;
   margin: 21px 0 0;
-  color: rgba(${getColor('gray500')});
+  color: var(--color-gray500);
   font-size: 14px;
   font-weight: 500;
 
   a {
-    color: rgba(${getColor('gray500')});
+    color: var(--color-gray500);
   }
 `
 

--- a/packages/core-elements/src/elements/button/basic-button.tsx
+++ b/packages/core-elements/src/elements/button/basic-button.tsx
@@ -1,5 +1,5 @@
 import { css } from 'styled-components'
-import { Color, getColor } from '@titicaca/color-palette'
+import { Color } from '@titicaca/color-palette'
 
 import { buttonBaseMixin, ButtonBaseProps } from './button-base'
 
@@ -27,7 +27,7 @@ export const basicButtonMixin = ({
   ...props
 }: BasicButtonProps) => css`
   ${buttonBaseMixin(props)}
-  border: 1px solid rgba(${getColor('gray200')});
+  border: 1px solid var(--color-gray200);
   border-radius: 4px;
   background-color: transparent;
   color: #3a3a3a;

--- a/packages/core-elements/src/elements/checkbox/checkbox-base.tsx
+++ b/packages/core-elements/src/elements/checkbox/checkbox-base.tsx
@@ -1,7 +1,6 @@
 import { ChangeEventHandler } from 'react'
 import styled from 'styled-components'
 import { useVisuallyHidden } from '@react-aria/visually-hidden'
-import { blue, gray200 } from '@titicaca/color-palette'
 
 type CheckboxVariant = 'square' | 'round'
 
@@ -16,13 +15,13 @@ const CheckboxBaseControl = styled.div<{ variant: CheckboxVariant }>`
   position: relative;
   width: 26px;
   height: 26px;
-  border: 1px solid ${gray200};
+  border: 1px solid var(--color-gray200);
   border-radius: ${({ variant }) => (variant === 'square' ? '6px' : '36px')};
   background-color: white;
 
   ${CheckboxBaseInput}:checked + & {
-    border-color: ${blue};
-    background-color: ${blue};
+    border-color: var(--color-blue);
+    background-color: var(--color-blue);
   }
 
   ${CheckboxBaseInput}:focus-visible + & {

--- a/packages/core-elements/src/elements/form-field/form-field-label.tsx
+++ b/packages/core-elements/src/elements/form-field/form-field-label.tsx
@@ -19,7 +19,7 @@ const Label = styled(Text)<LabelProps>`
   ${({ isFocused }) =>
     isFocused &&
     css`
-      color: rgba(${getColor('blue')});
+      color: var(--color-blue);
     `}
 
   ${({ isError }) =>

--- a/packages/core-elements/src/elements/form-field/form-field-label.tsx
+++ b/packages/core-elements/src/elements/form-field/form-field-label.tsx
@@ -1,4 +1,3 @@
-import { getColor } from '@titicaca/color-palette'
 import { PropsWithChildren } from 'react'
 import styled, { css } from 'styled-components'
 
@@ -26,7 +25,7 @@ const Label = styled(Text)<LabelProps>`
   ${({ isError }) =>
     isError &&
     css`
-      color: rgba(${getColor('red')});
+      color: var(--color-red);
     `}
 
   ${({ isRequired }) =>
@@ -35,7 +34,7 @@ const Label = styled(Text)<LabelProps>`
       &::after {
         content: ${isRequired ? "'*'" : undefined};
         display: inline;
-        color: rgba(${getColor('mediumRed')});
+        color: var(--color-mediumRed);
         font-weight: normal;
         margin-left: 4px;
       }

--- a/packages/core-elements/src/elements/gender-selector/gender-selector-item.tsx
+++ b/packages/core-elements/src/elements/gender-selector/gender-selector-item.tsx
@@ -1,6 +1,5 @@
 import { ChangeEventHandler, PropsWithChildren } from 'react'
 import styled from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
 import { useVisuallyHidden } from '@react-aria/visually-hidden'
 
 import { useRadioGroup } from '../radio'
@@ -12,18 +11,17 @@ const Label = styled.label<{ checked: boolean }>`
   padding: 15px 0;
   border: ${({ checked }) =>
     checked
-      ? `1px solid rgb(${getColor('blue')}) `
-      : `1px solid rgba(${getColor('gray100')}) `};
+      ? `1px solid var(--color-blue) `
+      : `1px solid var(--color-gray100) `};
   border-radius: 2px;
   text-align: center;
   font-size: 16px;
   color: ${({ checked }) =>
-    checked ? `rgb(${getColor('blue')}) ` : `rgba(${getColor('gray300')}) `};
+    checked ? `var(--color-blue) ` : `var(--color-gray300) `};
 
   &:last-child {
     border-left: none;
-    border: ${({ checked }) =>
-      checked && `1px solid rgb(${getColor('blue')}) `};
+    border: ${({ checked }) => checked && `1px solid var(--color-blue) `};
   }
 `
 

--- a/packages/core-elements/src/elements/image/circular.ts
+++ b/packages/core-elements/src/elements/image/circular.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
 import * as CSS from 'csstype'
 
 import { GlobalSizes } from '../../commons'
@@ -21,7 +20,7 @@ export const ImageCircular = styled.img<{
   border-radius: ${({ size, width }) =>
     ((size && ROUND_SIZES[size]) || width || (ROUND_SIZES.small as number)) /
     2}px;
-  background-color: rgba(${getColor('brightGray')});
+  background-color: var(--color-brightGray);
   object-fit: cover;
 
   float: ${({ floated }) => floated || 'none'};

--- a/packages/core-elements/src/elements/image/placeholder.tsx
+++ b/packages/core-elements/src/elements/image/placeholder.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { brightGray } from '@titicaca/color-palette'
 
 import { useContentAbsolute } from './fixed-ratio-frame'
 
@@ -9,7 +8,7 @@ export const Placeholder = styled.div<{
 }>`
   width: 100%;
   height: 100%;
-  background-color: ${brightGray};
+  background-color: var(--color-brightGray);
 
   ${({ src }) =>
     src &&

--- a/packages/core-elements/src/elements/input/input.tsx
+++ b/packages/core-elements/src/elements/input/input.tsx
@@ -1,7 +1,6 @@
 import { InputHTMLAttributes, forwardRef } from 'react'
 import styled from 'styled-components'
 import InputMask, { MaskOptions } from 'react-input-mask'
-import { getColor } from '@titicaca/color-palette'
 
 import {
   FormFieldContext,
@@ -16,21 +15,21 @@ const BaseInput = styled(InputMask)`
   font-size: 16px;
   height: 48px;
   font-weight: 500;
-  border: 1px solid rgba(${getColor('gray100')});
+  border: 1px solid var(--color-gray100);
   border-radius: 2px;
   width: 100%;
 
   &:focus {
     outline: none;
-    border-color: rgb(${getColor('blue')});
+    border-color: var(--color-blue);
   }
 
   &[aria-invalid='true'] {
-    border-color: rgb(${getColor('red')});
+    border-color: var(--color-red);
   }
 
   &::placeholder {
-    color: rgba(${getColor('gray300')});
+    color: var(--color-gray300);
   }
 `
 

--- a/packages/core-elements/src/elements/navbar/navbar.tsx
+++ b/packages/core-elements/src/elements/navbar/navbar.tsx
@@ -1,6 +1,6 @@
 import * as CSS from 'csstype'
 import styled, { css } from 'styled-components'
-import { Color, getColor, brightGray, white } from '@titicaca/color-palette'
+import { Color, getColor } from '@titicaca/color-palette'
 import {
   PropsWithChildren,
   Children,
@@ -35,7 +35,7 @@ const WrapperContainer = styled.div<
   left: 0;
   right: 0;
   ${layeringMixin(0)}
-  background: ${white};
+  background: var(--color-white);
   ${({ height }) =>
     height &&
     `
@@ -56,7 +56,7 @@ const NavbarFrame = styled.div<NavbarProps & LayeringMixinProps>`
     borderless
       ? ''
       : css`
-          box-shadow: 0 1px 0 0 ${brightGray};
+          box-shadow: 0 1px 0 0 var(--color-brightGray);
         `};
   padding: 9px 12px;
   margin: 0 auto;

--- a/packages/core-elements/src/elements/navbar/search-navbar.tsx
+++ b/packages/core-elements/src/elements/navbar/search-navbar.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
 import {
   forwardRef,
   KeyboardEvent,
@@ -36,7 +35,7 @@ const MainNavbarFrame = styled(Navbar.NavbarFrame)<
   { noBorder?: boolean } & LayeringMixinProps
 >`
   ${({ noBorder }) =>
-    noBorder ? '' : ` border-bottom: 1px solid rgba(${getColor('gray50')});`}
+    noBorder ? '' : ` border-bottom: 1px solid var(--color-gray50);`}
   ${layeringMixin(0)}
 `
 

--- a/packages/core-elements/src/elements/radio/radio-base.tsx
+++ b/packages/core-elements/src/elements/radio/radio-base.tsx
@@ -1,13 +1,12 @@
 import { ChangeEventHandler } from 'react'
 import styled from 'styled-components'
-import { blue, gray200 } from '@titicaca/color-palette'
 
 const RadioInput = styled.input`
   appearance: none;
   position: relative;
   width: 26px;
   height: 26px;
-  border: 1px solid ${gray200};
+  border: 1px solid var(--color-gray200);
   border-radius: 50%;
 
   &::after {
@@ -19,7 +18,7 @@ const RadioInput = styled.input`
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background-color: ${blue};
+    background-color: var(--color-blue);
     opacity: 0;
     transition: opacity 0.3s ease;
   }

--- a/packages/core-elements/src/elements/select/select.tsx
+++ b/packages/core-elements/src/elements/select/select.tsx
@@ -1,6 +1,5 @@
 import { SelectHTMLAttributes } from 'react'
 import styled from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
 
 import {
   FormFieldContext,
@@ -19,18 +18,18 @@ const BaseSelect = styled.select`
   text-indent: 16px;
   font-size: 16px;
   font-weight: 500;
-  border: 1px solid rgba(${getColor('gray100')});
+  border: 1px solid var(--color-gray100);
   border-radius: 2px;
-  color: rgba(${getColor('gray')});
+  color: var(--color-gray);
 
   &:disabled {
     background-color: rgba(235, 235, 235, 1);
-    color: rgba(${getColor('gray300')});
+    color: var(--color-gray300);
   }
 
   &[aria-invalid='true'] {
-    border-color: rgba(${getColor('red')});
-    color: rgba(${getColor('red')});
+    border-color: var(--color-red);
+    color: var(--color-red);
   }
 `
 

--- a/packages/core-elements/src/elements/skeleton/skeleton.tsx
+++ b/packages/core-elements/src/elements/skeleton/skeleton.tsx
@@ -1,5 +1,4 @@
 import styled, { css, keyframes } from 'styled-components'
-import { gray100, gray20 } from '@titicaca/color-palette'
 
 import { Container, ContainerProps } from '../container'
 
@@ -36,7 +35,7 @@ type SkeletonProps = ContainerProps & { height?: number | string }
 export const Skeleton = styled(Container)`
   position: relative;
   overflow: hidden;
-  background: ${gray100};
+  background: var(--color-gray100);
   animation: ${opacityAnimation} 1.5s ease-in-out 0.5s infinite;
 
   &::after {
@@ -48,7 +47,12 @@ export const Skeleton = styled(Container)`
     position: absolute;
     animation: ${waveAnimation} 1.6s linear 0.5s infinite;
     transform: translateX(-100%);
-    background: linear-gradient(90deg, transparent, ${gray20}, transparent);
+    background: linear-gradient(
+      90deg,
+      transparent,
+      var(--color-gray20),
+      transparent
+    );
   }
 `
 

--- a/packages/core-elements/src/elements/tabs/basic-tab-list.tsx
+++ b/packages/core-elements/src/elements/tabs/basic-tab-list.tsx
@@ -1,11 +1,10 @@
-import { brightGray } from '@titicaca/color-palette'
 import styled from 'styled-components'
 
 import { TabListBase, TabListBaseProps } from './tab-list-base'
 
 const StyledTabListBase = styled(TabListBase)`
   display: flex;
-  background-color: ${brightGray};
+  background-color: var(--color-brightGray);
   border-radius: 4px;
   padding: 2px;
 `

--- a/packages/core-elements/src/elements/tabs/basic-tab.tsx
+++ b/packages/core-elements/src/elements/tabs/basic-tab.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { gray, white } from '@titicaca/color-palette'
 
 import { TabBase, TabBaseProps } from './tab-base'
 
@@ -12,8 +11,8 @@ const StyledTabBase = styled(TabBase)`
   padding: 11px 0;
 
   &[aria-selected='true'] {
-    color: ${gray};
-    background-color: ${white};
+    color: var(--color-gray);
+    background-color: var(--color-white);
   }
 `
 

--- a/packages/core-elements/src/elements/tooltip/tooltip.tsx
+++ b/packages/core-elements/src/elements/tooltip/tooltip.tsx
@@ -1,6 +1,5 @@
 import { MouseEventHandler } from 'react'
 import styled, { css } from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
 
 interface PointingOptions {
   vertical: 'top' | 'bottom'
@@ -43,7 +42,7 @@ const POINTING_BASE_STYLE = css`
 
 const TooltipFrame = styled.div<TooltipFrameProps>`
   position: relative;
-  color: rgba(${getColor('white')});
+  color: var(--color-white);
   padding: 6px 11px;
 
   ${({ backgroundColor }) => `background-color: ${backgroundColor}`};

--- a/packages/core-elements/src/elements/video/controls.tsx
+++ b/packages/core-elements/src/elements/video/controls.tsx
@@ -8,7 +8,6 @@ import {
 } from 'react'
 import styled from 'styled-components'
 import { debounce } from '@titicaca/view-utilities'
-import { getColor } from '@titicaca/color-palette'
 
 import Seeker from './seeker'
 import PlayPauseButton from './play-pause-button'
@@ -66,7 +65,7 @@ const Progress = styled.progress`
 
   &::-webkit-progress-value {
     border-radius: 2.5px;
-    background-color: rgba(${getColor('blue')});
+    background-color: var(--color-blue);
   }
 `
 

--- a/packages/core-elements/src/elements/video/seeker.tsx
+++ b/packages/core-elements/src/elements/video/seeker.tsx
@@ -6,7 +6,6 @@ import {
 } from 'react'
 import styled from 'styled-components'
 import { debounce } from '@titicaca/view-utilities'
-import { getColor } from '@titicaca/color-palette'
 
 const SeekerBase = styled.input<{ handleVisible: boolean }>`
   background: transparent;
@@ -26,7 +25,7 @@ const SeekerBase = styled.input<{ handleVisible: boolean }>`
     width: 13px;
     height: 13px;
     border-radius: 10px;
-    background-color: rgba(${getColor('blue')});
+    background-color: var(--color-blue);
     cursor: pointer;
     opacity: ${({ handleVisible }) => (handleVisible ? '1' : '0')};
     transition: opacity 0.3s;
@@ -36,7 +35,7 @@ const SeekerBase = styled.input<{ handleVisible: boolean }>`
     width: 13px;
     height: 13px;
     border-radius: 10px;
-    background-color: rgba(${getColor('blue')});
+    background-color: var(--color-blue);
     cursor: pointer;
     opacity: ${({ handleVisible }) => (handleVisible ? '1' : '0')};
     transition: opacity 0.3s;
@@ -46,7 +45,7 @@ const SeekerBase = styled.input<{ handleVisible: boolean }>`
     width: 13px;
     height: 13px;
     border-radius: 10px;
-    background-color: rgba(${getColor('blue')});
+    background-color: var(--color-blue);
     cursor: pointer;
     opacity: ${({ handleVisible }) => (handleVisible ? '1' : '0')};
     transition: opacity 0.3s;

--- a/packages/core-elements/src/utils/form-field.tsx
+++ b/packages/core-elements/src/utils/form-field.tsx
@@ -1,6 +1,5 @@
 import { useState, ComponentType, FC } from 'react'
 import styled, { css } from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
 
 import { Container, Text } from '../elements'
 
@@ -19,13 +18,13 @@ const Label = styled((props) => <Text {...props} />)<{
   ${({ focused }) =>
     focused &&
     css`
-      color: rgba(${getColor('blue')});
+      color: var(--color-blue);
     `}
 
   ${({ error }) =>
     error &&
     css`
-      color: rgba(${getColor('red')});
+      color: var(--color-red);
     `}
 
   ${({ absolute }) =>
@@ -41,7 +40,7 @@ const Label = styled((props) => <Text {...props} />)<{
       &::after {
         content: ${required ? "'*'" : undefined};
         display: inline;
-        color: rgba(${getColor('mediumRed')});
+        color: var(--color-mediumRed);
         font-weight: normal;
         margin-left: 4px;
       }

--- a/packages/form/src/action-sheet-selector/index.tsx
+++ b/packages/form/src/action-sheet-selector/index.tsx
@@ -1,6 +1,5 @@
 import styled, { css } from 'styled-components'
 import { Container, Text, withField } from '@titicaca/core-elements'
-import { getColor } from '@titicaca/color-palette'
 
 import ArrowDown from '../arrow-down'
 
@@ -15,7 +14,7 @@ const FieldContainer = styled.div`
   ${({ error }: { error: boolean }) =>
     error &&
     css`
-      border: 1px solid rgba(${getColor('red')});
+      border: 1px solid var(--color-red);
     `}
 `
 

--- a/packages/form/src/confirm-checkbox/index.tsx
+++ b/packages/form/src/confirm-checkbox/index.tsx
@@ -1,7 +1,6 @@
 import { ReactNode, SyntheticEvent } from 'react'
 import styled, { css } from 'styled-components'
 import * as CSS from 'csstype'
-import { getColor } from '@titicaca/color-palette'
 import { MarginPadding, paddingMixin } from '@titicaca/core-elements'
 
 import withField from '../with-field'
@@ -21,26 +20,26 @@ const generateFillStyles = ({
     return
   }
 
-  const color = getColor(checked ? 'blue' : 'red')
+  const color = checked ? 'var(--color-gray)' : 'var(--color-red)'
 
   switch (fillType) {
     case 'full':
       return css`
-        border-color: rgba(${color});
+        border-color: ${color};
 
         & > * {
-          color: rgba(${color});
+          color: ${color};
           font-weight: bold;
         }
       `
     case 'border':
       return css`
-        border-color: rgba(${color});
+        border-color: ${color};
       `
     case 'text':
       return css`
         & > * {
-          color: rgba(${color});
+          color: ${color};
           font-weight: bold;
         }
       `
@@ -61,7 +60,7 @@ const ConfirmFrame = styled.div.attrs({})<{
   border-radius: 2px;
   position: relative;
   font-weight: bold;
-  color: rgba(${getColor('gray500')});
+  color: var(--color-gray500);
 
   ${({ checked, error, fillType }) =>
     fillType && generateFillStyles({ checked: !!checked, error, fillType })};

--- a/packages/form/src/gender-radio/index.tsx
+++ b/packages/form/src/gender-radio/index.tsx
@@ -1,6 +1,5 @@
 import { SyntheticEvent } from 'react'
 import styled from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
 import { Container } from '@titicaca/core-elements'
 
 import withField from '../with-field'
@@ -26,15 +25,14 @@ const GenderContainer = styled.div<{
   font-size: 16px;
   border: ${({ selected }) =>
     selected
-      ? `1px solid rgb(${getColor('blue')}) `
-      : `1px solid rgba(${getColor('gray100')}) `};
+      ? `1px solid var(--color-blue) `
+      : `1px solid var(--color-gray100) `};
   color: ${({ selected }) =>
-    selected ? `rgb(${getColor('blue')}) ` : `rgba(${getColor('gray300')}) `};
+    selected ? `var(--color-blue) ` : `var(--color-gray300) `};
 
   &:last-child {
     border-left: none;
-    border: ${({ selected }) =>
-      selected && `1px solid rgb(${getColor('blue')}) `};
+    border: ${({ selected }) => selected && `1px solid var(--color-blue) `};
   }
 `
 

--- a/packages/form/src/input/index.tsx
+++ b/packages/form/src/input/index.tsx
@@ -1,7 +1,6 @@
 import { InputHTMLAttributes, SyntheticEvent, FocusEvent } from 'react'
 import InputMask, { MaskOptions } from 'react-input-mask'
 import styled, { css } from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
 
 import withField from '../with-field'
 
@@ -10,24 +9,24 @@ const BaseInput = styled(InputMask)<{ focused?: string; error?: string }>`
   padding: 14px 16px;
   font-size: 16px;
   font-weight: 500;
-  border: 1px solid rgba(${getColor('gray100')});
+  border: 1px solid var(--color-gray100);
   border-radius: 2px;
   width: 100%;
 
   ::placeholder {
-    color: rgba(${getColor('gray300')});
+    color: var(--color-gray300);
   }
 
   ${({ focused }) =>
     focused &&
     css`
-      border-color: rgb(${getColor('blue')});
+      border-color: var(--color-blue);
     `};
 
   ${({ error }) =>
     error &&
     css`
-      border-color: rgb(${getColor('red')});
+      border-color: var(--color-red);
     `};
 `
 

--- a/packages/form/src/select/index.tsx
+++ b/packages/form/src/select/index.tsx
@@ -1,6 +1,5 @@
 import { SyntheticEvent, FocusEvent, SelectHTMLAttributes } from 'react'
 import styled, { css } from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
 
 import withField from '../with-field'
 import ArrowDown from '../arrow-down'
@@ -23,32 +22,33 @@ interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
 
 const SelectFrame = styled.div<{ focused?: string; error?: boolean }>`
   padding: 14px 16px;
-  border: 1px solid rgba(${getColor('gray100')});
+  border: 1px solid var(--color-gray100);
   border-radius: 2px;
   position: relative;
 
   ${({ focused }) =>
     focused &&
     css`
-      border-color: rgba(${getColor('blue')});
+      border-color: var(--color-blue);
     `};
 
   ${({ error }) =>
     error &&
     css`
-      border-color: rgba(${getColor('red')});
+      border-color: var(--color-red);
     `};
 `
 
 const BaseSelect = styled.select<{ selected?: boolean; error?: boolean }>`
   width: 100%;
   font-size: 16px;
-  color: rgba(${getColor('gray')}, ${({ selected }) => (selected ? 1 : 0.3)});
+  color: css(--color-gray);
+  opacity: ${({ selected }) => (selected ? 1 : 0.3)};
 
   ${({ error }) =>
     error &&
     css`
-      color: rgba(${getColor('red')});
+      color: var(--color-red);
     `};
 `
 

--- a/packages/form/src/textarea/index.tsx
+++ b/packages/form/src/textarea/index.tsx
@@ -1,6 +1,5 @@
 import { SyntheticEvent } from 'react'
 import styled, { css, StyledComponentProps } from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
 
 import withField from '../with-field'
 
@@ -35,19 +34,19 @@ const BaseTextarea = styled.textarea<BaseTextareaProps>`
   min-height: 100px;
 
   ::placeholder {
-    color: rgba(${getColor('gray300')});
+    color: var(--color-gray300);
   }
 
   ${({ focused }) =>
     focused &&
     css`
-      border-color: rgb(${getColor('blue')});
+      border-color: var(--color-blue);
     `};
 
   ${({ error }) =>
     error &&
     css`
-      border-color: rgb(${getColor('red')});
+      border-color: var(--color-red);
     `};
 `
 

--- a/packages/form/src/with-field.tsx
+++ b/packages/form/src/with-field.tsx
@@ -1,6 +1,5 @@
 import { useState, ComponentType, FC } from 'react'
 import styled, { css } from 'styled-components'
-import { getColor } from '@titicaca/color-palette'
 import { Container, Text } from '@titicaca/core-elements'
 
 const Label = styled(Text)<{
@@ -13,13 +12,13 @@ const Label = styled(Text)<{
   ${({ focused }) =>
     focused &&
     css`
-      color: rgba(${getColor('blue')});
+      color: var(--color-blue);
     `}
 
   ${({ error }) =>
     error &&
     css`
-      color: rgba(${getColor('red')});
+      color: var(--color-red);
     `}
 
   ${({ absolute }) =>

--- a/packages/listing-filter/src/index.tsx
+++ b/packages/listing-filter/src/index.tsx
@@ -1,14 +1,15 @@
 import styled, { css } from 'styled-components'
 import { MarginPadding, paddingMixin } from '@titicaca/core-elements'
-import { blue, gray, gray200, gray300, white } from '@titicaca/color-palette'
 import { HTMLAttributes, ReactNode, PureComponent } from 'react'
 
 const FilterEntryBase = styled.div<{ active?: boolean; disabled?: boolean }>`
   display: inline-block;
   font-size: 13px;
   line-height: 15px;
-  border: 1px solid ${({ active }) => (active ? blue : gray200)};
-  color: ${({ active }) => (active ? blue : gray200)};
+  border: 1px solid
+    ${({ active }) => (active ? 'var(--color-blue)' : 'var(--color-gray200)')};
+  color: ${({ active }) =>
+    active ? 'var(--color-blue)' : 'var(--color-gray200)'};
   background-repeat: no-repeat;
   border-radius: 2px;
   margin-right: 6px;
@@ -46,8 +47,8 @@ const ExpandingFilterEntryBadge = styled.div`
   height: 18px;
   width: 18px;
   line-height: 18px;
-  background-color: ${blue};
-  color: ${white};
+  background-color: var(--color-blue);
+  color: var(--color-white);
   border-radius: 9px;
   font-size: 12px;
   font-weight: bold;
@@ -107,12 +108,12 @@ const RegularFilterEntry = styled(FilterEntryBase)<{
   ${({ active }) =>
     active
       ? css`
-          color: ${white};
-          background-color: ${blue};
+          color: var(--color-white);
+          background-color: var(--color-blue);
         `
       : css`
-          color: ${gray200};
-          border: solid 1px ${gray200};
+          color: var(--color-gray200);
+          border: solid 1px var(--color-gray200);
         `};
   border-radius: 2px;
 `
@@ -126,11 +127,11 @@ const UnderlineRegularFilterEntry = styled(FilterEntryBase)<{
   padding: 10px;
   font-size: 14px;
   font-weight: bold;
-  color: ${gray300};
+  color: var(--color-gray300);
   ${({ active }) =>
     active &&
     css`
-      color: ${gray};
+      color: var(--color-gray);
 
       &::before {
         content: '';
@@ -139,7 +140,7 @@ const UnderlineRegularFilterEntry = styled(FilterEntryBase)<{
         left: 10px;
         right: 10px;
         height: 2px;
-        background: ${blue};
+        background: var(--color-blue);
       }
     `};
 `
@@ -151,10 +152,10 @@ const PrimaryFilterEntry = styled(FilterEntryBase)`
   background-position: top 5px left 10px;
   border: none;
   border-radius: 2px;
-  background-color: ${blue};
+  background-color: var(--color-blue);
   font-size: 13px;
   font-weight: bold;
-  color: ${white};
+  color: var(--color-white);
 `
 
 interface FilterEntryProps extends HTMLAttributes<HTMLElement> {

--- a/packages/public-header/src/extra-action-item.tsx
+++ b/packages/public-header/src/extra-action-item.tsx
@@ -1,4 +1,3 @@
-import { gray800 } from '@titicaca/color-palette'
 import styled from 'styled-components'
 
 import { MIN_DESKTOP_WIDTH } from './constants'
@@ -7,7 +6,7 @@ export const ExtraActionItem = styled.a`
   text-decoration: none;
   display: inline-flex;
   align-items: center;
-  color: ${gray800};
+  color: var(--color-gray800);
   font-size: 14px;
   padding: 10px 8px;
 

--- a/packages/public-header/src/extra-action-seperator.tsx
+++ b/packages/public-header/src/extra-action-seperator.tsx
@@ -1,4 +1,3 @@
-import { gray100 } from '@titicaca/color-palette'
 import styled from 'styled-components'
 
 import { MIN_DESKTOP_WIDTH } from './constants'
@@ -8,7 +7,7 @@ export const ExtraActionSeperator = styled.div`
   width: 1px;
   margin: 0 2px;
   height: 10px;
-  background-color: ${gray100};
+  background-color: var(--color-gray100);
 
   @media (min-width: ${MIN_DESKTOP_WIDTH}px) {
     height: 14px;

--- a/packages/public-header/src/public-header.tsx
+++ b/packages/public-header/src/public-header.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { white, brightGray } from '@titicaca/color-palette'
 import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 
 import {
@@ -40,10 +39,10 @@ const Wrapper = styled.div<{ visible: boolean }>`
 `
 
 const HeaderFrame = styled.div`
-  background-color: ${white};
+  background-color: var(--color-white);
   display: flex;
   align-items: center;
-  border-bottom: 1px solid ${brightGray};
+  border-bottom: 1px solid var(--color-brightGray);
   padding: 0 6px;
   height: ${HEADER_MOBILE_HEIGHT}px;
 

--- a/packages/static-page-contents/src/index.tsx
+++ b/packages/static-page-contents/src/index.tsx
@@ -1,12 +1,11 @@
 import { useState, useCallback, useEffect } from 'react'
 import styled from 'styled-components'
-import { gray500, gray, blue, brightGray } from '@titicaca/color-palette'
 
 const Contents = styled.div`
   padding: 20px;
   overflow-y: scroll;
   font-size: 16px;
-  color: ${gray500};
+  color: var(--color-gray500);
   line-height: 22px;
   margin: 20px 0;
 
@@ -19,11 +18,11 @@ const Contents = styled.div`
     font-size: 16px;
     font-weight: bold;
     margin-bottom: 10px;
-    color: ${gray};
+    color: var(--color-gray);
   }
 
   font {
-    color: ${gray500} !important;
+    color: var(--color-gray500) !important;
   }
 
   table {
@@ -41,8 +40,8 @@ const Contents = styled.div`
 
   th {
     font-size: 14px;
-    color: ${gray};
-    background-color: ${brightGray};
+    color: var(--color-gray);
+    background-color: var(--color-brightGray);
   }
 
   ul {
@@ -54,7 +53,7 @@ const Contents = styled.div`
   }
 
   strong {
-    color: ${blue} !important;
+    color: var(--color-blue) !important;
   }
 `
 
@@ -63,7 +62,7 @@ const NoContent = styled.div`
   justify-content: center;
   align-items: center;
   height: calc(100vh - 70px);
-  color: ${gray500};
+  color: var(--color-gray500);
 `
 
 export function StaticPageContents({

--- a/packages/triple-document/src/elements/itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react'
 import styled from 'styled-components'
 import { Container, Card, Text, FlexBox, Button } from '@titicaca/core-elements'
-import { gray100, white } from '@titicaca/color-palette'
 import type {
   TransportationType,
   Itinerary,
@@ -44,7 +43,7 @@ const Timeline = styled(FlexBox)`
     content: '';
     position: absolute;
     z-index: -1;
-    border-right: 1px solid ${gray100};
+    border-right: 1px solid var(--color-gray100);
     width: 50%;
     height: 100%;
     right: 50%;
@@ -71,7 +70,7 @@ const Stack = styled(Container)`
 `
 
 const Time = styled(Text)`
-  background-color: ${white};
+  background-color: var(--color-white);
 `
 
 const Duration = styled(Container)`

--- a/packages/triple-document/src/elements/itinerary/badge.ts
+++ b/packages/triple-document/src/elements/itinerary/badge.ts
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components'
-import { purple, white } from '@titicaca/color-palette'
+import { purple } from '@titicaca/color-palette'
 
 import withTypeCircleBadge from './with-type-circle-badge'
 
@@ -40,7 +40,7 @@ export const Badge = styled(BadgeBase)<{
           border: 1px solid ${color};
         `
       : css`
-          color: ${white};
+          color: var(--color-white);
           border: 1px solid ${color};
           background-color: ${color};
         `}
@@ -62,7 +62,7 @@ export const CircleBadge = styled(BadgeBase)<{
     borderless
       ? undefined
       : css`
-          border: 2px solid ${white};
+          border: 2px solid var(--color-white);
         `}
 `
 

--- a/packages/triple-document/src/elements/itinerary/tag-label.ts
+++ b/packages/triple-document/src/elements/itinerary/tag-label.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { gray100, gray, white } from '@titicaca/color-palette'
 
 /**
  * TODO: move to TF/core-elements
@@ -13,13 +12,13 @@ export const TagLabel = styled.div`
   justify-content: center;
   align-items: center;
   position: relative;
-  background-color: ${white};
+  background-color: var(--color-white);
   padding: 5px 1px 6px 3px;
-  color: ${gray};
+  color: var(--color-gray);
   text-transform: none;
   font-weight: 700;
   border-radius: 5px;
-  border: 1px solid ${gray100};
+  border: 1px solid var(--color-gray100);
   border-width: 1px 0 1px 1px;
   z-index: 2;
   font-size: 11px;
@@ -31,10 +30,10 @@ export const TagLabel = styled.div`
   }
 
   &::before {
-    border: 1px solid ${gray100};
+    border: 1px solid var(--color-gray100);
     border-radius: 5px;
     border-width: 1px 1px 0 0;
-    background-color: ${white};
+    background-color: var(--color-white);
     transform: translateX(-50%) translateY(-50%) rotate(45deg);
     top: 50%;
     right: -15px;


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

https://github.com/titicacadev/triple-frontend/issues/1523

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- color-palette 패키지의 getColor는 deprecated 되었고 css variable을 사용하도록 권장하고 있어서, 아직 getColor 함수를 쓰고 있던 곳을 찾아서 변경합니다. 
- `color` prop을 받아서 쓰는 곳은 타입 지원이 필요하기 때문에 아직은 제외합니다.

TF 내부에서만 변경한거라서 breaking change는 아니지만 color-palette 패키지를 없애는 걸 고려해봐야 합니다. 이번 단계에서는 패키지는 유지를 하지만 다음 Major 업데이트 개선 버전에서는 완전히 제거시켜 보고 싶습니다.

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->

- [x] 크로마틱에서 컬러 변화 없는지 확인해야 함