### PR TITLE
[core-elements] numeric-spinner에 customLabel prop 추가

### DIFF
--- a/packages/core-elements/src/elements/numeric-spinner/numeric-spinner.stories.tsx
+++ b/packages/core-elements/src/elements/numeric-spinner/numeric-spinner.stories.tsx
@@ -5,6 +5,8 @@ import {
 } from '@storybook/react'
 import { useState } from 'react'
 
+import { Text } from '../text'
+
 import { NumericSpinner } from './numeric-spinner'
 
 export default {
@@ -35,6 +37,17 @@ export const Size: ComponentStory<typeof NumericSpinner> = () => {
       <NumericSpinner {...Default.args} size="big" />
     </>
   )
+}
+
+export const CustomLabel: ComponentStoryObj<typeof NumericSpinner> = {
+  args: {
+    label: '성인',
+    customLabel: (
+      <Text size="mini" alpha={0.5} margin={{ top: 3 }}>
+        만 12세 이상 (국내선 만 13세 이상)
+      </Text>
+    ),
+  },
 }
 
 export const Controlled: ComponentStory<typeof NumericSpinner> = () => {

--- a/packages/core-elements/src/elements/numeric-spinner/numeric-spinner.tsx
+++ b/packages/core-elements/src/elements/numeric-spinner/numeric-spinner.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { ReactNode, useId } from 'react'
 
 import { FlexBox, FlexBoxItem } from '../flex-box'
 import { Text } from '../text'
@@ -12,12 +12,14 @@ export interface NumericSpinnerProps extends NumericSpinnerBaseProps {
   label?: string
   sublabel?: string
   strikeLabel?: string
+  customLabel?: ReactNode
 }
 
 export const NumericSpinner = ({
   label,
   sublabel,
   strikeLabel,
+  customLabel,
   disabled,
   max,
   min,
@@ -54,6 +56,8 @@ export const NumericSpinner = ({
             {strikeLabel}
           </Text>
         ) : null}
+
+        {customLabel}
       </FlexBoxItem>
 
       <NumericSpinnerBase


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
numeric-spinner에 customLabel prop 추가

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- triple-air-web에 적용하다 보니 라벨 스타일이 다른 경우 밑에 따로 엘리먼트를 추가하여 사용하고 있습니다. 
- 이번에 ui가 개편되면서 flexbox로 변경되면서 엘리먼트를 따로 추가할 경우 간격이 커지는데, 따로 스타일 맞추지 않고 customLabel을 추가하여 prop으로 넣을 수 있게 변경합니다. 

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
https://617b7c4431c922004a42c7cc-ljywuqeujm.chromatic.com/?path=/story/core-elements-numericspinner--custom-label