### PR TITLE
@titicaca/react-triple-client-interfaces를 peer dependency로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37681,11 +37681,11 @@
       "dependencies": {
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/i18n": "^10.3.0",
-        "@titicaca/popup": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0"
+        "@titicaca/popup": "^10.3.0"
       },
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
+        "@titicaca/react-triple-client-interfaces": "*",
         "react": "^18.0",
         "react-dom": "^18.0",
         "styled-components": "^5.3.1"
@@ -38134,11 +38134,11 @@
         "@titicaca/action-sheet": "^10.3.0",
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/i18n": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0",
         "@titicaca/type-definitions": "^10.3.0"
       },
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
+        "@titicaca/react-triple-client-interfaces": "*",
         "react": "^18.0",
         "react-dom": "^18.0",
         "styled-components": "^5.3.1"
@@ -38222,7 +38222,6 @@
         "@titicaca/image-carousel": "^10.3.0",
         "@titicaca/intersection-observer": "^10.3.0",
         "@titicaca/modals": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0",
         "@titicaca/type-definitions": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0",
         "@titicaca/web-storage": "^10.3.0",
@@ -38230,6 +38229,7 @@
       },
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
+        "@titicaca/react-triple-client-interfaces": "*",
         "react": "^18.0",
         "react-dom": "^18.0",
         "styled-components": "^5.3.1"
@@ -38406,12 +38406,12 @@
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/fetcher": "^10.3.0",
         "@titicaca/modals": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0",
         "@titicaca/router": "^10.3.0",
         "@titicaca/ui-flow": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0"
       },
       "peerDependencies": {
+        "@titicaca/react-triple-client-interfaces": "*",
         "react": "^18.0",
         "react-dom": "^18.0",
         "styled-components": "^5.3.1"
@@ -38478,7 +38478,6 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/modals": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0",
         "qs": "^6.9.4"
       },
@@ -38488,6 +38487,7 @@
       },
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
+        "@titicaca/react-triple-client-interfaces": "*",
         "next": "^13.0",
         "react": "^18.0",
         "react-dom": "^18.0",
@@ -38711,12 +38711,12 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/modals": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0",
         "qs": "^6.9.0"
       },
       "peerDependencies": {
         "@titicaca/fetcher": "*",
         "@titicaca/react-contexts": "*",
+        "@titicaca/react-triple-client-interfaces": "*",
         "next": "^13.0",
         "react": "^18.0",
         "react-dom": "^18.0"
@@ -47904,8 +47904,7 @@
       "requires": {
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/i18n": "^10.3.0",
-        "@titicaca/popup": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0"
+        "@titicaca/popup": "^10.3.0"
       }
     },
     "@titicaca/drawer-button": {
@@ -48234,7 +48233,6 @@
         "@titicaca/action-sheet": "^10.3.0",
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/i18n": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0",
         "@titicaca/type-definitions": "^10.3.0"
       }
     },
@@ -48287,7 +48285,6 @@
         "@titicaca/image-carousel": "^10.3.0",
         "@titicaca/intersection-observer": "^10.3.0",
         "@titicaca/modals": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0",
         "@titicaca/type-definitions": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0",
         "@titicaca/web-storage": "^10.3.0",
@@ -48394,7 +48391,6 @@
         "@titicaca/core-elements": "^10.3.0",
         "@titicaca/fetcher": "^10.3.0",
         "@titicaca/modals": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0",
         "@titicaca/router": "^10.3.0",
         "@titicaca/ui-flow": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0"
@@ -48442,7 +48438,6 @@
       "version": "file:packages/router",
       "requires": {
         "@titicaca/modals": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0",
         "@titicaca/view-utilities": "^10.3.0",
         "@types/qs": "^6.9.5",
         "@types/webpack": "^4.41.25",
@@ -48577,7 +48572,6 @@
       "version": "file:packages/ui-flow",
       "requires": {
         "@titicaca/modals": "^10.3.0",
-        "@titicaca/react-triple-client-interfaces": "^10.3.0",
         "qs": "^6.9.0"
       }
     },

--- a/packages/directions-finder/package.json
+++ b/packages/directions-finder/package.json
@@ -22,11 +22,11 @@
   "dependencies": {
     "@titicaca/core-elements": "^10.3.0",
     "@titicaca/i18n": "^10.3.0",
-    "@titicaca/popup": "^10.3.0",
-    "@titicaca/react-triple-client-interfaces": "^10.3.0"
+    "@titicaca/popup": "^10.3.0"
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
+    "@titicaca/react-triple-client-interfaces": "*",
     "react": "^18.0",
     "react-dom": "^18.0",
     "styled-components": "^5.3.1"

--- a/packages/directions-finder/tsconfig.build.json
+++ b/packages/directions-finder/tsconfig.build.json
@@ -17,10 +17,10 @@
       "path": "../popup/tsconfig.build.json"
     },
     {
-      "path": "../react-triple-client-interfaces/tsconfig.build.json"
+      "path": "../react-contexts/tsconfig.build.json"
     },
     {
-      "path": "../react-contexts/tsconfig.build.json"
+      "path": "../react-triple-client-interfaces/tsconfig.build.json"
     }
   ]
 }

--- a/packages/location-properties/package.json
+++ b/packages/location-properties/package.json
@@ -23,11 +23,11 @@
     "@titicaca/action-sheet": "^10.3.0",
     "@titicaca/core-elements": "^10.3.0",
     "@titicaca/i18n": "^10.3.0",
-    "@titicaca/react-triple-client-interfaces": "^10.3.0",
     "@titicaca/type-definitions": "^10.3.0"
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
+    "@titicaca/react-triple-client-interfaces": "*",
     "react": "^18.0",
     "react-dom": "^18.0",
     "styled-components": "^5.3.1"

