### PR TITLE
타입 수정 및 일부 core-elements 컴포넌트에 css prop 추가

### DIFF
--- a/packages/core-elements/src/elements/hr/hr.ts
+++ b/packages/core-elements/src/elements/hr/hr.ts
@@ -1,11 +1,7 @@
 import styled, { css } from 'styled-components'
 
-import { MarginPadding } from '../../commons'
-import { marginMixin } from '../../mixins'
-
 interface HrProps {
   compact?: boolean
-  margin?: MarginPadding
   color?: string
 }
 
@@ -19,8 +15,6 @@ export const HR1 = styled.div<HrProps>`
     css`
       margin: 0;
     `};
-
-  ${marginMixin}
 `
 
 export const HR2 = styled.div<HrProps>`
@@ -33,8 +27,6 @@ export const HR2 = styled.div<HrProps>`
     css`
       margin: 0;
     `};
-
-  ${marginMixin}
 `
 
 export const HR3 = styled.div<{ height?: number }>`
@@ -77,14 +69,6 @@ export const HR7 = styled.div<HrProps>`
       margin: 0;
     `};
 
-  ${({ margin }) =>
-    margin &&
-    css`
-      margin-top: ${margin.top || 0}px;
-      margin-bottom: ${margin.bottom || 0}px;
-      margin-left: ${margin.left || 0}px;
-      margin-right: ${margin.right || 0}px;
-    `};
   width: 100%;
   border-bottom: dashed 1px #efefef;
 `

--- a/packages/core-elements/src/elements/segment/segment.tsx
+++ b/packages/core-elements/src/elements/segment/segment.tsx
@@ -1,26 +1,12 @@
 import { PropsWithChildren } from 'react'
 import styled, { css, ThemedStyledProps } from 'styled-components'
 
-import { MarginPadding } from '../../commons'
-import {
-  KeyOfShadowSize,
-  marginMixin,
-  paddingMixin,
-  shadowMixin,
-  ShadowMixinProps,
-} from '../../mixins'
+import { KeyOfShadowSize, shadowMixin, ShadowMixinProps } from '../../mixins'
 
-export const Segment = styled.div<{
-  margin?: MarginPadding
-  padding?: MarginPadding
-}>`
+export const Segment = styled.div`
   padding: 20px;
   border-radius: 6px;
   background-color: #fafafa;
-
-  ${marginMixin}
-
-  ${paddingMixin}
 
   &::after {
     content: '';
@@ -31,8 +17,6 @@ export const Segment = styled.div<{
 
 export interface BoxProps {
   radius: number
-  margin: MarginPadding
-  padding: MarginPadding
 }
 
 export type CardProps = Partial<
@@ -52,9 +36,6 @@ const shadowMixinWithDefault = (props: ShadowMixinProps) =>
   shadowMixin({ shadow: 'medium', ...props })
 
 export const CardFrame = styled.div<CardProps>`
-  ${marginMixin}
-  ${paddingMixin}
-
   ${borderRadius}
   ${shadowMixinWithDefault}
 `
@@ -66,8 +47,6 @@ export const CardFrame = styled.div<CardProps>`
  *  - radius: number
  *  - shadow: ShadowType
  *  - shadowValue: string
