### PR TITLE
fix: 초기 메시지가 prop으로 있을 경우 api 호출하지 않도록 수정

### DIFF
--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -38,6 +38,10 @@ export interface ChatProps {
    * me(sender), others(receiver)에 대한 기본 정보
    */
   userInfo: UserInfoInterface
+  /**
+   * 초기 메시지들
+   */
+  messages?: MessageInterface[]
   postMessage?: PostMessageType
   getMessages: (option: {
     roomId: string
@@ -63,6 +67,7 @@ export const Chat = ({
   displayTarget,
   userInfo,
   room,
+  messages: initMessages,
 
   postMessage,
   getMessages,
@@ -139,18 +144,31 @@ export const Chat = ({
 
   useEffect(() => {
     ;(async function () {
-      const result = await getMessages({
-        roomId: room.id,
-        backward: true,
-        lastMessageId: Number(room.lastMessageId) + 1,
-      })
+      if (!room.id) {
+        return
+      }
 
-      result &&
-        dispatch({
-          action: ChatActions.INIT,
-          messages: result,
-          lastMessageId: Number(room.lastMessageId),
+      if (!initMessages) {
+        const result = await getMessages({
+          roomId: room.id,
+          backward: true,
+          lastMessageId: Number(room.lastMessageId) + 1,
         })
+
+        result &&
+          dispatch({
+            action: ChatActions.INIT,
+            messages: result,
+            lastMessageId: Number(room.lastMessageId),
+          })
+      } else {
+        initMessages.length > 0 &&
+          dispatch({
+            action: ChatActions.INIT,
+            messages: initMessages,
+            lastMessageId: Number(room.lastMessageId),
+          })
+      }
 
       await updateUnread()
 
@@ -158,7 +176,7 @@ export const Chat = ({
         scrollDown()
       }, 0)
     })()
-  }, [room.id]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [room, initMessages]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     fetchJob.add('refreshChatRoom', () => pollingFetchJob())


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
- 처음 대화하는 채팅일 경우 room이 존재하지 않아 메시지 조회를 하게 되면 undefined로 호출해 500 에러가 발생하는 것을 수정합니다.
- [관련 스레드](https://titicaca.slack.com/archives/CEEPB4TDY/p1673252610679029)
- https://github.com/titicacadev/triple-chat-web/pull/127

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- triple-chat-web의 서버사이드 부분과 chat 컴포넌트 부분에 api 가 중복 호출되고 있어 해당 부분 수정했습니다. 
- server side에서 api 호출을 빼는 방법도 있는데 우선 분기처리로 추가했습니다. 

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
