### PR TITLE
[core-elements] Button과 Input 관련 컴포넌트 props 타입 개선

### DIFF
--- a/packages/core-elements/src/elements/button/basic-button.tsx
+++ b/packages/core-elements/src/elements/button/basic-button.tsx
@@ -1,14 +1,14 @@
 import { css } from 'styled-components'
 import { Color } from '@titicaca/color-palette'
 
-import { buttonBaseMixin, ButtonBaseProps } from './button-base'
+import { buttonBaseMixin, ButtonBaseOwnProps } from './button-base'
 
 const BASIC_INVERTED_COLORS: Partial<Record<Color, string>> = {
   blue: '#368fff',
   gray: '#3a3a3a',
 }
 
-export interface BasicButtonProps extends ButtonBaseProps {
+export interface BasicButtonOwnProps extends ButtonBaseOwnProps {
   color?: Color
   /**
    * Compact 버튼을 사용합니다. Normal 및 Basic 버튼에서만 사용할 수 있습니다.
@@ -25,7 +25,7 @@ export const basicButtonMixin = ({
   compact,
   inverted,
   ...props
-}: BasicButtonProps) => css`
+}: BasicButtonOwnProps) => css`
   ${buttonBaseMixin(props)}
   border: 1px solid var(--color-gray200);
   border-radius: 4px;

--- a/packages/core-elements/src/elements/button/button-base.test.tsx
+++ b/packages/core-elements/src/elements/button/button-base.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react'
+
+import { ButtonBase } from './button-base'
+
+import '@testing-library/jest-dom'
+
+test('type attribute 기본값은 button 입니다.', () => {
+  const { getByText } = render(<ButtonBase>Default</ButtonBase>)
+
+  expect(getByText('Default')).toHaveAttribute('type', 'button')
+})
+
+test('type attribute를 변경할 수 있습니다.', () => {
+  const { getByText } = render(
+    <>
+      <ButtonBase type="button">Button</ButtonBase>
+      <ButtonBase type="submit">Submit</ButtonBase>
+      <ButtonBase type="reset">Reset</ButtonBase>
+    </>,
+  )
+
+  expect(getByText('Button')).toHaveAttribute('type', 'button')
+  expect(getByText('Submit')).toHaveAttribute('type', 'submit')
+  expect(getByText('Reset')).toHaveAttribute('type', 'reset')
+})

--- a/packages/core-elements/src/elements/button/button-base.tsx
+++ b/packages/core-elements/src/elements/button/button-base.tsx
@@ -83,5 +83,6 @@ export const buttonBaseMixin = ({
 `
 
 export const ButtonBase = styled.button.attrs((props) => ({
+  /* stylelint-disable-next-line property-no-unknown */
   type: props.type ?? 'button',
 }))(buttonBaseMixin)

--- a/packages/core-elements/src/elements/button/button-base.tsx
+++ b/packages/core-elements/src/elements/button/button-base.tsx
@@ -23,7 +23,7 @@ const SIZES: Record<ButtonSize, ReturnType<typeof css>> = {
   `,
 }
 
-export interface ButtonBaseProps extends PropsWithChildren {
+export interface ButtonBaseOwnProps {
   /**
    * Basic 및 Normal 버튼에서는 항상 `true` 입니다.
    */
@@ -43,6 +43,10 @@ export interface ButtonBaseProps extends PropsWithChildren {
   textColor?: Color
 }
 
+export type ButtonBaseProps = ButtonBaseOwnProps &
+  PropsWithChildren &
+  ButtonHTMLAttributes<HTMLButtonElement>
+
 export const buttonBaseMixin = ({
   bold,
   floated = 'none',
@@ -51,7 +55,7 @@ export const buttonBaseMixin = ({
   lineHeight,
   textAlpha = 1,
   textColor = 'gray',
-}: ButtonBaseProps) => css`
+}: ButtonBaseOwnProps) => css`
   display: inline-block;
   color: rgba(${GetGlobalColor(textColor)}, ${textAlpha});
   float: ${floated};
@@ -78,7 +82,6 @@ export const buttonBaseMixin = ({
   }
 `
 
