### PR TITLE
[core-elements] Tabs 컴포넌트를 generic type 으로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47584,7 +47584,7 @@
         "@titicaca/intersection-observer": "^10.3.0",
         "@titicaca/triple-fallback-action": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0",
-        "@types/lodash.once": "*",
+        "@types/lodash.once": "^4.1.7",
         "@types/react-transition-group": "^4.4.4",
         "lodash.once": "^4.1.1",
         "react-input-mask": "^2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14105,6 +14105,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash.once": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.once/-/lodash.once-4.1.7.tgz",
+      "integrity": "sha512-XWhnXzWkxoleOoXKmzUtep8vT+wiiQQgmPD+wzG0yO0bdlszmnqHRb2WiY5hK/8V0DTet1+z9DJj9cnbdAhWng==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "dev": true,
@@ -27322,8 +27331,8 @@
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
@@ -37672,10 +37681,12 @@
         "@titicaca/intersection-observer": "^10.3.0",
         "@titicaca/triple-fallback-action": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0",
+        "lodash.once": "^4.1.1",
         "react-input-mask": "^2.0.4",
         "react-transition-group": "^4.4.2"
       },
       "devDependencies": {
+        "@types/lodash.once": "^4.1.7",
         "@types/react-transition-group": "^4.4.4"
       },
       "peerDependencies": {
@@ -47573,7 +47584,9 @@
         "@titicaca/intersection-observer": "^10.3.0",
         "@titicaca/triple-fallback-action": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0",
+        "@types/lodash.once": "*",
         "@types/react-transition-group": "^4.4.4",
+        "lodash.once": "^4.1.1",
         "react-input-mask": "^2.0.4",
         "react-transition-group": "^4.4.2"
       }
@@ -48278,6 +48291,15 @@
     "@types/lodash": {
       "version": "4.14.182",
       "dev": true
+    },
+    "@types/lodash.once": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.once/-/lodash.once-4.1.7.tgz",
+      "integrity": "sha512-XWhnXzWkxoleOoXKmzUtep8vT+wiiQQgmPD+wzG0yO0bdlszmnqHRb2WiY5hK/8V0DTet1+z9DJj9cnbdAhWng==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/long": {
       "version": "4.0.2",
@@ -57098,7 +57120,8 @@
     },
     "lodash.once": {
       "version": "4.1.1",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "lodash.snakecase": {
       "version": "4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14105,15 +14105,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash.once": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.once/-/lodash.once-4.1.7.tgz",
-      "integrity": "sha512-XWhnXzWkxoleOoXKmzUtep8vT+wiiQQgmPD+wzG0yO0bdlszmnqHRb2WiY5hK/8V0DTet1+z9DJj9cnbdAhWng==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "dev": true,
@@ -27332,7 +27323,8 @@
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true
     },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
@@ -37681,12 +37673,10 @@
         "@titicaca/intersection-observer": "^10.3.0",
         "@titicaca/triple-fallback-action": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0",
-        "lodash.once": "^4.1.1",
         "react-input-mask": "^2.0.4",
         "react-transition-group": "^4.4.2"
       },
       "devDependencies": {
-        "@types/lodash.once": "^4.1.7",
         "@types/react-transition-group": "^4.4.4"
       },
       "peerDependencies": {
@@ -47584,9 +47574,7 @@
         "@titicaca/intersection-observer": "^10.3.0",
         "@titicaca/triple-fallback-action": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0",
-        "@types/lodash.once": "^4.1.7",
         "@types/react-transition-group": "^4.4.4",
-        "lodash.once": "^4.1.1",
         "react-input-mask": "^2.0.4",
         "react-transition-group": "^4.4.2"
       }