--- a/packages/location-properties/tsconfig.build.json
+++ b/packages/location-properties/tsconfig.build.json
@@ -17,13 +17,13 @@
       "path": "../i18n/tsconfig.build.json"
     },
     {
-      "path": "../react-triple-client-interfaces/tsconfig.build.json"
-    },
-    {
       "path": "../type-definitions/tsconfig.build.json"
     },
     {
       "path": "../react-contexts/tsconfig.build.json"
+    },
+    {
+      "path": "../react-triple-client-interfaces/tsconfig.build.json"
     }
   ]
 }

--- a/packages/poi-detail/package.json
+++ b/packages/poi-detail/package.json
@@ -29,7 +29,6 @@
     "@titicaca/image-carousel": "^10.3.0",
     "@titicaca/intersection-observer": "^10.3.0",
     "@titicaca/modals": "^10.3.0",
-    "@titicaca/react-triple-client-interfaces": "^10.3.0",
     "@titicaca/type-definitions": "^10.3.0",
     "@titicaca/view-utilities": "^10.3.0",
     "@titicaca/web-storage": "^10.3.0",
@@ -37,6 +36,7 @@
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
+    "@titicaca/react-triple-client-interfaces": "*",
     "react": "^18.0",
     "react-dom": "^18.0",
     "styled-components": "^5.3.1"

--- a/packages/poi-detail/tsconfig.build.json
+++ b/packages/poi-detail/tsconfig.build.json
@@ -35,9 +35,6 @@
       "path": "../modals/tsconfig.build.json"
     },
     {
-      "path": "../react-triple-client-interfaces/tsconfig.build.json"
-    },
-    {
       "path": "../type-definitions/tsconfig.build.json"
     },
     {
@@ -48,6 +45,9 @@
     },
     {
       "path": "../react-contexts/tsconfig.build.json"
+    },
+    {
+      "path": "../react-triple-client-interfaces/tsconfig.build.json"
     }
   ]
 }

--- a/packages/replies/package.json
+++ b/packages/replies/package.json
@@ -24,12 +24,12 @@
     "@titicaca/core-elements": "^10.3.0",
     "@titicaca/fetcher": "^10.3.0",
     "@titicaca/modals": "^10.3.0",
-    "@titicaca/react-triple-client-interfaces": "^10.3.0",
     "@titicaca/router": "^10.3.0",
     "@titicaca/ui-flow": "^10.3.0",
     "@titicaca/view-utilities": "^10.3.0"
   },
   "peerDependencies": {
+    "@titicaca/react-triple-client-interfaces": "*",
     "react": "^18.0",
     "react-dom": "^18.0",
     "styled-components": "^5.3.1"

--- a/packages/replies/tsconfig.build.json
+++ b/packages/replies/tsconfig.build.json
@@ -20,9 +20,6 @@
       "path": "../modals/tsconfig.build.json"
     },
     {
-      "path": "../react-triple-client-interfaces/tsconfig.build.json"
-    },
-    {
       "path": "../router/tsconfig.build.json"
     },
     {
@@ -30,6 +27,9 @@
     },
     {
       "path": "../view-utilities/tsconfig.build.json"
+    },
+    {
+      "path": "../react-triple-client-interfaces/tsconfig.build.json"
     }
   ]
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@titicaca/modals": "^10.3.0",
-    "@titicaca/react-triple-client-interfaces": "^10.3.0",
     "@titicaca/view-utilities": "^10.3.0",
     "qs": "^6.9.4"
   },
@@ -31,6 +30,7 @@
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
+    "@titicaca/react-triple-client-interfaces": "*",
     "next": "^13.0",
     "react": "^18.0",
     "react-dom": "^18.0",

--- a/packages/router/tsconfig.build.json
+++ b/packages/router/tsconfig.build.json
@@ -11,13 +11,13 @@
       "path": "../modals/tsconfig.build.json"
     },
     {
-      "path": "../react-triple-client-interfaces/tsconfig.build.json"
-    },
-    {
       "path": "../view-utilities/tsconfig.build.json"
     },
     {
       "path": "../react-contexts/tsconfig.build.json"
+    },
+    {
+      "path": "../react-triple-client-interfaces/tsconfig.build.json"
     }
   ]
 }

--- a/packages/ui-flow/package.json
+++ b/packages/ui-flow/package.json
@@ -27,12 +27,12 @@
   },
   "dependencies": {
     "@titicaca/modals": "^10.3.0",
-    "@titicaca/react-triple-client-interfaces": "^10.3.0",
     "qs": "^6.9.0"
   },
   "peerDependencies": {
     "@titicaca/fetcher": "*",
     "@titicaca/react-contexts": "*",
+    "@titicaca/react-triple-client-interfaces": "*",
     "next": "^13.0",
     "react": "^18.0",
     "react-dom": "^18.0"

--- a/packages/ui-flow/tsconfig.build.json
+++ b/packages/ui-flow/tsconfig.build.json
@@ -11,13 +11,13 @@
       "path": "../modals/tsconfig.build.json"
     },
     {
-      "path": "../react-triple-client-interfaces/tsconfig.build.json"
-    },
-    {
       "path": "../fetcher/tsconfig.build.json"
     },
     {
       "path": "../react-contexts/tsconfig.build.json"
+    },
+    {
+      "path": "../react-triple-client-interfaces/tsconfig.build.json"
     }
   ]
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

@titicaca/react-triple-client-interfaces를 peer dependency로 변경

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

@titicaca/react-triple-client-interfaces에서 global provider를 사용하기 때문에 @titicaca/react-contexts 처럼 peer dependency 로 설치해야 context를 정상적으로 사용할 수 있습니다.