### PR TITLE
styled.attrs로 스타일되었던 props를 css로 변경

### DIFF
--- a/packages/app-installation-cta/src/elements.tsx
+++ b/packages/app-installation-cta/src/elements.tsx
@@ -210,12 +210,12 @@ export const FloatingButtonContainer = styled.div<
 export const ContentContainer = styled(FlexBox).attrs({
   flex: true,
   centered: true,
-  maxWidth: 768,
-  padding: { top: 24, bottom: 24, left: 20, right: 20 },
   gap: '11px',
-  position: 'relative',
 })`
   overflow: hidden;
+  max-width: 768px;
+  padding: 24px 20px;
+  position: 'relative';
 `
 
 export const FloatingButton = styled.div`

--- a/packages/app-installation-cta/src/floating-button-cta.stories.tsx
+++ b/packages/app-installation-cta/src/floating-button-cta.stories.tsx
@@ -5,6 +5,11 @@ import FloatingButtonCTA from './floating-button-cta'
 export default {
   title: 'app-installation-cta / FloatingButtonCTA',
   component: FloatingButtonCTA,
+  parameters: {
+    chromatic: {
+      viewports: [375],
+    },
+  },
 } as ComponentMeta<typeof FloatingButtonCTA>
 
 export const Basic: ComponentStoryObj<typeof FloatingButtonCTA> = {

--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -19,9 +19,11 @@ import { checkUniqueReply } from './utils'
 
 const FixedBottom = styled(Container).attrs({
   backgroundColor: 'white',
-  positioning: { left: 0, right: 0, bottom: 0 },
 })`
   position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
   z-index: 3;
 
   ${safeAreaInsetMixin}

--- a/packages/review/src/components/review-placeholder-with-rating.tsx
+++ b/packages/review/src/components/review-placeholder-with-rating.tsx
@@ -22,10 +22,11 @@ const NavigateToReviewsListButton = styled(Button)`
   padding: 10px 20px;
 `
 
-const RecentTripContainer = styled(Container).attrs({
-  padding: { top: 180, bottom: 60 },
-})`
+const RecentTripContainer = styled(Container)`
   text-align: center;
+  padding-top: 180px;
+  padding-bottom: 60px;
+
   @media only screen and (max-width: 667px) {
     padding-top: 120px;
   }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

styled.attrs로 스타일되었던 props를 css로 변경

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- styled.attrs로 스타일되었던 props를 css로 변경
- app-installation-cta / floating-button-cta가 모바일 사이즈에서만 보이기 때문에 chromatic.viewports 값을 설정합니다.