### PR TITLE
[core-elements] Tabs에서 발생하는 non-boolean attributes warning 수정

### DIFF
--- a/packages/core-elements/src/elements/tabs/pointing-tab-list.tsx
+++ b/packages/core-elements/src/elements/tabs/pointing-tab-list.tsx
@@ -10,8 +10,10 @@ interface PointValue {
   width: number
 }
 
-interface StyledTabListBaseProps extends PointValue {
-  scroll: boolean
+interface StyledTabListBaseProps {
+  $left: number
+  $width: number
+  $scroll: boolean
 }
 
 const StyledTabListBase = styled(TabListBase)<StyledTabListBaseProps>`
@@ -19,8 +21,8 @@ const StyledTabListBase = styled(TabListBase)<StyledTabListBaseProps>`
   display: flex;
   border-bottom: 1px solid var(--color-gray50);
 
-  ${({ scroll }) =>
-    scroll &&
+  ${({ $scroll }) =>
+    $scroll &&
     css`
       overflow-x: scroll;
       -webkit-overflow-scrolling: touch;
@@ -35,8 +37,8 @@ const StyledTabListBase = styled(TabListBase)<StyledTabListBaseProps>`
     display: inline-block;
     position: absolute;
     bottom: 0;
-    width: ${({ width }) => `${width}px`};
-    left: ${({ left }) => `${left}px`};
+    width: ${({ $width }) => `${$width}px`};
+    left: ${({ $left }) => `${$left}px`};
     height: 2px;
     background: var(--color-blue);
     transition: all 0.2s;
@@ -72,9 +74,9 @@ export const PointingTabList = <Value extends string>({
   return (
     <StyledTabListBase
       {...props}
-      scroll={tabs.scroll}
-      left={pointValue.left}
-      width={pointValue.width}
+      $scroll={tabs.scroll}
+      $left={pointValue.left}
+      $width={pointValue.width}
     >
       <PointingTabContext.Provider
         value={{

--- a/packages/core-elements/src/elements/tabs/pointing-tab.tsx
+++ b/packages/core-elements/src/elements/tabs/pointing-tab.tsx
@@ -5,7 +5,7 @@ import { TabBase, TabBaseProps } from './tab-base'
 import { useTabs } from './tabs-context'
 
 interface StyledTabBaseProps {
-  scroll: boolean
+  $scroll: boolean
 }
 
 const StyledTabBase = styled(TabBase)<StyledTabBaseProps>`
@@ -19,8 +19,8 @@ const StyledTabBase = styled(TabBase)<StyledTabBaseProps>`
     color: var(--color-gray);
   }
 
-  ${({ scroll }) =>
-    scroll &&
+  ${({ $scroll }) =>
+    $scroll &&
     css`
       flex: none;
 
@@ -35,7 +35,7 @@ export const PointingTab = <Value,>({ children, ...props }: TabBaseProps) => {
   return (
     <StyledTabBase
       ref={(node) => (tabsRef.current[props.value] = node)}
-      scroll={tabs.scroll}
+      $scroll={tabs.scroll}
       {...props}
     >
       {children}

--- a/packages/core-elements/src/elements/tabs/rounded-tab-list.tsx
+++ b/packages/core-elements/src/elements/tabs/rounded-tab-list.tsx
@@ -4,7 +4,7 @@ import { TabListBase, TabListBaseProps } from './tab-list-base'
 import { useTabs } from './tabs-context'
 
 interface StyledTabListBaseProps {
-  scroll: boolean
+  $scroll: boolean
 }
 
 const StyledTabListBase = styled(TabListBase)<StyledTabListBaseProps>`
@@ -12,8 +12,8 @@ const StyledTabListBase = styled(TabListBase)<StyledTabListBaseProps>`
   gap: 5px;
   padding: 10px 30px;
 
-  ${({ scroll }) =>
-    scroll &&
+  ${({ $scroll }) =>
+    $scroll &&
     css`
       overflow-x: scroll;
       -webkit-overflow-scrolling: touch;
@@ -31,7 +31,7 @@ export const RoundedTabList = <Value,>({
   const tabs = useTabs<Value>()
 
   return (
-    <StyledTabListBase {...props} scroll={tabs.scroll}>
+    <StyledTabListBase {...props} $scroll={tabs.scroll}>
       {children}
     </StyledTabListBase>
   )


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

Tabs에서 발생하는 non-boolean attributes warning 수정

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

![image](https://user-images.githubusercontent.com/11497500/207219723-1e89fa11-a9a7-42eb-923f-234077f60594.png)

Tabs에서 styled 컴포넌트에 전달하는 props를 transient prop으로 변경해서 warning을 해결합니다.