### PR TITLE
[core-elements] tabs 컴포넌트 generic type 보완

### DIFF
--- a/packages/core-elements/src/elements/tabs/basic-tab.tsx
+++ b/packages/core-elements/src/elements/tabs/basic-tab.tsx
@@ -16,6 +16,9 @@ const StyledTabBase = styled(TabBase)`
   }
 `
 
-export const BasicTab = ({ children, ...props }: TabBaseProps) => {
+export const BasicTab = <Value extends number | string | symbol>({
+  children,
+  ...props
+}: TabBaseProps<Value>) => {
   return <StyledTabBase {...props}>{children}</StyledTabBase>
 }

--- a/packages/core-elements/src/elements/tabs/pointing-tab-context.tsx
+++ b/packages/core-elements/src/elements/tabs/pointing-tab-context.tsx
@@ -1,17 +1,21 @@
 import { createContext, MutableRefObject, useContext } from 'react'
 
-export interface PointingTabContextValue {
-  tabsRef: MutableRefObject<Record<string, HTMLButtonElement | null>>
+export interface PointingTabContextValue<
+  Value extends number | string | symbol,
+> {
+  tabsRef: MutableRefObject<Record<Value, HTMLButtonElement | null>>
   left: number
   width: number
 }
 
 export const PointingTabContext = createContext<
-  PointingTabContextValue | undefined
+  PointingTabContextValue<string> | undefined
 >(undefined)
 
-export function usePointingTab() {
-  const context = useContext(PointingTabContext)
+export function usePointingTab<Value extends number | string | symbol>() {
+  const context = useContext(PointingTabContext) as
+    | PointingTabContextValue<Value>
+    | undefined
   if (!context) {
     throw new Error('PointingTabContext가 없습니다.')
   }

--- a/packages/core-elements/src/elements/tabs/pointing-tab.tsx
+++ b/packages/core-elements/src/elements/tabs/pointing-tab.tsx
@@ -28,9 +28,12 @@ const StyledTabBase = styled(TabBase)<StyledTabBaseProps>`
     `}
 `
 
-export const PointingTab = <Value,>({ children, ...props }: TabBaseProps) => {
+export const PointingTab = <Value extends number | string | symbol>({
+  children,
+  ...props
+}: TabBaseProps<Value>) => {
   const tabs = useTabs<Value>()
-  const { tabsRef } = usePointingTab()
+  const { tabsRef } = usePointingTab<Value>()
 
   return (
     <StyledTabBase

--- a/packages/core-elements/src/elements/tabs/rounded-tab-list.tsx
+++ b/packages/core-elements/src/elements/tabs/rounded-tab-list.tsx
@@ -24,7 +24,7 @@ const StyledTabListBase = styled(TabListBase)<StyledTabListBaseProps>`
     `}
 `
 
-export const RoundedTabList = <Value,>({
+export const RoundedTabList = <Value extends number | string | symbol>({
   children,
   ...props
 }: TabListBaseProps) => {

--- a/packages/core-elements/src/elements/tabs/rounded-tab.tsx
+++ b/packages/core-elements/src/elements/tabs/rounded-tab.tsx
@@ -20,6 +20,9 @@ const StyledTabBase = styled(TabBase)`
   }
 `
 
-export const RoundedTab = ({ children, ...props }: TabBaseProps) => {
+export const RoundedTab = <Value extends number | string | symbol>({
+  children,
+  ...props
+}: TabBaseProps<Value>) => {
   return <StyledTabBase {...props}>{children}</StyledTabBase>
 }

--- a/packages/core-elements/src/elements/tabs/tab-base.tsx
+++ b/packages/core-elements/src/elements/tabs/tab-base.tsx
@@ -1,5 +1,6 @@
 import { useFocusManager } from '@react-aria/focus'
 import {
+  ForwardedRef,
   forwardRef,
   KeyboardEventHandler,
   MouseEventHandler,
@@ -8,59 +9,62 @@ import {
 
 import { useTabs } from './tabs-context'
 
-export interface TabBaseProps extends PropsWithChildren {
+export interface TabBaseProps<Value> extends PropsWithChildren {
   /**
    * 각 탭마다의 유니크한 값
    */
-  value: string
+  value: Value
 }
 
-export const TabBase = forwardRef<HTMLButtonElement, TabBaseProps>(
-  function TabBase({ children, value, ...props }, ref) {
-    const tabs = useTabs()
-    const focusManager = useFocusManager()
+function TabBaseComponent<Value extends number | string | symbol>(
+  { children, value, ...props }: TabBaseProps<Value>,
+  ref: ForwardedRef<HTMLButtonElement>,
+) {
+  const tabs = useTabs<Value>()
+  const focusManager = useFocusManager()
 
-    const isSelected = tabs.value === value
+  const isSelected = tabs.value === value
 
-    const handleClick: MouseEventHandler = () => {
-      tabs.onChange?.(value)
+  const handleClick: MouseEventHandler = () => {
+    tabs.onChange?.(value)
+  }
+
+  const handleKeyDown: KeyboardEventHandler = (event) => {
+    switch (event.key) {
+      case 'ArrowLeft':
+        event.stopPropagation()
+        focusManager.focusPrevious({ wrap: true })
+        break
+      case 'ArrowRight':
+        event.stopPropagation()
+        focusManager.focusNext({ wrap: true })
+        break
+      case 'Home':
+        event.stopPropagation()
+        focusManager.focusFirst({ wrap: true })
+        break
+      case 'End':
+        event.stopPropagation()
+        focusManager.focusLast({ wrap: true })
+        break
     }
+  }
 
-    const handleKeyDown: KeyboardEventHandler = (event) => {
-      switch (event.key) {
-        case 'ArrowLeft':
-          event.stopPropagation()
-          focusManager.focusPrevious({ wrap: true })
-          break
-        case 'ArrowRight':
-          event.stopPropagation()
-          focusManager.focusNext({ wrap: true })
-          break
-        case 'Home':
-          event.stopPropagation()
-          focusManager.focusFirst({ wrap: true })
-          break
-        case 'End':
-          event.stopPropagation()
-          focusManager.focusLast({ wrap: true })
-          break
-      }
-    }
+  return (
+    <button
+      ref={ref}
+      id={`${tabs.id}-tab-${value}`}
+      role="tab"
+      tabIndex={isSelected ? 0 : -1}
+      aria-controls={`${tabs.id}-panel-${value}`}
+      aria-selected={isSelected}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}
 
-    return (
-      <button
-        ref={ref}
-        id={`${tabs.id}-tab-${value}`}
-        role="tab"
-        tabIndex={isSelected ? 0 : -1}
-        aria-controls={`${tabs.id}-panel-${value}`}
-        aria-selected={isSelected}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        {...props}
-      >
-        {children}
-      </button>
-    )
-  },
-)
+export const TabBase = forwardRef(TabBaseComponent)

--- a/packages/core-elements/src/elements/tabs/tab-list.tsx
+++ b/packages/core-elements/src/elements/tabs/tab-list.tsx
@@ -6,8 +6,10 @@ import { useTabs } from './tabs-context'
 
 export type TabListProps = TabListBaseProps
 
-export const TabList = (props: TabListProps) => {
-  const tabs = useTabs()
+export const TabList = <Value extends number | string | symbol>(
+  props: TabListProps,
+) => {
+  const tabs = useTabs<Value>()
 
   switch (tabs.variant) {
     case 'basic':

--- a/packages/core-elements/src/elements/tabs/tab-panel.tsx
+++ b/packages/core-elements/src/elements/tabs/tab-panel.tsx
@@ -9,7 +9,10 @@ export interface TabPanelProps<Value> extends PropsWithChildren {
   value: Value
 }
 
-export const TabPanel = <Value,>({ children, value }: TabPanelProps<Value>) => {
+export const TabPanel = <Value extends number | string | symbol>({
+  children,
+  value,
+}: TabPanelProps<Value>) => {
   const tabs = useTabs<Value>()
 
   return (

--- a/packages/core-elements/src/elements/tabs/tab.tsx
+++ b/packages/core-elements/src/elements/tabs/tab.tsx
@@ -4,9 +4,11 @@ import { RoundedTab } from './rounded-tab'
 import { TabBaseProps } from './tab-base'
 import { useTabs } from './tabs-context'
 
-export type TabProps = TabBaseProps
+export type TabProps<Value> = TabBaseProps<Value>
 
-export const Tab = <Value,>(props: TabBaseProps) => {
+export const Tab = <Value extends number | string | symbol>(
+  props: TabProps<Value>,
+) => {
   const tabs = useTabs<Value>()
 
   switch (tabs.variant) {

--- a/packages/core-elements/src/elements/tabs/tabs-context.tsx
+++ b/packages/core-elements/src/elements/tabs/tabs-context.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext } from 'react'
 
 import { TabVariant } from './types'
 
-export interface TabsContextValue<Value = unknown> {
+export interface TabsContextValue<Value extends number | string | symbol> {
   id: string
   value: Value
   variant: TabVariant
@@ -10,11 +10,11 @@ export interface TabsContextValue<Value = unknown> {
   onChange?: (value: Value) => void
 }
 
-export const TabsContext = createContext<TabsContextValue | undefined>(
+export const TabsContext = createContext<TabsContextValue<string> | undefined>(
   undefined,
 )
 
-export function useTabs<Value>() {
+export function useTabs<Value extends number | string | symbol>() {
   const context = useContext(TabsContext) as TabsContextValue<Value> | undefined
   if (!context) {
     throw new Error('TabsContextContext가 없습니다.')

--- a/packages/core-elements/src/elements/tabs/tabs.tsx
+++ b/packages/core-elements/src/elements/tabs/tabs.tsx
@@ -6,7 +6,8 @@ import { TabPanel } from './tab-panel'
 import { TabsContext, TabsContextValue } from './tabs-context'
 import { TabVariant } from './types'
 
-export interface TabsProps<Value> extends PropsWithChildren {
+export interface TabsProps<Value extends number | string | symbol>
+  extends PropsWithChildren {
   /**
    * 현재 탭을 가르키는 값
    */
@@ -25,7 +26,7 @@ export interface TabsProps<Value> extends PropsWithChildren {
   onChange?: (value: Value) => void
 }
 
-export const Tabs = <Value,>({
+export const Tabs = <Value extends number | string | symbol>({
   children,
   value,
   variant = 'basic',


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
- tabs 컴포넌트에 generic이 빠졌던 부분 추가 및 타입 제한을 추가했습니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- https://github.com/titicacadev/triple-frontend/blob/59f73e6647e56bae04d8254782c23a49ae703d9d/packages/core-elements/src/elements/tabs/pointing-tab-context.tsx#L6
- Record의 key 타입이 `string | number | symbol`로 제한되어 있어서 extends로 추가했습니다. 
- 카나리 적용해보니 잘되긴 하는데 타입이 점점 거대해지네요...

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