-export const ButtonBase = styled.button.attrs({
-  /* stylelint-disable-next-line property-no-unknown */
-  type: 'button' as ButtonHTMLAttributes<HTMLButtonElement>['type'],
-})(buttonBaseMixin)
+export const ButtonBase = styled.button.attrs((props) => ({
+  type: props.type ?? 'button',
+}))(buttonBaseMixin)

--- a/packages/core-elements/src/elements/button/button.tsx
+++ b/packages/core-elements/src/elements/button/button.tsx
@@ -1,18 +1,18 @@
-import { ButtonHTMLAttributes } from 'react'
+import { ButtonHTMLAttributes, PropsWithChildren } from 'react'
 import styled from 'styled-components'
 
-import { basicButtonMixin, BasicButtonProps } from './basic-button'
+import { basicButtonMixin, BasicButtonOwnProps } from './basic-button'
 import { ButtonBase } from './button-base'
 import { ButtonContainer } from './button-container'
 import { ButtonGroup } from './button-group'
 import { ButtonIcon } from './button-icon'
-import { iconButtonMixin, IconButtonProps } from './icon-button'
-import { normalButtonMixin, NormalButtonProps } from './normal-button'
+import { iconButtonMixin, IconButtonOwnProps } from './icon-button'
+import { normalButtonMixin, NormalButtonOwnProps } from './normal-button'
 
 export interface ButtonOwnProps