@@ -48291,15 +48279,6 @@
     "@types/lodash": {
       "version": "4.14.182",
       "dev": true
-    },
-    "@types/lodash.once": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.once/-/lodash.once-4.1.7.tgz",
-      "integrity": "sha512-XWhnXzWkxoleOoXKmzUtep8vT+wiiQQgmPD+wzG0yO0bdlszmnqHRb2WiY5hK/8V0DTet1+z9DJj9cnbdAhWng==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
     },
     "@types/long": {
       "version": "4.0.2",
@@ -57121,7 +57100,8 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true
     },
     "lodash.snakecase": {
       "version": "4.1.1"

--- a/packages/core-elements/package.json
+++ b/packages/core-elements/package.json
@@ -33,10 +33,12 @@
     "@titicaca/intersection-observer": "^10.3.0",
     "@titicaca/triple-fallback-action": "^10.3.0",
     "@titicaca/view-utilities": "^10.3.0",
+    "lodash.once": "^4.1.1",
     "react-input-mask": "^2.0.4",
     "react-transition-group": "^4.4.2"
   },
   "devDependencies": {
+    "@types/lodash.once": "^4.1.7",
     "@types/react-transition-group": "^4.4.4"
   },
   "peerDependencies": {

--- a/packages/core-elements/package.json
+++ b/packages/core-elements/package.json
@@ -33,12 +33,10 @@
     "@titicaca/intersection-observer": "^10.3.0",
     "@titicaca/triple-fallback-action": "^10.3.0",
     "@titicaca/view-utilities": "^10.3.0",
-    "lodash.once": "^4.1.1",
     "react-input-mask": "^2.0.4",
     "react-transition-group": "^4.4.2"
   },
   "devDependencies": {
-    "@types/lodash.once": "^4.1.7",
     "@types/react-transition-group": "^4.4.4"
   },
   "peerDependencies": {

--- a/packages/core-elements/src/elements/tabs/pointing-tab-list.tsx
+++ b/packages/core-elements/src/elements/tabs/pointing-tab-list.tsx
@@ -43,8 +43,11 @@ const StyledTabListBase = styled(TabListBase)<StyledTabListBaseProps>`
   }
 `
 
-export const PointingTabList = ({ children, ...props }: TabListBaseProps) => {
-  const tabs = useTabs()
+export const PointingTabList = <Value extends string>({
+  children,
+  ...props
+}: TabListBaseProps) => {
+  const tabs = useTabs<Value>()
   const tabsRef = useRef<Record<string, HTMLButtonElement | null>>({})
   const [pointValue, setPointValue] = useState<PointValue>({
     left: 0,

--- a/packages/core-elements/src/elements/tabs/pointing-tab.tsx
+++ b/packages/core-elements/src/elements/tabs/pointing-tab.tsx
@@ -28,8 +28,8 @@ const StyledTabBase = styled(TabBase)<StyledTabBaseProps>`
     `}
 `
 
-export const PointingTab = ({ children, ...props }: TabBaseProps) => {
-  const tabs = useTabs()
+export const PointingTab = <Value,>({ children, ...props }: TabBaseProps) => {
+  const tabs = useTabs<Value>()
   const { tabsRef } = usePointingTab()
 
   return (

--- a/packages/core-elements/src/elements/tabs/rounded-tab-list.tsx
+++ b/packages/core-elements/src/elements/tabs/rounded-tab-list.tsx
@@ -24,8 +24,11 @@ const StyledTabListBase = styled(TabListBase)<StyledTabListBaseProps>`
     `}
 `
 
-export const RoundedTabList = ({ children, ...props }: TabListBaseProps) => {
-  const tabs = useTabs()
+export const RoundedTabList = <Value,>({
+  children,
+  ...props
+}: TabListBaseProps) => {
+  const tabs = useTabs<Value>()
 
   return (
     <StyledTabListBase {...props} scroll={tabs.scroll}>

--- a/packages/core-elements/src/elements/tabs/tab-panel.tsx
+++ b/packages/core-elements/src/elements/tabs/tab-panel.tsx
@@ -2,15 +2,15 @@ import React, { PropsWithChildren } from 'react'
 
 import { useTabs } from './tabs-context'
 
-export interface TabPanelProps extends PropsWithChildren {
+export interface TabPanelProps<Value> extends PropsWithChildren {
   /**
    * 각 탭마다의 유니크한 값
    */
-  value: string
+  value: Value
 }
 
-export const TabPanel = ({ children, value }: TabPanelProps) => {
-  const tabs = useTabs()
+export const TabPanel = <Value,>({ children, value }: TabPanelProps<Value>) => {
+  const tabs = useTabs<Value>()
 
   return (
     <div

--- a/packages/core-elements/src/elements/tabs/tabs-context.tsx
+++ b/packages/core-elements/src/elements/tabs/tabs-context.tsx
@@ -1,9 +1,8 @@
 import { createContext, useContext } from 'react'
-import once from 'lodash.once'
 
 import { TabVariant } from './types'
 
-export interface TabsContextValue<Value> {
+export interface TabsContextValue<Value = unknown> {
   id: string
   value: Value
   variant: TabVariant
@@ -11,12 +10,12 @@ export interface TabsContextValue<Value> {
   onChange?: (value: Value) => void
 }
 
-export const createTabsContext = once(<Value,>() =>
-  createContext<TabsContextValue<Value> | undefined>(undefined),
+export const TabsContext = createContext<TabsContextValue | undefined>(
+  undefined,
 )
 
 export function useTabs<Value>() {
-  const context = useContext(createTabsContext<Value>())
+  const context = useContext(TabsContext) as TabsContextValue<Value> | undefined
   if (!context) {
     throw new Error('TabsContextContext가 없습니다.')
   }

--- a/packages/core-elements/src/elements/tabs/tabs-context.tsx
+++ b/packages/core-elements/src/elements/tabs/tabs-context.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext } from 'react'
+import once from 'lodash.once'
 
 import { TabVariant } from './types'
 
@@ -10,12 +11,12 @@ export interface TabsContextValue<Value> {
   onChange?: (value: Value) => void
 }
 
-export const TabsContext = createContext<TabsContextValue<unknown> | undefined>(
-  undefined,
+export const createTabsContext = once(<Value,>() =>
+  createContext<TabsContextValue<Value> | undefined>(undefined),
 )
 
-export function useTabs() {
-  const context = useContext(TabsContext)
+export function useTabs<Value>() {
+  const context = useContext(createTabsContext<Value>())
   if (!context) {
     throw new Error('TabsContextContext가 없습니다.')
   }

--- a/packages/core-elements/src/elements/tabs/tabs-context.tsx
+++ b/packages/core-elements/src/elements/tabs/tabs-context.tsx
@@ -2,15 +2,15 @@ import { createContext, useContext } from 'react'
 
 import { TabVariant } from './types'
 
-export interface TabsContextValue {
+export interface TabsContextValue<Value> {
   id: string
-  value: string
+  value: Value
   variant: TabVariant
   scroll: boolean
-  onChange?: (value: string) => void
+  onChange?: (value: Value) => void
 }
 
-export const TabsContext = createContext<TabsContextValue | undefined>(
+export const TabsContext = createContext<TabsContextValue<unknown> | undefined>(
   undefined,
 )
 

--- a/packages/core-elements/src/elements/tabs/tabs.tsx
+++ b/packages/core-elements/src/elements/tabs/tabs.tsx
@@ -1,9 +1,9 @@
-import { PropsWithChildren, useId } from 'react'
+import { PropsWithChildren, Provider, useId } from 'react'
 
 import { Tab } from './tab'
 import { TabList } from './tab-list'
 import { TabPanel } from './tab-panel'
-import { createTabsContext } from './tabs-context'
+import { TabsContext, TabsContextValue } from './tabs-context'
 import { TabVariant } from './types'
 
 export interface TabsProps<Value> extends PropsWithChildren {
@@ -33,12 +33,14 @@ export const Tabs = <Value,>({
   onChange,
 }: TabsProps<Value>) => {
   const id = useId()
-  const TabsContext = createTabsContext<Value>()
+  const TabsContextProvider = TabsContext.Provider as Provider<
+    TabsContextValue<Value> | undefined
+  >
 
   return (
-    <TabsContext.Provider value={{ id, value, variant, scroll, onChange }}>
+    <TabsContextProvider value={{ id, value, variant, scroll, onChange }}>
       {children}
-    </TabsContext.Provider>
+    </TabsContextProvider>
   )
 }
 

--- a/packages/core-elements/src/elements/tabs/tabs.tsx
+++ b/packages/core-elements/src/elements/tabs/tabs.tsx
@@ -6,11 +6,11 @@ import { TabPanel } from './tab-panel'
 import { TabsContext } from './tabs-context'
 import { TabVariant } from './types'
 
-export interface TabsProps extends PropsWithChildren {
+export interface TabsProps<Value> extends PropsWithChildren {
   /**
    * 현재 탭을 가르키는 값
    */
-  value: string
+  value: Value
   /**
    * 디자인 variant
    */
@@ -22,16 +22,16 @@ export interface TabsProps extends PropsWithChildren {
   /**
    * 탭 변경 이벤트 핸들러
    */
-  onChange?: (value: string) => void
+  onChange?: (value: Value) => void
 }
 
-export const Tabs = ({
+export const Tabs = <Value,>({
   children,
   value,
   variant = 'basic',
   scroll = false,
   onChange,
-}: TabsProps) => {
+}: TabsProps<Value>) => {
   const id = useId()
 
   return (

--- a/packages/core-elements/src/elements/tabs/tabs.tsx
+++ b/packages/core-elements/src/elements/tabs/tabs.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren, useId } from 'react'
 import { Tab } from './tab'
 import { TabList } from './tab-list'
 import { TabPanel } from './tab-panel'
-import { TabsContext } from './tabs-context'
+import { createTabsContext } from './tabs-context'
 import { TabVariant } from './types'
 
 export interface TabsProps<Value> extends PropsWithChildren {
@@ -33,6 +33,7 @@ export const Tabs = <Value,>({
   onChange,
 }: TabsProps<Value>) => {
   const id = useId()
+  const TabsContext = createTabsContext<Value>()
 
   return (
     <TabsContext.Provider value={{ id, value, variant, scroll, onChange }}>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
Tabs 컴포넌트를 generic type 으로 변경합니다. 
## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
기존에 Tabs 컴포넌트를 enum 등을 사용해 generic 을 활용하고 있는 부분이 있었습니다. 
호환성을 높이기 위해 generic으로 변경했습니다. 
context에도 generic을 적용해야 해서 `lodash.once`를 사용하였습니다. 

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
카나리 적용해 제네릭 적용된 모습입니다. 
![Screenshot 2022-12-06 at 9 08 39 AM](https://user-images.githubusercontent.com/30427711/205773616-2cc66534-6eb1-49b8-8bbb-5d72a8ed7d15.png)
![Screenshot 2022-12-06 at 9 08 47 AM](https://user-images.githubusercontent.com/30427711/205773625-062452c4-d674-457e-85ed-507c72852f34.png)