- *  - margin: MarginPadding
- *  - padding: MarginPadding
  */
 export function Card({
   children,

--- a/packages/core-elements/src/elements/tabs/tab.tsx
+++ b/packages/core-elements/src/elements/tabs/tab.tsx
@@ -6,14 +6,14 @@ import { useTabs } from './tabs-context'
 
 export type TabProps = TabBaseProps
 
-export const Tab = (props: TabBaseProps) => {
-  const tabs = useTabs()
+export const Tab = <Value,>(props: TabBaseProps) => {
+  const tabs = useTabs<Value>()
 
   switch (tabs.variant) {
     case 'basic':
       return <BasicTab {...props} />
     case 'pointing':
-      return <PointingTab {...props} />
+      return <PointingTab<Value> {...props} />
     case 'rounded':
       return <RoundedTab {...props} />
   }

--- a/packages/core-elements/src/elements/textarea/textarea.tsx
+++ b/packages/core-elements/src/elements/textarea/textarea.tsx
@@ -41,7 +41,8 @@ const BaseTextarea = styled.textarea`
   }
 `
 
-interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+export interface TextareaProps
+  extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   required?: boolean
   label?: string
   error?: string | boolean

--- a/packages/directions-finder/src/ask-to-the-local.tsx
+++ b/packages/directions-finder/src/ask-to-the-local.tsx
@@ -73,7 +73,7 @@ export default function AskToTheLocal({
         <Text textStyle="M" margin={{ top: 10 }}>
           {localAddress}
         </Text>
-        <HR1 compact margin={{ top: 20, bottom: 20 }} />
+        <HR1 compact css={{ marginTop: 20, marginBottom: 20 }} />
         <Text textStyle="M" alpha={0.7}>
           {primaryName}
         </Text>

--- a/packages/hub-form/src/hub-form.stories.tsx
+++ b/packages/hub-form/src/hub-form.stories.tsx
@@ -12,7 +12,7 @@ export default {
 export const Hotel: ComponentStory<typeof HubForm> = () => {
   return (
     <>
-      <HubForm shadow="">
+      <HubForm>
         <Cell type="DESTINATION" placeholder="도시, 또는 호텔" value="" />
         <Cell type="SCHEDULE" placeholder="날짜" value="" />
         <Cell type="PEOPLE" placeholder="" value="인원 2명" />
@@ -27,7 +27,7 @@ export const Hotel: ComponentStory<typeof HubForm> = () => {
 export const Air: ComponentStory<typeof HubForm> = () => {
   return (
     <>
-      <HubForm shadow="">
+      <HubForm>
         <Cell type="ORIGIN" placeholder="출발 도시" value="" />
         <Cell type="DESTINATION" placeholder="도착 도시" value="" />
         <Cell type="SCHEDULE" placeholder="날짜" value="" />

--- a/packages/hub-form/src/hub-form.tsx
+++ b/packages/hub-form/src/hub-form.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react'
 import styled from 'styled-components'
-import { CardFrame } from '@titicaca/core-elements'
+import { CardFrame, CardProps } from '@titicaca/core-elements'
 
 const HubFormFrame = styled(CardFrame)`
   > div:not(:last-child) {
@@ -16,17 +16,18 @@ const HubFormFrame = styled(CardFrame)`
   }
 `
 
-function HubForm({
-  children,
-  shadow,
-  ...props
-}: PropsWithChildren<Parameters<typeof HubFormFrame>['0']>) {
+function HubForm({ children, shadow, ...props }: PropsWithChildren<CardProps>) {
   return (
     <HubFormFrame
-      margin={{ top: 10, bottom: 10 }}
-      padding={{ top: 4, bottom: 4, right: 18, left: 22 }}
-      borderRadius={6}
       shadow={shadow || 'medium'}
+      css={{
+        marginTop: 10,
+        marginBottom: 10,
+        paddingTop: 4,
+        paddingBottom: 4,
+        paddingRight: 18,
+        paddingLeft: 22,
+      }}
       {...props}
     >
       {children}

--- a/packages/poi-detail/src/actions.tsx
+++ b/packages/poi-detail/src/actions.tsx
@@ -115,7 +115,7 @@ function Actions({
           {t('common:share', '공유하기')}
         </ActionButton>
       </Button.Group>
-      {!noDivider && <HR1 margin={{ top: 8, bottom: 0 }} />}
+      {!noDivider && <HR1 css={{ marginTop: 8, marginBottom: 0 }} />}
     </Section>
   )
 }

--- a/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
+++ b/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
@@ -109,7 +109,7 @@ function PoiCardElement({
     <Card
       radius={6}
       shadowValue="0 1px 3px 0 rgba(0, 0, 0, 0.1)"
-      padding={{ top: 18, right: 18, bottom: 18, left: 18 }}
+      css={{ padding: 18 }}
     >
       <PoiCardBody
         position="relative"

--- a/packages/replies/src/list/index.tsx
+++ b/packages/replies/src/list/index.tsx
@@ -90,7 +90,11 @@ export default function ReplyList({
           <List margin={{ top: 20 }}>
             {replies.map((reply) => (
               <List.Item key={reply.id}>
-                <HR1 color="var(--color-gray50)" css={{ marginBottom: 20 }} />
+                <HR1
+                  color="var(--color-gray50)"
+                  compact
+                  css={{ marginBottom: 20 }}
+                />
                 <Reply
                   reply={reply}
                   focusInput={focusInput}

--- a/packages/replies/src/list/index.tsx
+++ b/packages/replies/src/list/index.tsx
@@ -90,7 +90,7 @@ export default function ReplyList({
           <List margin={{ top: 20 }}>
             {replies.map((reply) => (
               <List.Item key={reply.id}>
-                <HR1 margin={{ bottom: 20 }} color="var(--color-gray50)" />
+                <HR1 color="var(--color-gray50)" css={{ marginBottom: 20 }} />
                 <Reply
                   reply={reply}
                   focusInput={focusInput}

--- a/packages/replies/src/list/not-exist-replies.tsx
+++ b/packages/replies/src/list/not-exist-replies.tsx
@@ -4,8 +4,8 @@ export default function NotExistReplies() {
   return (
     <>
       <HR1
-        margin={{ top: 20, left: 30, right: 30 }}
         color="var(--color-gray50)"
+        css={{ marginTop: 20, marginLeft: 30, marginRight: 30 }}
       />
 
       <Container
@@ -20,7 +20,7 @@ export default function NotExistReplies() {
         </Text>
       </Container>
 
-      <HR1 margin={{ top: 0 }} color="var(--color-gray50)" />
+      <HR1 color="var(--color-gray50)" css={{ marginTop: 0 }} />
     </>
   )
 }

--- a/packages/replies/src/list/not-exist-replies.tsx
+++ b/packages/replies/src/list/not-exist-replies.tsx
@@ -5,6 +5,7 @@ export default function NotExistReplies() {
     <>
       <HR1
         color="var(--color-gray50)"
+        compact
         css={{ marginTop: 20, marginLeft: 30, marginRight: 30 }}
       />
 
@@ -20,7 +21,7 @@ export default function NotExistReplies() {
         </Text>
       </Container>
 
-      <HR1 color="var(--color-gray50)" css={{ marginTop: 0 }} />
+      <HR1 color="var(--color-gray50)" compact />
     </>
   )
 }

--- a/packages/replies/src/register.tsx
+++ b/packages/replies/src/register.tsx
@@ -84,7 +84,7 @@ function Register(
         cursor: 'pointer',
       }}
     >
-      <HR1 margin={{ top: 0 }} />
+      <HR1 css={{ marginTop: 0 }} />
 
       <FlexBox
         flex
@@ -113,7 +113,7 @@ function Register(
         </RegisterButton>
       </FlexBox>
 
-      <HR1 margin={{ top: 0 }} />
+      <HR1 css={{ marginTop: 0 }} />
     </Container>
   )
 }

--- a/packages/replies/src/register.tsx
+++ b/packages/replies/src/register.tsx
@@ -84,7 +84,7 @@ function Register(
         cursor: 'pointer',
       }}
     >
-      <HR1 css={{ marginTop: 0 }} />
+      <HR1 compact />
 
       <FlexBox
         flex
@@ -113,7 +113,7 @@ function Register(
         </RegisterButton>
       </FlexBox>
 
-      <HR1 css={{ marginTop: 0 }} />
+      <HR1 compact />
     </Container>
   )
 }

--- a/packages/standard-action-handler/src/image-download.ts
+++ b/packages/standard-action-handler/src/image-download.ts
@@ -26,19 +26,15 @@ export default async function imageDownload({ path, query }: UrlElements) {
     const windowUrl = window.URL || window.webkitURL
     const imageToDomString = windowUrl.createObjectURL(blobImage)
 
-    // ie에서는 Blob 저장이 정상적으로 이루어지지 않으므로 해당 케이스 추가
-    if (window.navigator.msSaveOrOpenBlob) {
-      window.navigator.msSaveOrOpenBlob(imageToDomString, 'image.jpeg')
-    } else {
-      const downloadAnchor = document.createElement('a')
-      downloadAnchor.setAttribute('href', imageToDomString)
-      downloadAnchor.setAttribute('download', 'image.jpeg')
-      downloadAnchor.click()
-      downloadAnchor.remove()
+    const downloadAnchor = document.createElement('a')
+    downloadAnchor.setAttribute('href', imageToDomString)
+    downloadAnchor.setAttribute('download', 'image.jpeg')
+    downloadAnchor.click()
+    downloadAnchor.remove()
 
-      // URL 더이상 사용되지 않아 메모리 누수를 방지
-      windowUrl.revokeObjectURL(imageToDomString)
-    }
+    // URL 더이상 사용되지 않아 메모리 누수를 방지
+    windowUrl.revokeObjectURL(imageToDomString)
+
     return true
   }
 

--- a/packages/standard-action-handler/src/services/share.ts
+++ b/packages/standard-action-handler/src/services/share.ts
@@ -18,7 +18,7 @@ interface SharingParams {
 
 export function createShareUrl() {
   if (!hasAccessibleTripleNativeClients()) {
-    return typeof navigator !== 'undefined' && navigator.share
+    return typeof navigator !== 'undefined' && 'share' in navigator
       ? navigatorShare
       : copyUrlToClipboard
   } else {

--- a/packages/triple-document/src/elements/itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary.tsx
@@ -194,7 +194,7 @@ export default function ItineraryElement({ value }: Props) {
                   <PoiCard
                     shadow="medium"
                     radius={6}
-                    margin={{ top: 5, bottom: 8 }}
+                    css={{ marginTop: 5, marginBottom: 8 }}
                   >
                     <Text size={16} bold ellipsis>
                       {name}

--- a/packages/triple-document/src/elements/note.tsx
+++ b/packages/triple-document/src/elements/note.tsx
@@ -6,7 +6,7 @@ export default function Note({
   value: { title: string; body: string }
 }) {
   return (
-    <Segment margin={{ top: 30, bottom: 30, left: 30, right: 30 }}>
+    <Segment css={{ margin: 30 }}>
       <Text bold size="small" color="gray" lineHeight={1.57}>
         {title}
       </Text>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
타입 수정, 일부 core-elements 컴포넌트에 css prop 추가

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- export TextareaProps
- (standard-action-handler) IE 호환 제거
- (standard-action-handler) navigator.share -> 'share' in navigator
- (core-elements) hr, segment 컴포넌트에도 margin, padding prop을 제거하고 css Prop을 사용하도록 변경
- (core-elements) Tabs.Tab 컴포넌트에도 Value 제네릭 추가