### PR TITLE
maxLinesMixin의 css를 수정

### DIFF
--- a/packages/core-elements/src/elements/text.test.tsx
+++ b/packages/core-elements/src/elements/text.test.tsx
@@ -128,7 +128,6 @@ it('should accept maxLines mixin', () => {
   expect(tree).toHaveStyleRule('display', '-webkit-box')
   expect(tree).toHaveStyleRule('-webkit-box-orient', 'vertical')
   expect(tree).toHaveStyleRule('-webkit-line-clamp', '2')
-  expect(tree).toHaveStyleRule('text-overflow', 'ellipsis')
   expect(tree).toHaveStyleRule('overflow', 'hidden')
 })
 

--- a/packages/core-elements/src/mixins/max-lines.ts
+++ b/packages/core-elements/src/mixins/max-lines.ts
@@ -11,8 +11,6 @@ export const maxLinesMixin = ({ maxLines }: Params) =>
         display: -webkit-box;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: ${maxLines};
-        text-overflow: ellipsis;
         overflow: hidden;
-        white-space: pre-line;
       `
     : undefined

--- a/packages/core-elements/src/mixins/max-lines.ts
+++ b/packages/core-elements/src/mixins/max-lines.ts
@@ -12,5 +12,6 @@ export const maxLinesMixin = ({ maxLines }: Params) =>
         -webkit-box-orient: vertical;
         -webkit-line-clamp: ${maxLines};
         overflow: hidden;
+        white-space: normal;
       `
     : undefined


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
호텔 지도웹페이지에서 2줄처리된 컴포넌트의 말줄임 처리가 풀리는 현상
관련 쓰레드: [https://titicaca.slack.com/archives/CEEPB4TDY/p1669943575731609](https://titicaca.slack.com/archives/CEEPB4TDY/p1669943575731609)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
-  text-overflow, white-space 제거
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