-  extends BasicButtonProps,
-    Omit<IconButtonProps, 'icon'>,
-    NormalButtonProps {
+  extends BasicButtonOwnProps,
+    Omit<IconButtonOwnProps, 'icon'>,
+    NormalButtonOwnProps {
   /**
    * Basic 유형 버튼을 사용합니다.
    */
@@ -20,10 +20,11 @@ export interface ButtonOwnProps
   /**
    * Block Icon 유형 버튼을 사용합니다.
    */
-  icon?: IconButtonProps['icon']
+  icon?: IconButtonOwnProps['icon']
 }
 
 export type ButtonProps = ButtonOwnProps &
+  PropsWithChildren &
   ButtonHTMLAttributes<HTMLButtonElement>
 
 const ButtonComponent = styled(ButtonBase)<ButtonOwnProps>((props) => {

--- a/packages/core-elements/src/elements/button/icon-button.tsx
+++ b/packages/core-elements/src/elements/button/icon-button.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components'
 
-import { buttonBaseMixin, ButtonBaseProps } from './button-base'
+import { buttonBaseMixin, ButtonBaseOwnProps } from './button-base'
 import { ButtonSize } from './types'
 
 const ICON_BUTTON_URLS = {
@@ -19,7 +19,7 @@ const ICON_PADDINGS: Partial<Record<ButtonSize, ReturnType<typeof css>>> = {
   tiny: css({ padding: '12px' }),
 }
 
-export interface IconButtonProps extends ButtonBaseProps {
+export interface IconButtonOwnProps extends ButtonBaseOwnProps {
   icon: Icon
 }
 
@@ -27,7 +27,7 @@ export const iconButtonMixin = ({
   icon,
   size = 'tiny',
   ...props
-}: IconButtonProps) => css`
+}: IconButtonOwnProps) => css`
   ${buttonBaseMixin({ size, ...props })}
   ${ICON_PADDINGS[size]}
 

--- a/packages/core-elements/src/elements/button/index.ts
+++ b/packages/core-elements/src/elements/button/index.ts
@@ -1,1 +1,2 @@
+export * from './button-base'
 export * from './button'

--- a/packages/core-elements/src/elements/button/normal-button.tsx
+++ b/packages/core-elements/src/elements/button/normal-button.tsx
@@ -1,7 +1,7 @@
 import { css } from 'styled-components'
 import { Color, getColor } from '@titicaca/color-palette'
 
-import { buttonBaseMixin, ButtonBaseProps } from './button-base'
+import { buttonBaseMixin, ButtonBaseOwnProps } from './button-base'
 import { ButtonSize } from './types'
 
 const NORMAL_PADDINGS: Partial<Record<ButtonSize, ReturnType<typeof css>>> = {
@@ -16,7 +16,7 @@ const COMPACT_NORMAL_PADDINGS: Partial<
   tiny: css({ padding: '9px 15px' }),
 }
 
-export interface NormalButtonProps extends ButtonBaseProps {
+export interface NormalButtonOwnProps extends ButtonBaseOwnProps {
   borderRadius?: number
   /**
    * Compact 버튼을 사용합니다. Normal 및 Basic 버튼에서만 사용할 수 있습니다.
@@ -31,7 +31,7 @@ export const normalButtonMixin = ({
   color = 'blue',
   size = 'tiny',
   ...props
-}: NormalButtonProps) => css`
+}: NormalButtonOwnProps) => css`
   ${buttonBaseMixin({ size, ...props })}
   border-radius: ${borderRadius ? `${borderRadius}px` : undefined};
   background-color: rgba(${getColor(color)});

--- a/packages/core-elements/src/elements/checkbox/checkbox-base.tsx
+++ b/packages/core-elements/src/elements/checkbox/checkbox-base.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes } from 'react'
+import { forwardRef, InputHTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { useVisuallyHidden } from '@react-aria/visually-hidden'
 
@@ -41,31 +41,35 @@ export interface CheckboxBaseProps
   variant?: CheckboxVariant
 }
 
-export const CheckboxBase = ({
-  variant = 'square',
-  ...props
-}: CheckboxBaseProps) => {
-  const { visuallyHiddenProps } = useVisuallyHidden()
+export const CheckboxBase = forwardRef<HTMLInputElement, CheckboxBaseProps>(
+  function CheckboxBase({ variant = 'square', ...props }, ref) {
+    const { visuallyHiddenProps } = useVisuallyHidden()
 
-  return (
-    <CheckboxBaseWrapper>
-      <CheckboxBaseInput type="checkbox" {...visuallyHiddenProps} {...props} />
-      <CheckboxBaseControl variant={variant}>
-        <CheckboxBaseSvg
-          width="14"
-          height="10"
-          viewBox="0 0 14 10"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          focusable={false}
-          aria-hidden
-        >
-          <path
-            d="M12.1893 0.251888C12.4644 -0.0577739 12.9385 -0.0857889 13.2481 0.189315C13.5296 0.43941 13.5784 0.853921 13.3782 1.15987L13.3107 1.24813L6.20347 9.24813C5.94894 9.53464 5.52525 9.57933 5.21887 9.36885L5.13077 9.29804L0.237987 4.72682C-0.0646829 4.44405 -0.0808087 3.96945 0.20197 3.66678C0.459041 3.39162 0.874642 3.35328 1.17548 3.56104L1.26202 3.63076L5.593 7.67601L12.1893 0.251888Z"
-            fill="white"
-          />
-        </CheckboxBaseSvg>
-      </CheckboxBaseControl>
-    </CheckboxBaseWrapper>
-  )
-}
+    return (
+      <CheckboxBaseWrapper>
+        <CheckboxBaseInput
+          ref={ref}
+          type="checkbox"
+          {...visuallyHiddenProps}
+          {...props}
+        />
+        <CheckboxBaseControl variant={variant}>
+          <CheckboxBaseSvg
+            width="14"
+            height="10"
+            viewBox="0 0 14 10"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable={false}
+            aria-hidden
+          >
+            <path
+              d="M12.1893 0.251888C12.4644 -0.0577739 12.9385 -0.0857889 13.2481 0.189315C13.5296 0.43941 13.5784 0.853921 13.3782 1.15987L13.3107 1.24813L6.20347 9.24813C5.94894 9.53464 5.52525 9.57933 5.21887 9.36885L5.13077 9.29804L0.237987 4.72682C-0.0646829 4.44405 -0.0808087 3.96945 0.20197 3.66678C0.459041 3.39162 0.874642 3.35328 1.17548 3.56104L1.26202 3.63076L5.593 7.67601L12.1893 0.251888Z"
+              fill="white"
+            />
+          </CheckboxBaseSvg>
+        </CheckboxBaseControl>
+      </CheckboxBaseWrapper>
+    )
+  },
+)

--- a/packages/core-elements/src/elements/checkbox/checkbox-base.tsx
+++ b/packages/core-elements/src/elements/checkbox/checkbox-base.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler } from 'react'
+import { InputHTMLAttributes } from 'react'
 import styled from 'styled-components'
 import { useVisuallyHidden } from '@react-aria/visually-hidden'
 
@@ -36,33 +36,20 @@ const CheckboxBaseSvg = styled.svg`
   left: 6px;
 `
 
-export interface CheckboxBaseProps {
+export interface CheckboxBaseProps
+  extends InputHTMLAttributes<HTMLInputElement> {
   variant?: CheckboxVariant
-  name?: string
-  checked?: boolean
-  value?: string
-  onChange?: ChangeEventHandler<HTMLInputElement>
 }
 
 export const CheckboxBase = ({
   variant = 'square',
-  name,
-  checked,
-  value,
-  onChange,
+  ...props
 }: CheckboxBaseProps) => {
   const { visuallyHiddenProps } = useVisuallyHidden()
 
   return (
     <CheckboxBaseWrapper>
-      <CheckboxBaseInput
-        {...visuallyHiddenProps}
-        type="checkbox"
-        name={name}
-        checked={checked}
-        value={value}
-        onChange={onChange}
-      />
+      <CheckboxBaseInput type="checkbox" {...visuallyHiddenProps} {...props} />
       <CheckboxBaseControl variant={variant}>
         <CheckboxBaseSvg
           width="14"

--- a/packages/core-elements/src/elements/checkbox/checkbox.tsx
+++ b/packages/core-elements/src/elements/checkbox/checkbox.tsx
@@ -29,6 +29,7 @@ export const Checkbox = ({
   checked,
   value,
   onChange,
+  ...props
 }: CheckboxProps) => {
   const group = useCheckboxGroup()
 
@@ -47,9 +48,13 @@ export const Checkbox = ({
     <CheckboxLabel>
       <CheckboxText>{children}</CheckboxText>
       <CheckboxBase
+        {...props}
         variant={variant}
         name={name ?? group?.name}
-        checked={checked ?? (value ? group?.value?.includes(value) : undefined)}
+        checked={
+          checked ??
+          (value ? group?.value?.includes(value.toString()) : undefined)
+        }
         value={value}
         onChange={handleChange}
       />

--- a/packages/core-elements/src/elements/checkbox/checkbox.tsx
+++ b/packages/core-elements/src/elements/checkbox/checkbox.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, PropsWithChildren } from 'react'
+import { ChangeEventHandler, forwardRef, PropsWithChildren } from 'react'
 import styled from 'styled-components'
 
 import { Text } from '../text'
@@ -22,42 +22,40 @@ const CheckboxText = styled(Text)`
 
 export interface CheckboxProps extends CheckboxBaseProps, PropsWithChildren {}
 
-export const Checkbox = ({
-  children,
-  variant = 'square',
-  name,
-  checked,
-  value,
-  onChange,
-  ...props
-}: CheckboxProps) => {
-  const group = useCheckboxGroup()
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  function Checkbox(
+    { children, variant = 'square', name, checked, value, onChange, ...props },
+    ref,
+  ) {
+    const group = useCheckboxGroup()
 
-  const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    if (group) {
-      const nextValue = event.target.checked
-        ? group.value.concat(event.target.value)
-        : group.value.filter((value) => event.target.value !== value)
-      group?.onChange?.(nextValue)
-    } else {
-      onChange?.(event)
+    const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+      if (group) {
+        const nextValue = event.target.checked
+          ? group.value.concat(event.target.value)
+          : group.value.filter((value) => event.target.value !== value)
+        group?.onChange?.(nextValue)
+      } else {
+        onChange?.(event)
+      }
     }
-  }
 
-  return (
-    <CheckboxLabel>
-      <CheckboxText>{children}</CheckboxText>
-      <CheckboxBase
-        {...props}
-        variant={variant}
-        name={name ?? group?.name}
-        checked={
-          checked ??
-          (value ? group?.value?.includes(value.toString()) : undefined)
-        }
-        value={value}
-        onChange={handleChange}
-      />
-    </CheckboxLabel>
-  )
-}
+    return (
+      <CheckboxLabel>
+        <CheckboxText>{children}</CheckboxText>
+        <CheckboxBase
+          {...props}
+          ref={ref}
+          variant={variant}
+          name={name ?? group?.name}
+          checked={
+            checked ??
+            (value ? group?.value?.includes(value.toString()) : undefined)
+          }
+          value={value}
+          onChange={handleChange}
+        />
+      </CheckboxLabel>
+    )
+  },
+)

--- a/packages/core-elements/src/elements/confirm-selector/confirm-selector.tsx
+++ b/packages/core-elements/src/elements/confirm-selector/confirm-selector.tsx
@@ -24,21 +24,12 @@ export interface ConfirmSelectorProps
 
 export const ConfirmSelector = ({
   children,
-  name,
-  checked,
-  value,
-  onChange,
+  ...props
 }: ConfirmSelectorProps) => {
   return (
     <ConfirmSelectorLabel>
       <ConfirmSelectorText>{children}</ConfirmSelectorText>
-      <CheckboxBase
-        variant="round"
-        name={name}
-        checked={checked}
-        value={value}
-        onChange={onChange}
-      />
+      <CheckboxBase {...props} variant="round" />
     </ConfirmSelectorLabel>
   )
 }

--- a/packages/core-elements/src/elements/confirm-selector/confirm-selector.tsx
+++ b/packages/core-elements/src/elements/confirm-selector/confirm-selector.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react'
+import { forwardRef, PropsWithChildren } from 'react'
 import styled from 'styled-components'
 
 import { CheckboxBase, CheckboxBaseProps } from '../checkbox'
@@ -22,14 +22,14 @@ export interface ConfirmSelectorProps
   extends Omit<CheckboxBaseProps, 'variant'>,
     PropsWithChildren {}
 
-export const ConfirmSelector = ({
-  children,
-  ...props
-}: ConfirmSelectorProps) => {
+export const ConfirmSelector = forwardRef<
+  HTMLInputElement,
+  ConfirmSelectorProps
+>(function ConfirmSelector({ children, ...props }, ref) {
   return (
     <ConfirmSelectorLabel>
       <ConfirmSelectorText>{children}</ConfirmSelectorText>
-      <CheckboxBase {...props} variant="round" />
+      <CheckboxBase {...props} ref={ref} variant="round" />
     </ConfirmSelectorLabel>
   )
-}
+})

--- a/packages/core-elements/src/elements/gender-selector/gender-selector.tsx
+++ b/packages/core-elements/src/elements/gender-selector/gender-selector.tsx
@@ -1,20 +1,12 @@
-import { RadioGroup } from '../radio'
+import { RadioGroup, RadioGroupProps } from '../radio'
 
 import { GenderSelectorItem } from './gender-selector-item'
 
-export interface GenderSelectorProps {
-  name?: string
-  value?: string
-  onChange?: (value: string) => void
-}
+export type GenderSelectorProps = Omit<RadioGroupProps, 'children'>
 
-export const GenderSelector = ({
-  name,
-  value,
-  onChange,
-}: GenderSelectorProps) => {
+export const GenderSelector = ({ ...props }: GenderSelectorProps) => {
   return (
-    <RadioGroup name={name} value={value} onChange={onChange}>
+    <RadioGroup {...props}>
       <GenderSelectorItem value="MALE">남자</GenderSelectorItem>
       <GenderSelectorItem value="FEMALE">여자</GenderSelectorItem>
     </RadioGroup>

--- a/packages/core-elements/src/elements/radio/radio-base.tsx
+++ b/packages/core-elements/src/elements/radio/radio-base.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler } from 'react'
+import { InputHTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 const RadioInput = styled.input`
@@ -28,26 +28,8 @@ const RadioInput = styled.input`
   }
 `
 
-export interface RadioBaseProps {
-  name?: string
-  checked?: boolean
-  value?: string
-  onChange?: ChangeEventHandler<HTMLInputElement>
-}
+export type RadioBaseProps = InputHTMLAttributes<HTMLInputElement>
 
-export const RadioBase = ({
-  name,
-  checked,
-  value,
-  onChange,
-}: RadioBaseProps) => {
-  return (
-    <RadioInput
-      type="radio"
-      name={name}
-      checked={checked}
-      value={value}
-      onChange={onChange}
-    />
-  )
+export const RadioBase = (props: RadioBaseProps) => {
+  return <RadioInput type="radio" {...props} />
 }

--- a/packages/core-elements/src/elements/radio/radio-base.tsx
+++ b/packages/core-elements/src/elements/radio/radio-base.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes } from 'react'
+import { forwardRef, InputHTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 const RadioInput = styled.input`
@@ -30,6 +30,8 @@ const RadioInput = styled.input`
 
 export type RadioBaseProps = InputHTMLAttributes<HTMLInputElement>
 
-export const RadioBase = (props: RadioBaseProps) => {
-  return <RadioInput type="radio" {...props} />
-}
+export const RadioBase = forwardRef<HTMLInputElement, RadioBaseProps>(
+  function RadioBase(props, ref) {
+    return <RadioInput ref={ref} type="radio" {...props} />
+  },
+)

--- a/packages/core-elements/src/elements/radio/radio.tsx
+++ b/packages/core-elements/src/elements/radio/radio.tsx
@@ -28,6 +28,7 @@ export const Radio = ({
   checked,
   value,
   onChange,
+  ...props
 }: RadioProps) => {
   const group = useRadioGroup()
 
@@ -43,8 +44,9 @@ export const Radio = ({
     <RadioLabel>
       <RadioText size="large">{children}</RadioText>
       <RadioBase
+        {...props}
         name={name ?? group?.name}
-        checked={checked ?? group?.value === value}
+        checked={checked ?? (value ? group?.value === value : undefined)}
         value={value}
         onChange={handleChange}
       />

--- a/packages/core-elements/src/elements/radio/radio.tsx
+++ b/packages/core-elements/src/elements/radio/radio.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, PropsWithChildren } from 'react'
+import { ChangeEventHandler, forwardRef, PropsWithChildren } from 'react'
 import styled from 'styled-components'
 
 import { Text } from '../text'
@@ -22,14 +22,10 @@ const RadioText = styled(Text)`
 
 export type RadioProps = RadioBaseProps & PropsWithChildren
 
-export const Radio = ({
-  children,
-  name,
-  checked,
-  value,
-  onChange,
-  ...props
-}: RadioProps) => {
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
+  { children, name, checked, value, onChange, ...props },
+  ref,
+) {
   const group = useRadioGroup()
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
@@ -45,6 +41,7 @@ export const Radio = ({
       <RadioText size="large">{children}</RadioText>
       <RadioBase
         {...props}
+        ref={ref}
         name={name ?? group?.name}
         checked={checked ?? (value ? group?.value === value : undefined)}
         value={value}
@@ -52,4 +49,4 @@ export const Radio = ({
       />
     </RadioLabel>
   )
-}
+})

--- a/packages/core-elements/src/elements/select/select.tsx
+++ b/packages/core-elements/src/elements/select/select.tsx
@@ -1,4 +1,4 @@
-import { SelectHTMLAttributes } from 'react'
+import { forwardRef, SelectHTMLAttributes } from 'react'
 import styled from 'styled-components'
 
 import {
@@ -41,85 +41,93 @@ const Svg = styled.svg`
 
 export type OptionValueType = string | number | readonly string[]
 
-export interface SelectOption<Value extends OptionValueType> {
+export interface SelectOption {
   label: string
-  value: Value
+  value: OptionValueType
 }
 
-export interface SelectOwnProps<Value extends OptionValueType> {
-  value?: Value
-  options?: SelectOption<Value>[]
+export interface SelectOwnProps {
+  value?: OptionValueType
+  options?: SelectOption[]
   placeholder?: string
   label?: string
   error?: string | boolean
   help?: string
 }
 
-export type SelectProps<Value extends OptionValueType> = SelectOwnProps<Value> &
+export type SelectProps = SelectOwnProps &
   SelectHTMLAttributes<HTMLSelectElement>
 
-export const Select = <Value extends OptionValueType>({
-  value,
-  placeholder,
-  options,
-  label,
-  error,
-  help,
-  onBlur,
-  onFocus,
-  ...props
-}: SelectProps<Value>) => {
-  const formFieldState = useFormFieldState({ onBlur, onFocus })
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  (
+    {
+      value,
+      placeholder,
+      options,
+      label,
+      error,
+      help,
+      onBlur,
+      onFocus,
+      ...props
+    },
+    ref,
+  ) => {
+    const formFieldState = useFormFieldState({ onBlur, onFocus })
 
-  const hasHelp = !!help
-  const isError = !!error
+    const hasHelp = !!help
+    const isError = !!error
 
-  return (
-    <FormFieldContext.Provider
-      value={{
-        ...formFieldState,
-        isDisabled: !!props.disabled,
-        isError,
-        isRequired: !!props.required,
-      }}
-    >
-      {label ? <FormFieldLabel>{label}</FormFieldLabel> : null}
-      <Container position="relative">
-        <BaseSelect
-          id={formFieldState.inputId}
-          value={value}
-          aria-describedby={hasHelp ? formFieldState.descriptionId : undefined}
-          aria-errormessage={isError ? formFieldState.errorId : undefined}
-          aria-invalid={isError}
-          {...props}
-        >
-          {placeholder ? <option value="">{placeholder}</option> : null}
-          {options?.map(({ label, value }, idx) => (
-            <option key={idx} value={value}>
-              {label}
-            </option>
-          ))}
-        </BaseSelect>
-        <Svg
-          width="10"
-          height="20"
-          viewBox="0 0 10 20"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M9 8.5L5 12.5L1 8.5"
-            stroke="#3A3A3A"
-            strokeOpacity="0.3"
-            strokeLinejoin="round"
-          />
-        </Svg>
-      </Container>
-      {error ? (
-        <FormFieldError>{error}</FormFieldError>
-      ) : help ? (
-        <FormFieldHelp>{help}</FormFieldHelp>
-      ) : null}
-    </FormFieldContext.Provider>
-  )
-}
+    return (
+      <FormFieldContext.Provider
+        value={{
+          ...formFieldState,
+          isDisabled: !!props.disabled,
+          isError,
+          isRequired: !!props.required,
+        }}
+      >
+        {label ? <FormFieldLabel>{label}</FormFieldLabel> : null}
+        <Container position="relative">
+          <BaseSelect
+            ref={ref}
+            id={formFieldState.inputId}
+            value={value}
+            aria-describedby={
+              hasHelp ? formFieldState.descriptionId : undefined
+            }
+            aria-errormessage={isError ? formFieldState.errorId : undefined}
+            aria-invalid={isError}
+            {...props}
+          >
+            {placeholder ? <option value="">{placeholder}</option> : null}
+            {options?.map(({ label, value }, idx) => (
+              <option key={idx} value={value}>
+                {label}
+              </option>
+            ))}
+          </BaseSelect>
+          <Svg
+            width="10"
+            height="20"
+            viewBox="0 0 10 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M9 8.5L5 12.5L1 8.5"
+              stroke="#3A3A3A"
+              strokeOpacity="0.3"
+              strokeLinejoin="round"
+            />
+          </Svg>
+        </Container>
+        {error ? (
+          <FormFieldError>{error}</FormFieldError>
+        ) : help ? (
+          <FormFieldHelp>{help}</FormFieldHelp>
+        ) : null}
+      </FormFieldContext.Provider>
+    )
+  },
+)


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

[core-elements] Button과 Input 관련 컴포넌트 props 타입 개선

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- Button, ButtonBase의 Props와 OwnProps 분리
- ButtonBase의 type attribute가 변경되지 않던 문제 수정
- Checkbox, Radio 컴포넌트에 InputHTMLAttributes 타입 추가
- GenderSelector, ConfirmSelector Props 타입도 extend
- Input 관련 컴포넌트에 forwardRef 추가