### PR TITLE
peer dependencies 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6079,18 +6079,212 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.3.1",
-      "license": "MIT"
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.0.5.tgz",
+      "integrity": "sha512-F3KLtiDrUslAZhTYTh8Zk5ZaavbYwLUn3NYPBnOjAXU8hWm0QVGVzKIOuURQ098ofRU4e9oglf3Sj9pFx5nI5w=="
     },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "12.3.1",
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.5.tgz",
+      "integrity": "sha512-YO691dxHlviy6H0eghgwqn+5kU9J3iQnKERHTDSppqjjGDBl6ab4wz9XfI5AhljjkaTg3TknHoIEWFDoZ4Ve8g==",
       "cpu": [
-        "x64"
+        "arm"
       ],
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.5.tgz",
+      "integrity": "sha512-ugbwffkUmp8cd2afehDC8LtQeFUxElRUBBngfB5UYSWBx18HW4OgzkPFIY8jUBH16zifvGZWXbICXJWDHrOLtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.5.tgz",
+      "integrity": "sha512-mshlh8QOtOalfZbc17uNAftWgqHTKnrv6QUwBe+mpGz04eqsSUzVz1JGZEdIkmuDxOz00cK2NPoc+VHDXh99IQ==",
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.5.tgz",
+      "integrity": "sha512-SfigOKW4Z2UB3ruUPyvrlDIkcJq1hiw1wvYApWugD+tQsAkYZKEoz+/8emCmeYZ6Gwgi1WHV+z52Oj8u7bEHPg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.5.tgz",
+      "integrity": "sha512-0NJg8HZr4yG8ynmMGFXQf+Mahvq4ZgBmUwSlLXXymgxEQgH17erH/LoR69uITtW+KTsALgk9axEt5AAabM4ucg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.5.tgz",
+      "integrity": "sha512-Cye+h3oDT3NDWjACMlRaolL8fokpKie34FlPj9nfoW7bYKmoMBY1d4IO/GgBF+5xEl7HkH0Ny/qex63vQ0pN+A==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.5.tgz",
+      "integrity": "sha512-5BfDS/VoRDR5QUGG9oedOCEZGmV2zxUVFYLUJVPMSMeIgqkjxWQBiG2BUHZI6/LGk9yvHmjx7BTvtBCLtRg6IQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.5.tgz",
+      "integrity": "sha512-xenvqlXz+KxVKAB1YR723gnVNszpsCvKZkiFFaAYqDGJ502YuqU2fwLsaSm/ASRizNcBYeo9HPLTyc3r/9cdMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.5.tgz",
+      "integrity": "sha512-9Ahi1bbdXwhrWQmOyoTod23/hhK05da/FzodiNqd6drrMl1y7+RujoEcU8Dtw3H1mGWB+yuTlWo8B4Iba8hqiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.5.tgz",
+      "integrity": "sha512-V+1mnh49qmS9fOZxVRbzjhBEz9IUGJ7AQ80JPWAYQM5LI4TxfdiF4APLPvJ52rOmNeTqnVz1bbKtVOso+7EZ4w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.5.tgz",
+      "integrity": "sha512-wRE9rkp7I+/3Jf2T9PFIJOKq3adMWYEFkPOA7XAkUfYbQHlDJm/U5cVCWUsKByyQq5RThwufI91sgd19MfxRxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.5.tgz",
+      "integrity": "sha512-Q1XQSLEhFuFhkKFdJIGt7cYQ4T3u6P5wrtUNreg5M+7P+fjSiC8+X+Vjcw+oebaacsdl0pWZlK+oACGafush1w==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.5.tgz",
+      "integrity": "sha512-t5gRblrwwiNZP6cT7NkxlgxrFgHWtv9ei5vUraCLgBqzvIsa7X+PnarZUeQCXqz6Jg9JSGGT9j8lvzD97UqeJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "peer": true,
       "engines": {
@@ -6802,6 +6996,23 @@
         "rollup": "^2.53.1"
       }
     },
+    "node_modules/@rollup/plugin-virtual": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.0.tgz",
+      "integrity": "sha512-K9KORe1myM62o0lKkNR4MmCxjwuAXsZEtIHpaILfv4kILXTOrXt/R2ha7PzMcCHPYdnkWPiBZK8ed4Zr3Ll5lQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
       "dev": true,
@@ -6831,300 +7042,6 @@
         "zen-observable": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@sentry/browser": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/core": "7.16.0",
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/cli": {
-      "version": "1.74.5",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "mkdirp": "^0.5.5",
-        "node-fetch": "^2.6.7",
-        "npmlog": "^4.1.2",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "sentry-cli": "bin/sentry-cli"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@sentry/cli/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/core/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/integrations": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "localforage": "^1.8.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/integrations/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/nextjs": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/plugin-sucrase": "4.0.4",
-        "@sentry/core": "7.16.0",
-        "@sentry/integrations": "7.16.0",
-        "@sentry/node": "7.16.0",
-        "@sentry/react": "7.16.0",
-        "@sentry/tracing": "7.16.0",
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "@sentry/webpack-plugin": "1.19.0",
-        "chalk": "3.0.0",
-        "rollup": "2.78.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "next": "^10.0.8 || ^11.0 || ^12.0",
-        "react": "15.x || 16.x || 17.x || 18.x",
-        "webpack": ">= 4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/chalk": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@sentry/nextjs/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/nextjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/node": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/core": "7.16.0",
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/cookie": {
-      "version": "0.4.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/react": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/browser": "7.16.0",
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": "15.x || 16.x || 17.x || 18.x"
-      }
-    },
-    "node_modules/@sentry/react/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/tracing": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.16.0",
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/tracing/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/types": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "7.16.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sentry/types": "7.16.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/utils/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/@sentry/webpack-plugin": {
-      "version": "1.19.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/cli": "^1.74.4"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -13354,15 +13271,17 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.4.11",
-      "license": "MIT",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@swc/helpers/node_modules/tslib": {
-      "version": "2.4.0",
-      "license": "0BSD"
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/@swc/jest": {
       "version": "0.2.23",
@@ -17239,6 +17158,11 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -28639,42 +28563,42 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "12.3.1",
-      "license": "MIT",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.0.5.tgz",
+      "integrity": "sha512-awpc3DkphyKydwCotcBnuKwh6hMqkT5xdiBK4OatJtOZurDPBYLP62jtM2be/4OunpmwIbsS0Eyv+ZGU97ciEg==",
       "dependencies": {
-        "@next/env": "12.3.1",
-        "@swc/helpers": "0.4.11",
+        "@next/env": "13.0.5",
+        "@swc/helpers": "0.4.14",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.0.7",
-        "use-sync-external-store": "1.2.0"
+        "styled-jsx": "5.1.0"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=14.6.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.3.1",
-        "@next/swc-android-arm64": "12.3.1",
-        "@next/swc-darwin-arm64": "12.3.1",
-        "@next/swc-darwin-x64": "12.3.1",
-        "@next/swc-freebsd-x64": "12.3.1",
-        "@next/swc-linux-arm-gnueabihf": "12.3.1",
-        "@next/swc-linux-arm64-gnu": "12.3.1",
-        "@next/swc-linux-arm64-musl": "12.3.1",
-        "@next/swc-linux-x64-gnu": "12.3.1",
-        "@next/swc-linux-x64-musl": "12.3.1",
-        "@next/swc-win32-arm64-msvc": "12.3.1",
-        "@next/swc-win32-ia32-msvc": "12.3.1",
-        "@next/swc-win32-x64-msvc": "12.3.1"
+        "@next/swc-android-arm-eabi": "13.0.5",
+        "@next/swc-android-arm64": "13.0.5",
+        "@next/swc-darwin-arm64": "13.0.5",
+        "@next/swc-darwin-x64": "13.0.5",
+        "@next/swc-freebsd-x64": "13.0.5",
+        "@next/swc-linux-arm-gnueabihf": "13.0.5",
+        "@next/swc-linux-arm64-gnu": "13.0.5",
+        "@next/swc-linux-arm64-musl": "13.0.5",
+        "@next/swc-linux-x64-gnu": "13.0.5",
+        "@next/swc-linux-x64-musl": "13.0.5",
+        "@next/swc-win32-arm64-msvc": "13.0.5",
+        "@next/swc-win32-ia32-msvc": "13.0.5",
+        "@next/swc-win32-x64-msvc": "13.0.5"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
         "node-sass": "^6.0.0 || ^7.0.0",
-        "react": "^17.0.2 || ^18.0.0-0",
-        "react-dom": "^17.0.2 || ^18.0.0-0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -34260,8 +34184,12 @@
       }
     },
     "node_modules/styled-jsx": {
-      "version": "5.0.7",
-      "license": "MIT",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+      "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -36270,13 +36198,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/util": {
       "version": "0.11.1",
       "dev": true,
@@ -37535,7 +37456,9 @@
       "license": "MIT",
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
-        "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+        "next": "^13.0",
+        "react": "^18.0",
+        "react-dom": "^18.0"
       }
     },
     "packages/action-sheet": {
@@ -37554,8 +37477,9 @@
         "@types/react-transition-group": "^4.4.4"
       },
       "peerDependencies": {
-        "react": ">=16.3.0",
-        "styled-components": ">=4.4.1 < 6"
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/ad-banners": {
@@ -37571,7 +37495,10 @@
         "@titicaca/router": "^10.3.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/app-banner": {
@@ -37580,6 +37507,11 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/app-installation-cta": {
@@ -37595,7 +37527,10 @@
         "@types/react-transition-group": "^4.4.4"
       },
       "peerDependencies": {
-        "@titicaca/web-storage": "*"
+        "@titicaca/web-storage": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/author": {
@@ -37606,6 +37541,11 @@
         "@titicaca/color-palette": "^10.3.0",
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/type-definitions": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/booking-completion": {
@@ -37620,7 +37560,10 @@
       },
       "peerDependencies": {
         "@titicaca/modals": "*",
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/carousel": {
@@ -37636,7 +37579,10 @@
         "@titicaca/type-definitions": "^10.3.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/chat": {
@@ -37652,6 +37598,11 @@
       },
       "devDependencies": {
         "@types/isomorphic-fetch": "^0.0.36"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/chat/node_modules/@titicaca/triple-web-to-native-interfaces": {
@@ -37675,6 +37626,11 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/core-elements": {
@@ -37696,9 +37652,9 @@
         "@types/react-transition-group": "^4.4.4"
       },
       "peerDependencies": {
-        "react": "*",
-        "react-dom": "*",
-        "styled-components": ">=4.4.1 < 6"
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/date-picker": {
@@ -37710,6 +37666,11 @@
         "@titicaca/fetcher": "^10.3.0",
         "moment": "^2.24.0",
         "react-day-picker": "^7.4.10"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/directions-finder": {
@@ -37723,7 +37684,10 @@
         "@titicaca/react-triple-client-interfaces": "^10.3.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/drawer-button": {
@@ -37732,6 +37696,11 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/fetcher": {
@@ -37743,18 +37712,299 @@
         "universal-cookie": "^4.0.3"
       },
       "devDependencies": {
-        "@sentry/nextjs": "7.16.0",
+        "@sentry/nextjs": "7.22.0",
         "@types/node-fetch": "^2.5.12",
         "isomorphic-fetch": "^2.2.1",
-        "next": "12.3.1",
+        "next": "13.0.5",
         "node-fetch": "^2.6.7"
       },
       "peerDependencies": {
-        "@sentry/nextjs": "*",
+        "@sentry/nextjs": "^7.17.1",
         "@titicaca/view-utilities": "*",
-        "next": "^9.3.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
+        "next": "^13.0",
         "ts-custom-error": "^3.2.0",
         "universal-cookie": "^4.0.3"
+      }
+    },
+    "packages/fetcher/node_modules/@sentry/browser": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.22.0.tgz",
+      "integrity": "sha512-8MA+f46+T3G7fb4BYYX9Wl3bMDloG5a3Ng0GWdBeq6DE2tXVHeCvba8Yrrcnn1qFHpmnOn5Nz4xWBUDs3uBFxA==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/core": "7.22.0",
+        "@sentry/types": "7.22.0",
+        "@sentry/utils": "7.22.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/fetcher/node_modules/@sentry/cli": {
+      "version": "1.74.6",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.74.6.tgz",
+      "integrity": "sha512-pJ7JJgozyjKZSTjOGi86chIngZMLUlYt2HOog+OJn+WGvqEkVymu8m462j1DiXAnex9NspB4zLLNuZ/R6rTQHg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "mkdirp": "^0.5.5",
+        "node-fetch": "^2.6.7",
+        "npmlog": "^4.1.2",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "packages/fetcher/node_modules/@sentry/core": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.22.0.tgz",
+      "integrity": "sha512-qYJiJrL1mfQQln84mNunBRUkXq7xDGQQoNh4Sz9VYP5698va51zmS5BLYRCZ5CkPwRYNuhUqlUXN7bpYGYOOIA==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "7.22.0",
+        "@sentry/utils": "7.22.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/fetcher/node_modules/@sentry/integrations": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.22.0.tgz",
+      "integrity": "sha512-yuT5NdSSi3dT2yY9SIFRET4sjO2MeX5ButUUH1KD7KGJqYumq+HGZPS0huIe4/McSxEkxhWM/XvvMMhfvNhX5w==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "7.22.0",
+        "@sentry/utils": "7.22.0",
+        "localforage": "^1.8.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/fetcher/node_modules/@sentry/nextjs": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-7.22.0.tgz",
+      "integrity": "sha512-ztABScQJrfJYEO6eZ0ZCNa+C+whI6v5jWfeXcwJLTcMpjVZ9VqneJwITEIQChKiqmAWwcyXV6m8bO4Q6+d1avA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/plugin-sucrase": "4.0.4",
+        "@rollup/plugin-virtual": "3.0.0",
+        "@sentry/core": "7.22.0",
+        "@sentry/integrations": "7.22.0",
+        "@sentry/node": "7.22.0",
+        "@sentry/react": "7.22.0",
+        "@sentry/tracing": "7.22.0",
+        "@sentry/types": "7.22.0",
+        "@sentry/utils": "7.22.0",
+        "@sentry/webpack-plugin": "1.20.0",
+        "chalk": "3.0.0",
+        "rollup": "2.78.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "next": "^10.0.8 || ^11.0 || ^12.0 || ^13.0",
+        "react": "15.x || 16.x || 17.x || 18.x",
+        "webpack": ">= 4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "packages/fetcher/node_modules/@sentry/node": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.22.0.tgz",
+      "integrity": "sha512-jKhxqKsbEEaY/g3FTzpj1fwukN0IkNv4V+0Fl+t/EmSNUL/7q5FMmDBa+fFQuQzwps8UEpzqPOzMSRapVsoP0w==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/core": "7.22.0",
+        "@sentry/types": "7.22.0",
+        "@sentry/utils": "7.22.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/fetcher/node_modules/@sentry/react": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.22.0.tgz",
+      "integrity": "sha512-nbZD+bobhV65r/4mpfRgGct1nrYWEmnNzTYZM4PQyPyImuk/VmNNdnzP3BLWqAnV4LvbVWEkgZIcquN8yA098g==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/browser": "7.22.0",
+        "@sentry/types": "7.22.0",
+        "@sentry/utils": "7.22.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "15.x || 16.x || 17.x || 18.x"
+      }
+    },
+    "packages/fetcher/node_modules/@sentry/tracing": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.22.0.tgz",
+      "integrity": "sha512-s68aSnrRaWQ+Z5oG9ozIegUkofZy9PwicuXYEPA8K/R30F1CVpHvDZ/3KlFnByl+aXTbAyLBQzN2sAObB5g4pQ==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/core": "7.22.0",
+        "@sentry/types": "7.22.0",
+        "@sentry/utils": "7.22.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/fetcher/node_modules/@sentry/types": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.22.0.tgz",
+      "integrity": "sha512-LhCL+wb1Jch+OesB2CIt6xpfO1Ab6CRvoNYRRzVumWPLns1T3ZJkarYfhbLaOEIb38EIbPgREdxn2AJT560U4Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/fetcher/node_modules/@sentry/utils": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.22.0.tgz",
+      "integrity": "sha512-1GiNw1opIngxg0nktCTc9wibh4/LV12kclrnB9dAOHrqazZXHXZRAkjqrhQphKcMpT+3By91W6EofjaDt5a/hg==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/types": "7.22.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/fetcher/node_modules/@sentry/webpack-plugin": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.20.0.tgz",
+      "integrity": "sha512-Ssj1mJVFsfU6vMCOM2d+h+KQR7QHSfeIP16t4l20Uq/neqWXZUQ2yvQfe4S3BjdbJXz/X4Rw8Hfy1Sd0ocunYw==",
+      "dev": true,
+      "dependencies": {
+        "@sentry/cli": "^1.74.6",
+        "webpack-sources": "^2.0.0 || ^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "packages/fetcher/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/fetcher/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/fetcher/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "packages/fetcher/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "packages/fetcher/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/fetcher/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "packages/fetcher/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/fetcher/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "packages/fetcher/node_modules/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "packages/footer": {
@@ -37768,7 +38018,10 @@
         "qs": "^6.9.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/form": {
@@ -37781,6 +38034,11 @@
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/drawer-button": "^10.3.0",
         "react-input-mask": "^2.0.4"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/hub-form": {
@@ -37790,6 +38048,11 @@
       "dependencies": {
         "@titicaca/color-palette": "^10.3.0",
         "@titicaca/core-elements": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/i18n": {
@@ -37808,6 +38071,11 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/image-carousel": {
@@ -37822,7 +38090,10 @@
         "@titicaca/type-definitions": "^10.3.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/intersection-observer": {
@@ -37834,7 +38105,10 @@
         "intersection-observer": "^0.7.0"
       },
       "peerDependencies": {
-        "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+        "next": "^13.0",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/listing-filter": {
@@ -37846,8 +38120,9 @@
         "@titicaca/core-elements": "^10.3.0"
       },
       "peerDependencies": {
-        "react": "*",
-        "styled-components": ">=4.4.1 < 6"
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/location-properties": {
@@ -37862,7 +38137,10 @@
         "@titicaca/type-definitions": "^10.3.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/map": {
@@ -37875,7 +38153,10 @@
         "@titicaca/router": "^10.3.0"
       },
       "devDependencies": {
-        "@types/googlemaps": "^3.43.3"
+        "@types/googlemaps": "^3.43.3",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/meta-tags": {
@@ -37884,7 +38165,9 @@
       "license": "MIT",
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
-        "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/modals": {
@@ -37897,7 +38180,10 @@
         "@titicaca/core-elements": "^10.3.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/nearby-pois": {
@@ -37915,7 +38201,10 @@
         "@titicaca/view-utilities": "^10.3.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/poi-detail": {
@@ -37939,7 +38228,10 @@
         "qs": "^6.10.1"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/poi-list-elements": {
@@ -37954,7 +38246,10 @@
         "@titicaca/view-utilities": "^10.3.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/popup": {
@@ -37967,6 +38262,11 @@
       },
       "devDependencies": {
         "@types/react-transition-group": "^4.4.4"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/pricing": {
@@ -37977,6 +38277,11 @@
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/type-definitions": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/public-header": {
@@ -37990,8 +38295,9 @@
       },
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
-        "react": "*",
-        "styled-components": ">=4.4.1 < 6"
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/react-contexts": {
@@ -38015,7 +38321,10 @@
       "peerDependencies": {
         "@titicaca/triple-web-to-native-interfaces": "*",
         "firebase": "^9.11.0",
-        "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+        "next": "^13.0",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/react-hooks": {
@@ -38032,7 +38341,8 @@
         "@types/scroll-to-element": "^2.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
+        "react": "^18.0",
+        "react-dom": "^18.0"
       }
     },
     "packages/react-hooks/node_modules/react-fast-compare": {
@@ -38054,7 +38364,9 @@
       },
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
-        "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+        "next": "^13.0",
+        "react": "^18.0",
+        "react-dom": "^18.0"
       }
     },
     "packages/react-triple-client-interfaces/node_modules/semver": {
@@ -38077,6 +38389,11 @@
       "dependencies": {
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/intersection-observer": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/replies": {
@@ -38092,6 +38409,11 @@
         "@titicaca/router": "^10.3.0",
         "@titicaca/ui-flow": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/resource-list-element": {
@@ -38104,6 +38426,11 @@
         "@titicaca/scrap-button": "^10.3.0",
         "@titicaca/type-definitions": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/review": {
@@ -38138,7 +38465,10 @@
         "csstype": "^3.0.2"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/router": {
@@ -38157,7 +38487,10 @@
       },
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
-        "next": "^9.5.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+        "next": "^13.0",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/scrap-button": {
@@ -38166,8 +38499,9 @@
       "license": "MIT",
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
-        "react": "*",
-        "styled-components": ">=4.4.1 < 6"
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/scroll-spy": {
@@ -38180,7 +38514,9 @@
         "react-use": "^17.2.1"
       },
       "peerDependencies": {
-        "react": "*"
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/scroll-to-element": {
@@ -38202,7 +38538,10 @@
       },
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
-        "@titicaca/triple-web-to-native-interfaces": "*"
+        "@titicaca/triple-web-to-native-interfaces": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/slider": {
@@ -38213,6 +38552,11 @@
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0",
         "react-compound-slider": "^3.4.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/social-reviews": {
@@ -38227,7 +38571,10 @@
         "react-i18next": "^11.3.3"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/standard-action-handler": {
@@ -38254,6 +38601,11 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/static-page-contents": {
@@ -38262,6 +38614,11 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/color-palette": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/style-box": {
@@ -38296,7 +38653,10 @@
         "@titicaca/view-utilities": "^10.3.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/triple-document/node_modules/@titicaca/content-type-definitions": {
@@ -38309,12 +38669,21 @@
       "dependencies": {
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/type-definitions": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/triple-fallback-action": {
       "name": "@titicaca/triple-fallback-action",
       "version": "10.3.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0"
+      }
     },
     "packages/triple-media": {
       "name": "@titicaca/triple-media",
@@ -38323,6 +38692,11 @@
       "dependencies": {
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/type-definitions": "^10.3.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/type-definitions": {
@@ -38342,7 +38716,9 @@
       "peerDependencies": {
         "@titicaca/fetcher": "*",
         "@titicaca/react-contexts": "*",
-        "next": "^9.3.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+        "next": "^13.0",
+        "react": "^18.0",
+        "react-dom": "^18.0"
       }
     },
     "packages/user-verification": {
@@ -38358,7 +38734,10 @@
         "@titicaca/router": "^10.3.0"
       },
       "peerDependencies": {
-        "@titicaca/react-contexts": "*"
+        "@titicaca/react-contexts": "*",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "packages/view-utilities": {
@@ -38388,7 +38767,9 @@
       },
       "peerDependencies": {
         "@titicaca/modals": "*",
-        "react": "*"
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     }
   },
@@ -42472,10 +42853,98 @@
       "requires": {}
     },
     "@next/env": {
-      "version": "12.3.1"
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.0.5.tgz",
+      "integrity": "sha512-F3KLtiDrUslAZhTYTh8Zk5ZaavbYwLUn3NYPBnOjAXU8hWm0QVGVzKIOuURQ098ofRU4e9oglf3Sj9pFx5nI5w=="
+    },
+    "@next/swc-android-arm-eabi": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.5.tgz",
+      "integrity": "sha512-YO691dxHlviy6H0eghgwqn+5kU9J3iQnKERHTDSppqjjGDBl6ab4wz9XfI5AhljjkaTg3TknHoIEWFDoZ4Ve8g==",
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-android-arm64": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.5.tgz",
+      "integrity": "sha512-ugbwffkUmp8cd2afehDC8LtQeFUxElRUBBngfB5UYSWBx18HW4OgzkPFIY8jUBH16zifvGZWXbICXJWDHrOLtw==",
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.5.tgz",
+      "integrity": "sha512-mshlh8QOtOalfZbc17uNAftWgqHTKnrv6QUwBe+mpGz04eqsSUzVz1JGZEdIkmuDxOz00cK2NPoc+VHDXh99IQ==",
+      "optional": true,
+      "peer": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.3.1",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.5.tgz",
+      "integrity": "sha512-SfigOKW4Z2UB3ruUPyvrlDIkcJq1hiw1wvYApWugD+tQsAkYZKEoz+/8emCmeYZ6Gwgi1WHV+z52Oj8u7bEHPg==",
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.5.tgz",
+      "integrity": "sha512-0NJg8HZr4yG8ynmMGFXQf+Mahvq4ZgBmUwSlLXXymgxEQgH17erH/LoR69uITtW+KTsALgk9axEt5AAabM4ucg==",
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.5.tgz",
+      "integrity": "sha512-Cye+h3oDT3NDWjACMlRaolL8fokpKie34FlPj9nfoW7bYKmoMBY1d4IO/GgBF+5xEl7HkH0Ny/qex63vQ0pN+A==",
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.5.tgz",
+      "integrity": "sha512-5BfDS/VoRDR5QUGG9oedOCEZGmV2zxUVFYLUJVPMSMeIgqkjxWQBiG2BUHZI6/LGk9yvHmjx7BTvtBCLtRg6IQ==",
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.5.tgz",
+      "integrity": "sha512-xenvqlXz+KxVKAB1YR723gnVNszpsCvKZkiFFaAYqDGJ502YuqU2fwLsaSm/ASRizNcBYeo9HPLTyc3r/9cdMQ==",
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.5.tgz",
+      "integrity": "sha512-9Ahi1bbdXwhrWQmOyoTod23/hhK05da/FzodiNqd6drrMl1y7+RujoEcU8Dtw3H1mGWB+yuTlWo8B4Iba8hqiQ==",
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.5.tgz",
+      "integrity": "sha512-V+1mnh49qmS9fOZxVRbzjhBEz9IUGJ7AQ80JPWAYQM5LI4TxfdiF4APLPvJ52rOmNeTqnVz1bbKtVOso+7EZ4w==",
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.5.tgz",
+      "integrity": "sha512-wRE9rkp7I+/3Jf2T9PFIJOKq3adMWYEFkPOA7XAkUfYbQHlDJm/U5cVCWUsKByyQq5RThwufI91sgd19MfxRxg==",
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.5.tgz",
+      "integrity": "sha512-Q1XQSLEhFuFhkKFdJIGt7cYQ4T3u6P5wrtUNreg5M+7P+fjSiC8+X+Vjcw+oebaacsdl0pWZlK+oACGafush1w==",
+      "optional": true,
+      "peer": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.5.tgz",
+      "integrity": "sha512-t5gRblrwwiNZP6cT7NkxlgxrFgHWtv9ei5vUraCLgBqzvIsa7X+PnarZUeQCXqz6Jg9JSGGT9j8lvzD97UqeJQ==",
       "optional": true,
       "peer": true
     },
@@ -42959,6 +43428,13 @@
         "sucrase": "^3.20.0"
       }
     },
+    "@rollup/plugin-virtual": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.0.tgz",
+      "integrity": "sha512-K9KORe1myM62o0lKkNR4MmCxjwuAXsZEtIHpaILfv4kILXTOrXt/R2ha7PzMcCHPYdnkWPiBZK8ed4Zr3Ll5lQ==",
+      "dev": true,
+      "requires": {}
+    },
     "@rollup/pluginutils": {
       "version": "4.2.1",
       "dev": true,
@@ -42972,217 +43448,6 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
-      }
-    },
-    "@sentry/browser": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@sentry/core": "7.16.0",
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/cli": {
-      "version": "1.74.5",
-      "dev": true,
-      "requires": {
-        "https-proxy-agent": "^5.0.0",
-        "mkdirp": "^0.5.5",
-        "node-fetch": "^2.6.7",
-        "npmlog": "^4.1.2",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.6",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        }
-      }
-    },
-    "@sentry/core": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/integrations": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "localforage": "^1.8.1",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/nextjs": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@rollup/plugin-sucrase": "4.0.4",
-        "@sentry/core": "7.16.0",
-        "@sentry/integrations": "7.16.0",
-        "@sentry/node": "7.16.0",
-        "@sentry/react": "7.16.0",
-        "@sentry/tracing": "7.16.0",
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "@sentry/webpack-plugin": "1.19.0",
-        "chalk": "3.0.0",
-        "rollup": "2.78.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/node": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@sentry/core": "7.16.0",
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.4.2",
-          "dev": true
-        },
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/react": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@sentry/browser": "7.16.0",
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/tracing": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@sentry/core": "7.16.0",
-        "@sentry/types": "7.16.0",
-        "@sentry/utils": "7.16.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/types": {
-      "version": "7.16.0",
-      "dev": true
-    },
-    "@sentry/utils": {
-      "version": "7.16.0",
-      "dev": true,
-      "requires": {
-        "@sentry/types": "7.16.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "dev": true
-        }
-      }
-    },
-    "@sentry/webpack-plugin": {
-      "version": "1.19.0",
-      "dev": true,
-      "requires": {
-        "@sentry/cli": "^1.74.4"
       }
     },
     "@sindresorhus/is": {
@@ -47324,13 +47589,17 @@
       "optional": true
     },
     "@swc/helpers": {
-      "version": "0.4.11",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
       "requires": {
         "tslib": "^2.4.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.4.0"
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },
@@ -47668,13 +47937,222 @@
     "@titicaca/fetcher": {
       "version": "file:packages/fetcher",
       "requires": {
-        "@sentry/nextjs": "7.16.0",
+        "@sentry/nextjs": "7.22.0",
         "@types/node-fetch": "^2.5.12",
         "isomorphic-fetch": "^2.2.1",
-        "next": "12.3.1",
+        "next": "13.0.5",
         "node-fetch": "^2.6.7",
         "ts-custom-error": "^3.2.0",
         "universal-cookie": "^4.0.3"
+      },
+      "dependencies": {
+        "@sentry/browser": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.22.0.tgz",
+          "integrity": "sha512-8MA+f46+T3G7fb4BYYX9Wl3bMDloG5a3Ng0GWdBeq6DE2tXVHeCvba8Yrrcnn1qFHpmnOn5Nz4xWBUDs3uBFxA==",
+          "dev": true,
+          "requires": {
+            "@sentry/core": "7.22.0",
+            "@sentry/types": "7.22.0",
+            "@sentry/utils": "7.22.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/cli": {
+          "version": "1.74.6",
+          "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.74.6.tgz",
+          "integrity": "sha512-pJ7JJgozyjKZSTjOGi86chIngZMLUlYt2HOog+OJn+WGvqEkVymu8m462j1DiXAnex9NspB4zLLNuZ/R6rTQHg==",
+          "dev": true,
+          "requires": {
+            "https-proxy-agent": "^5.0.0",
+            "mkdirp": "^0.5.5",
+            "node-fetch": "^2.6.7",
+            "npmlog": "^4.1.2",
+            "progress": "^2.0.3",
+            "proxy-from-env": "^1.1.0",
+            "which": "^2.0.2"
+          }
+        },
+        "@sentry/core": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.22.0.tgz",
+          "integrity": "sha512-qYJiJrL1mfQQln84mNunBRUkXq7xDGQQoNh4Sz9VYP5698va51zmS5BLYRCZ5CkPwRYNuhUqlUXN7bpYGYOOIA==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.22.0",
+            "@sentry/utils": "7.22.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/integrations": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.22.0.tgz",
+          "integrity": "sha512-yuT5NdSSi3dT2yY9SIFRET4sjO2MeX5ButUUH1KD7KGJqYumq+HGZPS0huIe4/McSxEkxhWM/XvvMMhfvNhX5w==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.22.0",
+            "@sentry/utils": "7.22.0",
+            "localforage": "^1.8.1",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/nextjs": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-7.22.0.tgz",
+          "integrity": "sha512-ztABScQJrfJYEO6eZ0ZCNa+C+whI6v5jWfeXcwJLTcMpjVZ9VqneJwITEIQChKiqmAWwcyXV6m8bO4Q6+d1avA==",
+          "dev": true,
+          "requires": {
+            "@rollup/plugin-sucrase": "4.0.4",
+            "@rollup/plugin-virtual": "3.0.0",
+            "@sentry/core": "7.22.0",
+            "@sentry/integrations": "7.22.0",
+            "@sentry/node": "7.22.0",
+            "@sentry/react": "7.22.0",
+            "@sentry/tracing": "7.22.0",
+            "@sentry/types": "7.22.0",
+            "@sentry/utils": "7.22.0",
+            "@sentry/webpack-plugin": "1.20.0",
+            "chalk": "3.0.0",
+            "rollup": "2.78.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/node": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.22.0.tgz",
+          "integrity": "sha512-jKhxqKsbEEaY/g3FTzpj1fwukN0IkNv4V+0Fl+t/EmSNUL/7q5FMmDBa+fFQuQzwps8UEpzqPOzMSRapVsoP0w==",
+          "dev": true,
+          "requires": {
+            "@sentry/core": "7.22.0",
+            "@sentry/types": "7.22.0",
+            "@sentry/utils": "7.22.0",
+            "cookie": "^0.4.1",
+            "https-proxy-agent": "^5.0.0",
+            "lru_map": "^0.3.3",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/react": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.22.0.tgz",
+          "integrity": "sha512-nbZD+bobhV65r/4mpfRgGct1nrYWEmnNzTYZM4PQyPyImuk/VmNNdnzP3BLWqAnV4LvbVWEkgZIcquN8yA098g==",
+          "dev": true,
+          "requires": {
+            "@sentry/browser": "7.22.0",
+            "@sentry/types": "7.22.0",
+            "@sentry/utils": "7.22.0",
+            "hoist-non-react-statics": "^3.3.2",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/tracing": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.22.0.tgz",
+          "integrity": "sha512-s68aSnrRaWQ+Z5oG9ozIegUkofZy9PwicuXYEPA8K/R30F1CVpHvDZ/3KlFnByl+aXTbAyLBQzN2sAObB5g4pQ==",
+          "dev": true,
+          "requires": {
+            "@sentry/core": "7.22.0",
+            "@sentry/types": "7.22.0",
+            "@sentry/utils": "7.22.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.22.0.tgz",
+          "integrity": "sha512-LhCL+wb1Jch+OesB2CIt6xpfO1Ab6CRvoNYRRzVumWPLns1T3ZJkarYfhbLaOEIb38EIbPgREdxn2AJT560U4Q==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.22.0.tgz",
+          "integrity": "sha512-1GiNw1opIngxg0nktCTc9wibh4/LV12kclrnB9dAOHrqazZXHXZRAkjqrhQphKcMpT+3By91W6EofjaDt5a/hg==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.22.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/webpack-plugin": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/@sentry/webpack-plugin/-/webpack-plugin-1.20.0.tgz",
+          "integrity": "sha512-Ssj1mJVFsfU6vMCOM2d+h+KQR7QHSfeIP16t4l20Uq/neqWXZUQ2yvQfe4S3BjdbJXz/X4Rw8Hfy1Sd0ocunYw==",
+          "dev": true,
+          "requires": {
+            "@sentry/cli": "^1.74.6",
+            "webpack-sources": "^2.0.0 || ^3.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        },
+        "webpack-sources": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+          "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+          "dev": true
+        }
       }
     },
     "@titicaca/footer": {
@@ -47765,7 +48243,10 @@
         "@react-google-maps/api": "^2.13.1",
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/router": "^10.3.0",
-        "@types/googlemaps": "^3.43.3"
+        "@types/googlemaps": "^3.43.3",
+        "react": "^18.0",
+        "react-dom": "^18.0",
+        "styled-components": "^5.3.1"
       }
     },
     "@titicaca/meta-tags": {
@@ -48075,7 +48556,8 @@
       }
     },
     "@titicaca/triple-fallback-action": {
-      "version": "file:packages/triple-fallback-action"
+      "version": "file:packages/triple-fallback-action",
+      "requires": {}
     },
     "@titicaca/triple-media": {
       "version": "file:packages/triple-media",
@@ -50433,6 +50915,11 @@
     "cli-width": {
       "version": "3.0.0",
       "dev": true
+    },
+    "client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -58006,27 +58493,28 @@
       "dev": true
     },
     "next": {
-      "version": "12.3.1",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.0.5.tgz",
+      "integrity": "sha512-awpc3DkphyKydwCotcBnuKwh6hMqkT5xdiBK4OatJtOZurDPBYLP62jtM2be/4OunpmwIbsS0Eyv+ZGU97ciEg==",
       "requires": {
-        "@next/env": "12.3.1",
-        "@next/swc-android-arm-eabi": "12.3.1",
-        "@next/swc-android-arm64": "12.3.1",
-        "@next/swc-darwin-arm64": "12.3.1",
-        "@next/swc-darwin-x64": "12.3.1",
-        "@next/swc-freebsd-x64": "12.3.1",
-        "@next/swc-linux-arm-gnueabihf": "12.3.1",
-        "@next/swc-linux-arm64-gnu": "12.3.1",
-        "@next/swc-linux-arm64-musl": "12.3.1",
-        "@next/swc-linux-x64-gnu": "12.3.1",
-        "@next/swc-linux-x64-musl": "12.3.1",
-        "@next/swc-win32-arm64-msvc": "12.3.1",
-        "@next/swc-win32-ia32-msvc": "12.3.1",
-        "@next/swc-win32-x64-msvc": "12.3.1",
-        "@swc/helpers": "0.4.11",
+        "@next/env": "13.0.5",
+        "@next/swc-android-arm-eabi": "13.0.5",
+        "@next/swc-android-arm64": "13.0.5",
+        "@next/swc-darwin-arm64": "13.0.5",
+        "@next/swc-darwin-x64": "13.0.5",
+        "@next/swc-freebsd-x64": "13.0.5",
+        "@next/swc-linux-arm-gnueabihf": "13.0.5",
+        "@next/swc-linux-arm64-gnu": "13.0.5",
+        "@next/swc-linux-arm64-musl": "13.0.5",
+        "@next/swc-linux-x64-gnu": "13.0.5",
+        "@next/swc-linux-x64-musl": "13.0.5",
+        "@next/swc-win32-arm64-msvc": "13.0.5",
+        "@next/swc-win32-ia32-msvc": "13.0.5",
+        "@next/swc-win32-x64-msvc": "13.0.5",
+        "@swc/helpers": "0.4.14",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.0.7",
-        "use-sync-external-store": "1.2.0"
+        "styled-jsx": "5.1.0"
       }
     },
     "nice-try": {
@@ -61768,8 +62256,12 @@
       }
     },
     "styled-jsx": {
-      "version": "5.0.7",
-      "requires": {}
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+      "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
+      "requires": {
+        "client-only": "0.0.1"
+      }
     },
     "stylelint": {
       "version": "14.1.0",
@@ -63027,10 +63519,6 @@
     "use": {
       "version": "3.1.1",
       "dev": true
-    },
-    "use-sync-external-store": {
-      "version": "1.2.0",
-      "requires": {}
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
     "utility-types": "^3.10.0",
     "webpack": "^5.74.0"
   },
+  "overrides": {
+    "storybook-addon-next-router": {
+      "next": "^13.0"
+    }
+  },
   "workspaces": [
     "packages/*",
     "integration-test"

--- a/packages/ab-experiments/package.json
+++ b/packages/ab-experiments/package.json
@@ -21,6 +21,8 @@
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
-    "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+    "next": "^13.0",
+    "react": "^18.0",
+    "react-dom": "^18.0"
   }
 }

--- a/packages/action-sheet/package.json
+++ b/packages/action-sheet/package.json
@@ -31,7 +31,8 @@
     "@types/react-transition-group": "^4.4.4"
   },
   "peerDependencies": {
-    "react": ">=16.3.0",
-    "styled-components": ">=4.4.1 < 6"
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/ad-banners/package.json
+++ b/packages/ad-banners/package.json
@@ -28,6 +28,9 @@
     "@titicaca/router": "^10.3.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/app-banner/package.json
+++ b/packages/app-banner/package.json
@@ -21,5 +21,10 @@
   },
   "dependencies": {
     "@titicaca/core-elements": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/app-installation-cta/package.json
+++ b/packages/app-installation-cta/package.json
@@ -35,6 +35,9 @@
     "@types/react-transition-group": "^4.4.4"
   },
   "peerDependencies": {
-    "@titicaca/web-storage": "*"
+    "@titicaca/web-storage": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/author/package.json
+++ b/packages/author/package.json
@@ -23,5 +23,10 @@
     "@titicaca/color-palette": "^10.3.0",
     "@titicaca/core-elements": "^10.3.0",
     "@titicaca/type-definitions": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/booking-completion/package.json
+++ b/packages/booking-completion/package.json
@@ -27,6 +27,9 @@
   },
   "peerDependencies": {
     "@titicaca/modals": "*",
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -28,7 +28,10 @@
     "@titicaca/type-definitions": "^10.3.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   },
   "author": "torres-triple <torres@triple-corp.com>"
 }

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -32,5 +32,10 @@
     "@titicaca/react-contexts": "^10.1.0",
     "@titicaca/triple-web-to-native-interfaces": "^1.7.0",
     "autolinker": "^4.0.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/content-sharing/package.json
+++ b/packages/content-sharing/package.json
@@ -21,5 +21,10 @@
   },
   "dependencies": {
     "@titicaca/core-elements": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/core-elements/package.json
+++ b/packages/core-elements/package.json
@@ -40,8 +40,8 @@
     "@types/react-transition-group": "^4.4.4"
   },
   "peerDependencies": {
-    "react": "*",
-    "react-dom": "*",
-    "styled-components": ">=4.4.1 < 6"
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -24,5 +24,10 @@
     "@titicaca/fetcher": "^10.3.0",
     "moment": "^2.24.0",
     "react-day-picker": "^7.4.10"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/directions-finder/package.json
+++ b/packages/directions-finder/package.json
@@ -26,6 +26,9 @@
     "@titicaca/react-triple-client-interfaces": "^10.3.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/drawer-button/package.json
+++ b/packages/drawer-button/package.json
@@ -25,5 +25,10 @@
   },
   "dependencies": {
     "@titicaca/core-elements": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -24,16 +24,16 @@
     "universal-cookie": "^4.0.3"
   },
   "devDependencies": {
-    "@sentry/nextjs": "7.16.0",
+    "@sentry/nextjs": "7.22.0",
     "@types/node-fetch": "^2.5.12",
     "isomorphic-fetch": "^2.2.1",
-    "next": "12.3.1",
+    "next": "13.0.5",
     "node-fetch": "^2.6.7"
   },
   "peerDependencies": {
-    "@sentry/nextjs": "*",
+    "@sentry/nextjs": "^7.17.1",
     "@titicaca/view-utilities": "*",
-    "next": "^9.3.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
+    "next": "^13.0",
     "ts-custom-error": "^3.2.0",
     "universal-cookie": "^4.0.3"
   }

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -26,6 +26,9 @@
     "qs": "^6.9.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -25,5 +25,10 @@
     "@titicaca/core-elements": "^10.3.0",
     "@titicaca/drawer-button": "^10.3.0",
     "react-input-mask": "^2.0.4"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/hub-form/package.json
+++ b/packages/hub-form/package.json
@@ -22,5 +22,10 @@
   "dependencies": {
     "@titicaca/color-palette": "^10.3.0",
     "@titicaca/core-elements": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -21,5 +21,10 @@
   },
   "dependencies": {
     "@titicaca/color-palette": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/image-carousel/package.json
+++ b/packages/image-carousel/package.json
@@ -27,6 +27,9 @@
     "@titicaca/type-definitions": "^10.3.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/intersection-observer/package.json
+++ b/packages/intersection-observer/package.json
@@ -24,6 +24,9 @@
     "intersection-observer": "^0.7.0"
   },
   "peerDependencies": {
-    "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+    "next": "^13.0",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/listing-filter/package.json
+++ b/packages/listing-filter/package.json
@@ -24,7 +24,8 @@
     "@titicaca/core-elements": "^10.3.0"
   },
   "peerDependencies": {
-    "react": "*",
-    "styled-components": ">=4.4.1 < 6"
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/location-properties/package.json
+++ b/packages/location-properties/package.json
@@ -27,6 +27,9 @@
     "@titicaca/type-definitions": "^10.3.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -25,6 +25,9 @@
     "@titicaca/router": "^10.3.0"
   },
   "devDependencies": {
-    "@types/googlemaps": "^3.43.3"
+    "@types/googlemaps": "^3.43.3",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/meta-tags/package.json
+++ b/packages/meta-tags/package.json
@@ -21,6 +21,8 @@
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
-    "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -25,6 +25,9 @@
     "@titicaca/core-elements": "^10.3.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/nearby-pois/package.json
+++ b/packages/nearby-pois/package.json
@@ -30,6 +30,9 @@
     "@titicaca/view-utilities": "^10.3.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/poi-detail/package.json
+++ b/packages/poi-detail/package.json
@@ -36,6 +36,9 @@
     "qs": "^6.10.1"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/poi-list-elements/package.json
+++ b/packages/poi-list-elements/package.json
@@ -27,6 +27,9 @@
     "@titicaca/view-utilities": "^10.3.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -29,5 +29,10 @@
   },
   "devDependencies": {
     "@types/react-transition-group": "^4.4.4"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -23,5 +23,10 @@
     "@titicaca/core-elements": "^10.3.0",
     "@titicaca/type-definitions": "^10.3.0",
     "@titicaca/view-utilities": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/public-header/package.json
+++ b/packages/public-header/package.json
@@ -26,7 +26,8 @@
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
-    "react": "*",
-    "styled-components": ">=4.4.1 < 6"
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/react-contexts/package.json
+++ b/packages/react-contexts/package.json
@@ -36,7 +36,10 @@
   "peerDependencies": {
     "@titicaca/triple-web-to-native-interfaces": "*",
     "firebase": "^9.11.0",
-    "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+    "next": "^13.0",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   },
   "author": ""
 }

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -29,6 +29,7 @@
     "@types/scroll-to-element": "^2.0.0"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": "^18.0",
+    "react-dom": "^18.0"
   }
 }

--- a/packages/react-triple-client-interfaces/package.json
+++ b/packages/react-triple-client-interfaces/package.json
@@ -23,6 +23,8 @@
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
-    "next": "^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+    "next": "^13.0",
+    "react": "^18.0",
+    "react-dom": "^18.0"
   }
 }

--- a/packages/recommended-contents/package.json
+++ b/packages/recommended-contents/package.json
@@ -22,5 +22,10 @@
   "dependencies": {
     "@titicaca/core-elements": "^10.3.0",
     "@titicaca/intersection-observer": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/replies/package.json
+++ b/packages/replies/package.json
@@ -28,5 +28,10 @@
     "@titicaca/router": "^10.3.0",
     "@titicaca/ui-flow": "^10.3.0",
     "@titicaca/view-utilities": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/resource-list-element/package.json
+++ b/packages/resource-list-element/package.json
@@ -25,5 +25,10 @@
     "@titicaca/scrap-button": "^10.3.0",
     "@titicaca/type-definitions": "^10.3.0",
     "@titicaca/view-utilities": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/review/package.json
+++ b/packages/review/package.json
@@ -48,6 +48,9 @@
     "csstype": "^3.0.2"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -31,6 +31,9 @@
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
-    "next": "^9.5.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+    "next": "^13.0",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/scrap-button/package.json
+++ b/packages/scrap-button/package.json
@@ -21,7 +21,8 @@
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
-    "react": "*",
-    "styled-components": ">=4.4.1 < 6"
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/scroll-spy/package.json
+++ b/packages/scroll-spy/package.json
@@ -25,6 +25,8 @@
     "react-use": "^17.2.1"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -29,6 +29,9 @@
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
-    "@titicaca/triple-web-to-native-interfaces": "*"
+    "@titicaca/triple-web-to-native-interfaces": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -23,5 +23,10 @@
     "@titicaca/core-elements": "^10.3.0",
     "@titicaca/view-utilities": "^10.3.0",
     "react-compound-slider": "^3.4.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/social-reviews/package.json
+++ b/packages/social-reviews/package.json
@@ -27,6 +27,9 @@
     "react-i18next": "^11.3.3"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/static-map/package.json
+++ b/packages/static-map/package.json
@@ -21,5 +21,10 @@
   },
   "dependencies": {
     "@titicaca/core-elements": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/static-page-contents/package.json
+++ b/packages/static-page-contents/package.json
@@ -21,5 +21,10 @@
   },
   "dependencies": {
     "@titicaca/color-palette": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -38,6 +38,9 @@
     "@titicaca/view-utilities": "^10.3.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/triple-email-document/package.json
+++ b/packages/triple-email-document/package.json
@@ -22,5 +22,10 @@
   "dependencies": {
     "@titicaca/core-elements": "^10.3.0",
     "@titicaca/type-definitions": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/triple-fallback-action/package.json
+++ b/packages/triple-fallback-action/package.json
@@ -18,5 +18,9 @@
   "scripts": {
     "build": "npm run build:cjs",
     "build:cjs": "swc src -d lib --config-file ../../.swcrc"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0"
   }
 }

--- a/packages/triple-media/package.json
+++ b/packages/triple-media/package.json
@@ -22,5 +22,10 @@
   "dependencies": {
     "@titicaca/core-elements": "^10.3.0",
     "@titicaca/type-definitions": "^10.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/ui-flow/package.json
+++ b/packages/ui-flow/package.json
@@ -33,6 +33,8 @@
   "peerDependencies": {
     "@titicaca/fetcher": "*",
     "@titicaca/react-contexts": "*",
-    "next": "^9.3.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
+    "next": "^13.0",
+    "react": "^18.0",
+    "react-dom": "^18.0"
   }
 }

--- a/packages/user-verification/package.json
+++ b/packages/user-verification/package.json
@@ -34,6 +34,9 @@
     "@titicaca/router": "^10.3.0"
   },
   "peerDependencies": {
-    "@titicaca/react-contexts": "*"
+    "@titicaca/react-contexts": "*",
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }

--- a/packages/web-storage/package.json
+++ b/packages/web-storage/package.json
@@ -25,6 +25,8 @@
   },
   "peerDependencies": {
     "@titicaca/modals": "*",
-    "react": "*"
+    "react": "^18.0",
+    "react-dom": "^18.0",
+    "styled-components": "^5.3.1"
   }
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

peer dependencies 수정

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- 대부분의 패키지에서 react, react-dom, styled-components peerDependency가 빠져있어서 추가합니다.
- react, react-dom는 18에서 새로 추가된 API를 사용하기 때문에 `^18.0`
- styled-components는 react 18을 지원하는 최소버전인 `^5.3.1`
- next도 react 18을 지원하는 최소버전인 `^13.0`
- @sentry/nextjs는 next 13을 지원하는 최소버전인 `^7.17.1`

으로 설정합니다.