### PR TITLE
i18n translation key에 한국어 fallback을 추가합니다.

### DIFF
--- a/integration-test/src/router-modal.test.tsx
+++ b/integration-test/src/router-modal.test.tsx
@@ -55,7 +55,7 @@ test('브라우저를 허용하지 않는 링크라면 브라우저 환경에서
   const dialog = getByRole('dialog')
 
   expect(assign).not.toBeCalled()
-  expect(dialog).toHaveTextContent(/teuripeul-gagi/)
+  expect(dialog).toHaveTextContent(/트리플 가기/)
 })
 
 test('로그인한 앱에서만 열리는 링크라면 로그인하지 않은 앱 환경에서 클릭했을 때 링크를 열지않고 로그인 유도 모달을 표시합니다.', () => {
@@ -95,7 +95,7 @@ test('로그인한 앱에서만 열리는 링크라면 로그인하지 않은 �
   const dialog = getByRole('dialog')
 
   expect(assign).not.toBeCalled()
-  expect(dialog).toHaveTextContent(/rogeuini-pilyohabnida\./)
+  expect(dialog).toHaveTextContent(/로그인이 필요합니다\./)
 })
 
 function EnvProviderWrapper({ children }: PropsWithChildren<unknown>) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@swc/plugin-styled-components": "1.5.25",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
-        "@titicaca/eslint-config-triple": "0.0.0-9bdaba1",
+        "@titicaca/eslint-config-triple": "4.2.0",
         "@types/jest": "^27.0.2",
         "@types/node": "^12.12.47",
         "@types/react": "^18.0.21",
@@ -20241,9 +20241,9 @@
       "link": true
     },
     "node_modules/@titicaca/eslint-config-triple": {
-      "version": "0.0.0-9bdaba1",
-      "resolved": "https://registry.npmjs.org/@titicaca/eslint-config-triple/-/eslint-config-triple-0.0.0-9bdaba1.tgz",
-      "integrity": "sha512-1TM7osRSdNEcRgZB9m2dzb03ReHp3JtpB5TkIk+nRJul6sP3DiMXwwkzAEyIfQQSH/04DlUlJx93Ekl6LbFv1Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@titicaca/eslint-config-triple/-/eslint-config-triple-4.2.0.tgz",
+      "integrity": "sha512-jf6rJ+XqNi0H+sxHpYs8pfsM70khDZcY42t8Q/Ft0CU8c8B37Mi9LbJwCFhJgc8B3AzQbQd0jhPkzHDiw3bF7Q==",
       "dev": true,
       "dependencies": {
         "@babel/eslint-parser": "7.15.8",
@@ -66005,9 +66005,9 @@
       }
     },
     "@titicaca/eslint-config-triple": {
-      "version": "0.0.0-9bdaba1",
-      "resolved": "https://registry.npmjs.org/@titicaca/eslint-config-triple/-/eslint-config-triple-0.0.0-9bdaba1.tgz",
-      "integrity": "sha512-1TM7osRSdNEcRgZB9m2dzb03ReHp3JtpB5TkIk+nRJul6sP3DiMXwwkzAEyIfQQSH/04DlUlJx93Ekl6LbFv1Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@titicaca/eslint-config-triple/-/eslint-config-triple-4.2.0.tgz",
+      "integrity": "sha512-jf6rJ+XqNi0H+sxHpYs8pfsM70khDZcY42t8Q/Ft0CU8c8B37Mi9LbJwCFhJgc8B3AzQbQd0jhPkzHDiw3bF7Q==",
       "dev": true,
       "requires": {
         "@babel/eslint-parser": "7.15.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@swc/plugin-styled-components": "1.5.25",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
-        "@titicaca/eslint-config-triple": "0.0.0-1721338",
+        "@titicaca/eslint-config-triple": "0.0.0-9bdaba1",
         "@types/jest": "^27.0.2",
         "@types/node": "^12.12.47",
         "@types/react": "^18.0.21",
@@ -19542,12 +19542,12 @@
       }
     },
     "node_modules/@stylelint/postcss-css-in-js": {
-      "version": "0.37.2",
-      "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
-      "integrity": "sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.38.0.tgz",
+      "integrity": "sha512-XOz5CAe49kS95p5yRd+DAIWDojTjfmyAQ4bbDlXMdbZTQ5t0ThjSLvWI6JI2uiS7MFurVBkZ6zUqcimzcLTBoQ==",
       "dev": true,
       "dependencies": {
-        "@babel/core": ">=7.9.0"
+        "@babel/core": "^7.17.9"
       },
       "peerDependencies": {
         "postcss": ">=7.0.0",
@@ -20241,12 +20241,13 @@
       "link": true
     },
     "node_modules/@titicaca/eslint-config-triple": {
-      "version": "0.0.0-1721338",
+      "version": "0.0.0-9bdaba1",
+      "resolved": "https://registry.npmjs.org/@titicaca/eslint-config-triple/-/eslint-config-triple-0.0.0-9bdaba1.tgz",
+      "integrity": "sha512-1TM7osRSdNEcRgZB9m2dzb03ReHp3JtpB5TkIk+nRJul6sP3DiMXwwkzAEyIfQQSH/04DlUlJx93Ekl6LbFv1Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "7.15.8",
-        "@stylelint/postcss-css-in-js": "0.37.2",
+        "@stylelint/postcss-css-in-js": "0.38.0",
         "@typescript-eslint/parser": "5.6.0",
         "eslint-config-prettier": "8.3.0",
         "eslint-config-standard": "16.0.3",
@@ -65432,12 +65433,12 @@
       }
     },
     "@stylelint/postcss-css-in-js": {
-      "version": "0.37.2",
-      "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
-      "integrity": "sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.38.0.tgz",
+      "integrity": "sha512-XOz5CAe49kS95p5yRd+DAIWDojTjfmyAQ4bbDlXMdbZTQ5t0ThjSLvWI6JI2uiS7MFurVBkZ6zUqcimzcLTBoQ==",
       "dev": true,
       "requires": {
-        "@babel/core": ">=7.9.0"
+        "@babel/core": "^7.17.9"
       }
     },
     "@swc/cli": {
@@ -66004,11 +66005,13 @@
       }
     },
     "@titicaca/eslint-config-triple": {
-      "version": "0.0.0-1721338",
+      "version": "0.0.0-9bdaba1",
+      "resolved": "https://registry.npmjs.org/@titicaca/eslint-config-triple/-/eslint-config-triple-0.0.0-9bdaba1.tgz",
+      "integrity": "sha512-1TM7osRSdNEcRgZB9m2dzb03ReHp3JtpB5TkIk+nRJul6sP3DiMXwwkzAEyIfQQSH/04DlUlJx93Ekl6LbFv1Q==",
       "dev": true,
       "requires": {
         "@babel/eslint-parser": "7.15.8",
-        "@stylelint/postcss-css-in-js": "0.37.2",
+        "@stylelint/postcss-css-in-js": "0.38.0",
         "@typescript-eslint/parser": "5.6.0",
         "eslint-config-prettier": "8.3.0",
         "eslint-config-standard": "16.0.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@swc/plugin-styled-components": "1.5.25",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
-    "@titicaca/eslint-config-triple": "0.0.0-9bdaba1",
+    "@titicaca/eslint-config-triple": "4.2.0",
     "@types/jest": "^27.0.2",
     "@types/node": "^12.12.47",
     "@types/react": "^18.0.21",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@swc/plugin-styled-components": "1.5.25",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
-    "@titicaca/eslint-config-triple": "0.0.0-1721338",
+    "@titicaca/eslint-config-triple": "0.0.0-9bdaba1",
     "@types/jest": "^27.0.2",
     "@types/node": "^12.12.47",
     "@types/react": "^18.0.21",

--- a/packages/app-banner/src/index.tsx
+++ b/packages/app-banner/src/index.tsx
@@ -104,7 +104,7 @@ function AppBanner({
         </Text>
       </ContentContainer>
       <CallToAction href={href} onClick={onCtaClick}>
-        {cta || t('aebeseo-bogi')}
+        {cta || t(['aebeseo-bogi', '앱에서 보기'])}
       </CallToAction>
     </AppBannerFrame>
   )

--- a/packages/app-installation-cta/src/chatbot-cta.tsx
+++ b/packages/app-installation-cta/src/chatbot-cta.tsx
@@ -143,11 +143,11 @@ export default function ChatbotCta({
             {text}
           </ChatbotAction>
           <ChatbotCloseButton onClick={handleDismiss}>
-            {t('dadgi')}
+            {t(['dadgi', '닫기'])}
           </ChatbotCloseButton>
         </ChatBalloon>
         <ChatbotIcon href={installUrl} onClick={handleClick}>
-          {t('teuripeul')}
+          {t(['teuripeul', '트리플'])}
         </ChatbotIcon>
       </ChatbotContainer>
     </CSSTransition>

--- a/packages/app-installation-cta/src/image-banner.tsx
+++ b/packages/app-installation-cta/src/image-banner.tsx
@@ -67,11 +67,15 @@ function ImageBanner({
         <span role="img" aria-label="eyes">
           👀
         </span>
-        <span>&nbsp;&nbsp;{installText || t('pyeonhage-aebeseo-bogi')}</span>
+        <span>
+          &nbsp;&nbsp;
+          {installText || t(['pyeonhage-aebeseo-bogi', '편하게 앱에서 보기'])}
+        </span>
       </InstallLink>
 
       <DismissButton onClick={handleDismiss}>
-        {dismissText || t('aggabjiman-najunge-badeulgeyo')}
+        {dismissText ||
+          t(['aggabjiman-najunge-badeulgeyo', '아깝지만 나중에 받을게요'])}
       </DismissButton>
     </ImageBannerWrapper>
   )

--- a/packages/booking-completion/src/index.tsx
+++ b/packages/booking-completion/src/index.tsx
@@ -96,7 +96,8 @@ function BookingCompletion({
         }}
       >
         <Text size={28} bold>
-          {title || t('yeyagi-n-jeobsudoeeossseubnida.')}
+          {title ||
+            t(['yeyagi-n-jeobsudoeeossseubnida.', '예약이\n접수되었습니다.'])}
         </Text>
       </Container>
       {(descriptions || []).map((description, idx) => (
@@ -111,7 +112,10 @@ function BookingCompletion({
         </DescriptionText>
       ))}
       <Text color="gray" size="mini" alpha={0.5}>
-        {t('jasehan-sahangeun-nae-yeyageseo-hwaginhaejuseyo.')}
+        {t([
+          'jasehan-sahangeun-nae-yeyageseo-hwaginhaejuseyo.',
+          '자세한 사항은 내 예약에서 확인해주세요.',
+        ])}
       </Text>
       {compact ? (
         <Button
@@ -123,7 +127,8 @@ function BookingCompletion({
           onClick={onMoveToBookingDetail}
           fluid
         >
-          {myBookingButtonTitle || t('nae-yeyageseo-hwagin')}
+          {myBookingButtonTitle ||
+            t(['nae-yeyageseo-hwagin', '내 예약에서 확인'])}
         </Button>
       ) : (
         <>
@@ -140,7 +145,8 @@ function BookingCompletion({
                 size="small"
                 onClick={onMoveToBookingDetail}
               >
-                {myBookingButtonTitle || t('nae-yeyageseo-hwagin')}
+                {myBookingButtonTitle ||
+                  t(['nae-yeyageseo-hwagin', '내 예약에서 확인'])}
               </Button>
               <Button
                 basic
@@ -152,19 +158,25 @@ function BookingCompletion({
                   navigate('/main')
                 }}
               >
-                {t('teuripeul-homeuro-gagi')}
+                {t(['teuripeul-homeuro-gagi', '트리플 홈으로 가기'])}
               </Button>
             </ButtonGroup>
           </Container>
           {regionName ? (
             <GrayButton fluid margin={{ top: 6 }} onClick={handleMoveToRegion}>
-              {t('regionname-yeohaeng-junbihareo-gagi', { regionName })}
+              {t(
+                [
+                  'regionname-yeohaeng-junbihareo-gagi',
+                  '{{regionName}} 여행 준비하러 가기',
+                ],
+                { regionName },
+              )}
             </GrayButton>
           ) : null}
 
           {onAddToSchedule ? (
             <GrayButton fluid margin={{ top: 6 }} onClick={onAddToSchedule}>
-              {t('nae-iljeonge-cugahagi')}
+              {t(['nae-iljeonge-cugahagi', '내 일정에 추가하기'])}
             </GrayButton>
           ) : null}
         </>

--- a/packages/core-elements/src/utils/format-source-url.ts
+++ b/packages/core-elements/src/utils/format-source-url.ts
@@ -4,5 +4,7 @@ export default function formatSourceUrl(url: string) {
   const t = getTranslation('common-web')
 
   const httpsSchemeRemovedUrl = url.replace(/^https?:\/\//, '')
-  return t('culceo-httpsschemeremovedurl', { httpsSchemeRemovedUrl })
+  return t(['culceo-httpsschemeremovedurl', '출처 {{httpsSchemeRemovedUrl}}'], {
+    httpsSchemeRemovedUrl,
+  })
 }

--- a/packages/directions-finder/src/ask-to-the-local.tsx
+++ b/packages/directions-finder/src/ask-to-the-local.tsx
@@ -100,7 +100,7 @@ export default function AskToTheLocal({
                     />
                   </Icon>
                 </IconContainer>
-                {t('jeonhwahagi')}
+                {t(['jeonhwahagi', '전화하기'])}
               </CallButton>
               {isDomestic ? null : (
                 <Text
@@ -108,7 +108,10 @@ export default function AskToTheLocal({
                   alpha={0.5}
                   padding={{ top: 6, bottom: 0 }}
                 >
-                  {t('gugje-jeonhwa-yogeumi-bugwadoel-su-issseubnida.')}
+                  {t([
+                    'gugje-jeonhwa-yogeumi-bugwadoel-su-issseubnida.',
+                    '국제 전화 요금이 부과될 수 있습니다.',
+                  ])}
                 </Text>
               )}
             </DrawerContentContainer>

--- a/packages/directions-finder/src/direction-buttons.tsx
+++ b/packages/directions-finder/src/direction-buttons.tsx
@@ -49,7 +49,7 @@ function DirectionButtons({
             size="small"
             onClick={handleAskToLocalsClick}
           >
-            {t('hyeonjieseo-gilmudgi')}
+            {t(['hyeonjieseo-gilmudgi', '현지에서 길묻기'])}
           </Button>
         ) : null}
         <Button
@@ -59,7 +59,7 @@ function DirectionButtons({
           size="small"
           onClick={onDirectionsClick}
         >
-          {t('gilcajgi')}
+          {t(['gilcajgi', '길찾기'])}
         </Button>
       </ButtonGroup>
 

--- a/packages/form/src/action-sheet-selector/action-sheet.tsx
+++ b/packages/form/src/action-sheet-selector/action-sheet.tsx
@@ -79,7 +79,7 @@ export default function ActionSheetWrapper({
             }
           }}
         >
-          {t('seontaegwanryo')}
+          {t(['seontaegwanryo', '선택완료'])}
         </DrawerButton>
       )}
     </>

--- a/packages/form/src/action-sheet-selector/index.tsx
+++ b/packages/form/src/action-sheet-selector/index.tsx
@@ -51,7 +51,7 @@ function ActionSheetSelector({
       ? []
       : [
           {
-            label: t('seontaeghagi'),
+            label: t(['seontaeghagi', '선택하기']),
             value: null,
           },
         ]),
@@ -65,7 +65,7 @@ function ActionSheetSelector({
       <Container onClick={onOpen}>
         <FieldContainer error={!!error}>
           <Text size="large" alpha={selected ? 1 : 0.5}>
-            {selected ? selected.label : t('seontaeghagi')}
+            {selected ? selected.label : t(['seontaeghagi', '선택하기'])}
           </Text>
           <ArrowDown />
         </FieldContainer>

--- a/packages/form/src/gender-radio/index.tsx
+++ b/packages/form/src/gender-radio/index.tsx
@@ -48,7 +48,7 @@ function GenderRadio({ name, value, onChange }: GenderRadioProps) {
         selected={value === 'MALE'}
         onClick={(e: SyntheticEvent) => onChange && onChange(e, 'MALE')}
       >
-        {t('namja')}
+        {t(['namja', '남자'])}
       </GenderContainer>
 
       <GenderContainer
@@ -57,7 +57,7 @@ function GenderRadio({ name, value, onChange }: GenderRadioProps) {
         selected={value === 'FEMALE'}
         onClick={(e: SyntheticEvent) => onChange && onChange(e, 'FEMALE')}
       >
-        {t('yeoja')}
+        {t(['yeoja', '여자'])}
       </GenderContainer>
     </Container>
   )

--- a/packages/i18n/src/assets/ko/common-web.ts
+++ b/packages/i18n/src/assets/ko/common-web.ts
@@ -191,4 +191,4 @@ export const koCommonWeb = {
   'selpeupaekiji-cugahalin-ganeung': '셀프패키지 추가할인 가능',
   gwangwang: '관광',
   masjib: '맛집',
-}
+} as const

--- a/packages/i18n/src/i18n-common-web-keys.ts
+++ b/packages/i18n/src/i18n-common-web-keys.ts
@@ -1,3 +1,5 @@
 import { koCommonWeb } from './assets/ko/common-web'
 
-export type I18nCommonWebKeys = typeof koCommonWeb
+type I18nKeys = typeof koCommonWeb
+type I18nTokens = Record<I18nKeys[keyof I18nKeys], string>
+export type I18nCommonWebKeys = I18nKeys & I18nTokens

--- a/packages/location-properties/src/location-properties.tsx
+++ b/packages/location-properties/src/location-properties.tsx
@@ -50,7 +50,7 @@ function LocationProperties({
 
       addressValue &&
         allValues.set('addresses', {
-          title: t('juso'),
+          title: t(['juso', '주소']),
           value: addressValue,
           onClick: onAddressesClick,
           eventActionFragment: '기본정보_주소',
@@ -58,7 +58,7 @@ function LocationProperties({
 
       phoneNumber &&
         allValues.set('phoneNumber', {
-          title: t('jeonhwa'),
+          title: t(['jeonhwa', '전화']),
           value: phoneNumber,
           onClick: onPhoneNumberClick,
           eventActionFragment: '기본정보_전화번호',
@@ -66,7 +66,7 @@ function LocationProperties({
 
       officialSiteUrl &&
         allValues.set('officialSiteUrl', {
-          title: t('hompeiji'),
+          title: t(['hompeiji', '홈페이지']),
           value: officialSiteUrl,
           singleLine: true,
           onClick: onOfficialSiteUrlClick,
@@ -114,11 +114,14 @@ function LocationProperties({
         </List>
       </Segment>
       <ActionSheet
-        title={t('bogsahagi')}
+        title={t(['bogsahagi', '복사하기'])}
         open={isActionSheetOpen}
         onClose={back}
       >
-        <ActionSheetItem buttonLabel={t('bogsa')} onClick={handleClick} />
+        <ActionSheetItem
+          buttonLabel={t(['bogsa', '복사'])}
+          onClick={handleClick}
+        />
       </ActionSheet>
     </>
   )

--- a/packages/meta-tags/src/facebook-app-link-meta.tsx
+++ b/packages/meta-tags/src/facebook-app-link-meta.tsx
@@ -22,12 +22,12 @@ export function FacebookAppLinkMeta({
       <meta
         key="al-ios-app-name"
         property="al:ios:app_name"
-        content={appName ?? t('teuripeul')}
+        content={appName ?? t(['teuripeul', '트리플'])}
       />
       <meta
         key="al-android-app-name"
         property="al:android:app_name"
-        content={appName ?? t('teuripeul')}
+        content={appName ?? t(['teuripeul', '트리플'])}
       />
       <meta
         key="al-ios-url"

--- a/packages/modals/src/login-cta-modal.test.tsx
+++ b/packages/modals/src/login-cta-modal.test.tsx
@@ -53,7 +53,7 @@ test('history context가 LOGIN_CTA_MODAL_HASH를 반환할 때 로그인 dialog�
 
   const { getByRole } = render(<LoginCtaModalProvider />)
 
-  expect(getByRole('dialog')).toHaveTextContent(/rogeuini-pilyohabnida\./)
+  expect(getByRole('dialog')).toHaveTextContent(/로그인이 필요합니다\./)
 })
 
 test('여러 개의 provider가 있어도 하나의 dialog를 렌더링합니다.', () => {

--- a/packages/modals/src/login-cta-modal.tsx
+++ b/packages/modals/src/login-cta-modal.tsx
@@ -47,7 +47,7 @@ export function LoginCtaModalProvider({
 
       <Confirm
         open={open}
-        title={t('rogeuini-pilyohabnida.')}
+        title={t(['rogeuini-pilyohabnida.', '로그인이 필요합니다.'])}
         onClose={back}
         onCancel={back}
         onConfirm={() => {
@@ -67,7 +67,10 @@ export function LoginCtaModalProvider({
           return true
         }}
       >
-        {t('rogeuinhago-teuripeuleul-deo-pyeonhage-iyonghaseyo')}
+        {t([
+          'rogeuinhago-teuripeuleul-deo-pyeonhage-iyonghaseyo',
+          '로그인하고 트리플을\n더 편하게 이용하세요🙂',
+        ])}
       </Confirm>
     </LoginCtaContext.Provider>
   )

--- a/packages/modals/src/transition-modal.tsx
+++ b/packages/modals/src/transition-modal.tsx
@@ -36,7 +36,7 @@ export enum TransitionType {
 
 const MODAL_CONTENT: {
   [type: string]: {
-    description?: keyof I18nCommonWebKeys
+    description?: (keyof I18nCommonWebKeys)[]
     eventLabel?: string
   }
 } = {
@@ -64,8 +64,10 @@ const MODAL_CONTENT: {
     eventLabel: '호텔_선택',
   },
   [TransitionType.View]: {
-    description:
+    description: [
       'iljeong-jjagibuteo-hotel-tueotikes-yeyagggaji-teuripeulro-han-beone-yeohaeng-junbihaseyo.',
+      '일정 짜기부터 호텔, 투어・티켓 예약까지!\n트리플로 한 번에 여행 준비하세요.',
+    ],
     eventLabel: '컨텐츠_연속보기',
   },
 }
@@ -86,7 +88,10 @@ export function TransitionModal({
 
   if (matchData && Object.keys(MODAL_CONTENT).includes(matchData[1])) {
     const {
-      description = 'teuripeul-aebeseo-deoug-dayanghan-gineungeul-pyeonrihage-iyonghaeboseyo.',
+      description = [
+        'teuripeul-aebeseo-deoug-dayanghan-gineungeul-pyeonrihage-iyonghaeboseyo.',
+        '트리플 앱에서 더욱 다양한 기능을\n편리하게 이용해보세요.',
+      ],
       eventLabel = '',
     } = MODAL_CONTENT[matchData[1]] || {}
 
@@ -104,7 +109,7 @@ export function TransitionModal({
         </Modal.Body>
         <Modal.Actions>
           <Modal.Action color="gray" onClick={back}>
-            {t('cwiso')}
+            {t(['cwiso', '취소'])}
           </Modal.Action>
           <Modal.Action
             color="blue"
@@ -121,7 +126,7 @@ export function TransitionModal({
               window.location.href = deepLink
             }}
           >
-            {t('teuripeul-gagi')}
+            {t(['teuripeul-gagi', '트리플 가기'])}
           </Modal.Action>
         </Modal.Actions>
       </Modal>

--- a/packages/nearby-pois/src/nearby-pois.tsx
+++ b/packages/nearby-pois/src/nearby-pois.tsx
@@ -156,18 +156,18 @@ function NearbyPois({
           margin: '0 0 20px',
         }}
       >
-        {t('geunceoyi-cuceon-jangso')}
+        {t(['geunceoyi-cuceon-jangso', '근처의 추천 장소'])}
       </H1>
 
       <Tabs variant="basic" value={currentTab} onChange={handleTabChange}>
         <TabList>
-          <Tab value="attraction">{t('gwangwang')}</Tab>
-          <Tab value="restaurant">{t('masjib')}</Tab>
+          <Tab value="attraction">{t(['gwangwang', '관광'])}</Tab>
+          <Tab value="restaurant">{t(['masjib', '맛집'])}</Tab>
         </TabList>
         <TabPanel value={currentTab}>
           {pois.length === 0 && hasMore === false ? (
             <Paragraph center margin={{ top: 70 }}>
-              {t('jangsoga-eobsseubnida.')}
+              {t(['jangsoga-eobsseubnida.', '장소가 없습니다.'])}
             </Paragraph>
           ) : (
             <>
@@ -193,7 +193,7 @@ function NearbyPois({
                   disabled={fetching}
                   onClick={handleLoadMore}
                 >
-                  {t('deo-manheun-jangso-bogi')}
+                  {t(['deo-manheun-jangso-bogi', '더 많은 장소 보기'])}
                 </Button>
               )}
             </>

--- a/packages/poi-detail/src/actions.tsx
+++ b/packages/poi-detail/src/actions.tsx
@@ -81,12 +81,14 @@ function Actions({
             icon={scraped ? 'saveFilled' : 'saveEmpty'}
             onClick={onScrapedChange}
           >
-            {scraped ? t('jeojangcwiso') : t('jeojanghagi')}
+            {scraped
+              ? t(['jeojangcwiso', '저장취소'])
+              : t(['jeojanghagi', '저장하기'])}
           </ActionButton>
         ) : null}
         {onScheduleAdd ? (
           <ActionButton icon="schedule" onClick={onScheduleAdd}>
-            {t('iljeongcuga')}
+            {t(['iljeongcuga', '일정추가'])}
           </ActionButton>
         ) : null}
         <ActionButton
@@ -106,10 +108,12 @@ function Actions({
               positioning={{ top: -26 }}
             />
           ) : null}
-          {reviewed ? t('ribyusujeong') : t('ribyusseugi')}
+          {reviewed
+            ? t(['ribyusujeong', '리뷰수정'])
+            : t(['ribyusseugi', '리뷰쓰기'])}
         </ActionButton>
         <ActionButton icon="share" onClick={onContentShare}>
-          {t('gongyuhagi')}
+          {t(['gongyuhagi', '공유하기'])}
         </ActionButton>
       </ButtonGroup>
       {!noDivider && <HR1 css={{ marginTop: 8, marginBottom: 0 }} />}

--- a/packages/poi-detail/src/copy-action-sheet-item.tsx
+++ b/packages/poi-detail/src/copy-action-sheet-item.tsx
@@ -14,7 +14,7 @@ export default function CopyActionSheetItem({
   const handleClick = useCallback(() => value && onCopy(value), [value, onCopy])
 
   return value ? (
-    <ActionSheetItem onClick={handleClick} buttonLabel={t('bogsa')}>
+    <ActionSheetItem onClick={handleClick} buttonLabel={t(['bogsa', '복사'])}>
       {value}
     </ActionSheetItem>
   ) : null

--- a/packages/poi-detail/src/detail-header-v2/index.tsx
+++ b/packages/poi-detail/src/detail-header-v2/index.tsx
@@ -115,7 +115,7 @@ function DetailHeaderV2({
                 <Rating score={reviewsRating} />
                 {reviewsCount > 0 && ` ${formatNumber(reviewsCount)}`}
                 <ArrowButton onClick={onReviewsRatingClick}>
-                  {t('ribyubogi')}
+                  {t(['ribyubogi', '리뷰보기'])}
                 </ArrowButton>
               </Text>
             ) : null}
@@ -127,7 +127,9 @@ function DetailHeaderV2({
           vicinity={vicinity}
           arrowAction={
             onAreaClick ? (
-              <ArrowButton onClick={onAreaClick}>{t('jidobogi')}</ArrowButton>
+              <ArrowButton onClick={onAreaClick}>
+                {t(['jidobogi', '지도보기'])}
+              </ArrowButton>
             ) : null
           }
         />

--- a/packages/poi-detail/src/detail-header/business-hours-note.tsx
+++ b/packages/poi-detail/src/detail-header/business-hours-note.tsx
@@ -39,8 +39,14 @@ export default function BusinessHoursNote({
           onClick={onClick}
         >
           {todayBusinessHours
-            ? t('yeongeobjunbijung-todaybusinesshours', { todayBusinessHours })
-            : t('hyumuil')}
+            ? t(
+                [
+                  'yeongeobjunbijung-todaybusinesshours',
+                  '영업준비중 {{todayBusinessHours}}',
+                ],
+                { todayBusinessHours },
+              )
+            : t(['hyumuil', '휴무일'])}
         </Text>
 
         <IconBox>

--- a/packages/poi-detail/src/image-carousel/cta-overlay.tsx
+++ b/packages/poi-detail/src/image-carousel/cta-overlay.tsx
@@ -26,7 +26,7 @@ export default function CtaOverlay() {
   return (
     <MoreImageOverlayLink>
       <MoreImageOverlayLinkIcon src="https://assets.triple.guide/images/ico-arrow@4x.png" />
-      {t('teuripeul-aebeseo-deobogi')}
+      {t(['teuripeul-aebeseo-deobogi', '트리플 앱에서 더보기'])}
     </MoreImageOverlayLink>
   )
 }

--- a/packages/poi-detail/src/image-carousel/note.tsx
+++ b/packages/poi-detail/src/image-carousel/note.tsx
@@ -40,7 +40,7 @@ export function PermanentlyClosedNote({
   return (
     <NoteContainer warning bottomBorderRadius={bottomBorderRadius}>
       <Text bold size="small" color="white">
-        {t('deoisang-unyeonghaji-anhseubnida.')}
+        {t(['deoisang-unyeonghaji-anhseubnida.', '더이상 운영하지 않습니다.'])}
       </Text>
     </NoteContainer>
   )
@@ -75,10 +75,22 @@ export function BusinessHoursNote({
     >
       <Text bold size="small" color="white">
         {currentBusinessHours
-          ? t('yeongeobjung-todaybusinesshours', { todayBusinessHours })
+          ? t(
+              [
+                'yeongeobjung-todaybusinesshours',
+                '영업중 {{todayBusinessHours}}',
+              ],
+              { todayBusinessHours },
+            )
           : todayBusinessHours
-          ? t('yeongeobjunbijung-todaybusinesshours', { todayBusinessHours })
-          : t('hyumuil')}
+          ? t(
+              [
+                'yeongeobjunbijung-todaybusinesshours',
+                '영업준비중 {{todayBusinessHours}}',
+              ],
+              { todayBusinessHours },
+            )
+          : t(['hyumuil', '휴무일'])}
       </Text>
     </NoteContainer>
   )

--- a/packages/poi-detail/src/image-carousel/placeholder.tsx
+++ b/packages/poi-detail/src/image-carousel/placeholder.tsx
@@ -56,7 +56,10 @@ function ImagePlaceholder({
           <>
             <PlaceholderIcon src="https://assets.triple.guide/images/img-empty-photo-m@4x.png" />
             <Text size="small" color="gray" alpha={0.3}>
-              {t('igosyi-ceos-beonjjae-sajineul-olryeojuseyo.')}
+              {t([
+                'igosyi-ceos-beonjjae-sajineul-olryeojuseyo.',
+                '이곳의 첫 번째 사진을 올려주세요.',
+              ])}
             </Text>
           </>
         )}

--- a/packages/poi-detail/src/recommended-articles/recommended-articles.tsx
+++ b/packages/poi-detail/src/recommended-articles/recommended-articles.tsx
@@ -125,7 +125,10 @@ function RecommendedArticles({
             textAlign: 'center',
           }}
         >
-          {t('nohcigi-aggaun-i-jiyeog-ggul-jeongbo')}
+          {t([
+            'nohcigi-aggaun-i-jiyeog-ggul-jeongbo',
+            '놓치기 아까운 이 지역 꿀 정보',
+          ])}
         </H1>
 
         <Carousel
@@ -159,7 +162,7 @@ function RecommendedArticles({
           )}
         >
           <MoreButton basic compact onClick={handleShowMoreClick}>
-            {t('yeohaeng-jeongbo-deobogi')}
+            {t(['yeohaeng-jeongbo-deobogi', '여행 정보 더보기'])}
           </MoreButton>
         </Container>
       </Responsive>
@@ -169,7 +172,10 @@ function RecommendedArticles({
             margin: '0 0 0 30px',
           }}
         >
-          {t('nohcigi-aggaun-ni-jiyeog-ggul-jeongbo')}
+          {t([
+            'nohcigi-aggaun-ni-jiyeog-ggul-jeongbo',
+            '놓치기 아까운\n이 지역 꿀 정보',
+          ])}
         </H1>
 
         <Carousel
@@ -203,7 +209,7 @@ function RecommendedArticles({
           )}
         >
           <MoreButton basic compact onClick={handleShowMoreClick}>
-            {t('yeohaeng-jeongbo-deobogi')}
+            {t(['yeohaeng-jeongbo-deobogi', '여행 정보 더보기'])}
           </MoreButton>
         </Container>
       </Responsive>

--- a/packages/poi-list-elements/src/extended-poi-list-element.tsx
+++ b/packages/poi-list-elements/src/extended-poi-list-element.tsx
@@ -79,7 +79,7 @@ export function ExtendedPoiListElement<T extends PoiListElementType>({
   const note = (
     notes || [
       starRating
-        ? t('starrating-seonggeub', { starRating })
+        ? t(['starrating-seonggeub', '{{starRating}}성급'], { starRating })
         : category
         ? category.name
         : null,

--- a/packages/poi-list-elements/src/get-type-names.ts
+++ b/packages/poi-list-elements/src/get-type-names.ts
@@ -4,11 +4,11 @@ import { I18nCommonWebKeys } from '@titicaca/i18n'
 import { PoiListElementType } from './types'
 
 const TYPE_NAMES: {
-  [key in PoiListElementType['type']]: keyof I18nCommonWebKeys
+  [key in PoiListElementType['type']]: (keyof I18nCommonWebKeys)[]
 } = {
-  attraction: 'gwangwangmyeongso',
-  restaurant: 'eumsigjeom',
-  hotel: 'hotel',
+  attraction: ['gwangwangmyeongso', '관광명소'],
+  restaurant: ['eumsigjeom', '음식점'],
+  hotel: ['hotel', '호텔'],
 }
 
 export function getTypeNames(type: PoiListElementType['type']) {

--- a/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
+++ b/packages/poi-list-elements/src/poi-card-element/poi-card-element.tsx
@@ -198,7 +198,7 @@ function PoiCardElement({
                   color="blue"
                   margin={{ right: 4 }}
                 >
-                  {t('distance-inae', { distance })}
+                  {t(['distance-inae', '{{distance}} 이내'], { distance })}
                 </Text>
               ) : null}
 
@@ -206,7 +206,13 @@ function PoiCardElement({
               {priceLabelOverride ||
                 (nightlyPrice !== undefined ? (
                   <Text inlineBlock size="small">
-                    {t('formattednightlyprice-weon', { formattedNightlyPrice })}
+                    {t(
+                      [
+                        'formattednightlyprice-weon',
+                        '{{formattedNightlyPrice}}원',
+                      ],
+                      { formattedNightlyPrice },
+                    )}
                   </Text>
                 ) : null)}
             </Container>

--- a/packages/pricing/src/fixed-pricing-v2/index.tsx
+++ b/packages/pricing/src/fixed-pricing-v2/index.tsx
@@ -179,7 +179,13 @@ function FixedPricingV2({
                       color={isSoldOut ? 'gray300' : 'gray'}
                     >
                       {priceLabelOverride ||
-                        t('formattedsaleprice-weon', { formattedSalePrice })}
+                        t(
+                          [
+                            'formattedsaleprice-weon',
+                            '{{formattedSalePrice}}원',
+                          ],
+                          { formattedSalePrice },
+                        )}
                       {discountRate}
                     </Text>
                     {pricingDescription}

--- a/packages/pricing/src/fixed-pricing.tsx
+++ b/packages/pricing/src/fixed-pricing.tsx
@@ -129,7 +129,9 @@ export default function FixedPricing({
               color={isSoldOut ? 'gray300' : 'gray'}
             >
               {priceLabelOverride ||
-                t('formattedsaleprice-weon', { formattedSalePrice })}
+                t(['formattedsaleprice-weon', '{{formattedSalePrice}}원'], {
+                  formattedSalePrice,
+                })}
               {discountRate}
             </Text>
             {pricingDescription}

--- a/packages/pricing/src/index.tsx
+++ b/packages/pricing/src/index.tsx
@@ -175,7 +175,9 @@ function RichPricing({
 
         <Text size={20} bold inline color={isSoldOut ? 'gray300' : 'gray'}>
           {priceLabelOverride ||
-            t('formattedsaleprice-weon', { formattedSalePrice })}
+            t(['formattedsaleprice-weon', '{{formattedSalePrice}}원'], {
+              formattedSalePrice,
+            })}
         </Text>
       </PricingContainer>
       {pricingDescription}
@@ -210,7 +212,9 @@ const RegularPricing = ({
       )}
       <Text size={18} bold inline color={isSoldOut ? 'gray300' : 'gray'}>
         {priceLabelOverride ||
-          t('formattedsaleprice-weon', { formattedSalePrice })}
+          t(['formattedsaleprice-weon', '{{formattedSalePrice}}원'], {
+            formattedSalePrice,
+          })}
       </Text>
     </PricingContainer>
   )

--- a/packages/public-header/src/categories.ts
+++ b/packages/public-header/src/categories.ts
@@ -20,13 +20,13 @@ export function getCategoryTitle(category?: Category) {
 
   switch (category) {
     case 'air':
-      return t('triple-hanggong-hom')
+      return t(['triple-hanggong-hom', 'Triple 항공 홈'])
     case 'hotels':
-      return t('triple-sugso-hom')
+      return t(['triple-sugso-hom', 'Triple 숙소 홈'])
     case 'tna':
-      return t('triple-tueo-tikes-hom')
+      return t(['triple-tueo-tikes-hom', 'Triple 투어 티켓 홈'])
     default:
-      return t('triple-hom')
+      return t(['triple-hom', 'Triple 홈'])
   }
 }
 
@@ -36,17 +36,17 @@ export function getCategoryImageProps(category?: Category) {
   switch (category) {
     case 'air':
       return {
-        alt: t('hanggong'),
+        alt: t(['hanggong', '항공']),
         src: 'https://assets.triple.guide/images/img_intro_logo_air.svg',
       }
     case 'hotels':
       return {
-        alt: t('sugso'),
+        alt: t(['sugso', '숙소']),
         src: 'https://assets.triple.guide/images/img_intro_logo_hotels.svg',
       }
     case 'tna':
       return {
-        alt: t('tueo-tikes'),
+        alt: t(['tueo-tikes', '투어 티켓']),
         src: 'https://assets.triple.guide/images/img_intro_logo_tna.svg',
       }
     default:

--- a/packages/public-header/src/public-header-deeplink.tsx
+++ b/packages/public-header/src/public-header-deeplink.tsx
@@ -29,7 +29,7 @@ export function PublicHeaderDeeplink({ deeplinkPath }: Props) {
           })
         }
       >
-        {t('aebeseo-bogi')}
+        {t(['aebeseo-bogi', '앱에서 보기'])}
       </ExtraActionItem>
     </>
   )

--- a/packages/public-header/src/public-header.tsx
+++ b/packages/public-header/src/public-header.tsx
@@ -128,7 +128,7 @@ export function PublicHeader({
 
         <ExtraActionsContainer>
           <ExtraActionItem href={linkHref} onClick={onClick}>
-            {linkLabel ?? t('nae-yeyag')}
+            {linkLabel ?? t(['nae-yeyag', '내 예약'])}
           </ExtraActionItem>
           {deeplinkPath && <PublicHeaderDeeplink deeplinkPath={deeplinkPath} />}
         </ExtraActionsContainer>

--- a/packages/replies/src/guide-text.tsx
+++ b/packages/replies/src/guide-text.tsx
@@ -37,13 +37,22 @@ export default function GuideText() {
         >
           <Text size={12} lineHeight="19px" bold color="gray700">
             {!currentMessageId
-              ? t('mentioningusername-nimgge-dabgeul-jagseong-jung', {
-                  mentioningUserName,
-                })
+              ? t(
+                  [
+                    'mentioningusername-nimgge-dabgeul-jagseong-jung',
+                    '{{mentioningUserName}}님께 답글 작성 중',
+                  ],
+                  {
+                    mentioningUserName,
+                  },
+                )
               : currentMessageId === parentMessageId
-              ? t('daesgeul-sujeong-jung')
+              ? t(['daesgeul-sujeong-jung', '댓글 수정 중'])
               : t(
-                  'mentioningusername-nimege-jagseonghan-dabgeul-sujeong-jung',
+                  [
+                    'mentioningusername-nimege-jagseonghan-dabgeul-sujeong-jung',
+                    '{{mentioningUserName}}님에게 작성한 답글 수정 중',
+                  ],
                   { mentioningUserName },
                 )}
           </Text>

--- a/packages/replies/src/list/index.tsx
+++ b/packages/replies/src/list/index.tsx
@@ -40,8 +40,8 @@ export default function ReplyList({
   const { showToast } = useTripleClientActions()
 
   const description = mentioningUserName
-    ? t('dabgeuleul-sagjehasigessseubnigga')
-    : t('daesgeuleul-sagjehasigessseubnigga')
+    ? t(['dabgeuleul-sagjehasigessseubnigga', '답글을 삭제하시겠습니까?'])
+    : t(['daesgeuleul-sagjehasigessseubnigga', '댓글을 삭제하시겠습니까?'])
 
   const handleReplyDelete = async () => {
     const response = await deleteReply({
@@ -56,9 +56,9 @@ export default function ReplyList({
       }
 
       if (showToast) {
-        showToast(t('sagjedoeeossseubnida.'))
+        showToast(t(['sagjedoeeossseubnida.', '삭제되었습니다.']))
       } else {
-        alert(t('sagjedoeeossseubnida.'))
+        alert(t(['sagjedoeeossseubnida.', '삭제되었습니다.']))
       }
     }
   }
@@ -86,7 +86,7 @@ export default function ReplyList({
               inlineBlock
               onClick={() => fetchMoreReplies()}
             >
-              {t('ijeon-daesgeul-deobogi')}
+              {t(['ijeon-daesgeul-deobogi', '이전 댓글 더보기'])}
             </Text>
           ) : null}
 
@@ -137,9 +137,10 @@ function ConfirmEditModal({ onConfirm }: { onConfirm: () => void }) {
       onClose={back}
       onConfirm={onConfirm}
     >
-      {t(
+      {t([
         'sujeongeul-cwisohasigessseubnigga-n-sujeonghan-naeyongeun-jeojangdoeji-anhseubnida.',
-      )}
+        '수정을 취소하시겠습니까?\n수정한 내용은 저장되지 않습니다.',
+      ])}
     </Confirm>
   )
 }

--- a/packages/replies/src/list/not-exist-replies.tsx
+++ b/packages/replies/src/list/not-exist-replies.tsx
@@ -19,9 +19,10 @@ export default function NotExistReplies() {
         }}
       >
         <Text size={14} lineHeight={1.2} color="gray300">
-          {t(
+          {t([
             'ajig-daesgeuli-eobseoyo.-gajang-meonjeo-daesgeuleul-jagseonghaeboseyo',
-          )}
+            '아직 댓글이 없어요.\n가장 먼저 댓글을 작성해보세요!',
+          ])}
         </Text>
       </Container>
 

--- a/packages/replies/src/list/reply.tsx
+++ b/packages/replies/src/list/reply.tsx
@@ -309,7 +309,10 @@ export default function Reply({
 
             {likeReactionCount && likeReactionCount > 0 ? (
               <Text padding={{ left: 2 }} size={12} color="gray300" bold>
-                {t('johayo-likereactioncount', { likeReactionCount })}
+                {t(
+                  ['johayo-likereactioncount', '좋아요 {{likeReactionCount}}'],
+                  { likeReactionCount },
+                )}
               </Text>
             ) : null}
 
@@ -320,7 +323,7 @@ export default function Reply({
               bold
               onClick={() => handleWriteReplyClick(actionReply)}
             >
-              {t('dabgeuldalgi')}
+              {t(['dabgeuldalgi', '답글달기'])}
             </Text>
           </ReactionBox>
         ) : null}
@@ -336,7 +339,7 @@ export default function Reply({
           inlineBlock
           onClick={() => fetchMoreReplies(reply)}
         >
-          {t('ijeon-dabgeul-deobogi')}
+          {t(['ijeon-dabgeul-deobogi', '이전 답글 더보기'])}
         </Text>
       ) : null}
 
@@ -359,11 +362,11 @@ export default function Reply({
         title={
           isMine
             ? parentId
-              ? t('nae-dabgeul')
-              : t('nae-daesgeul')
+              ? t(['nae-dabgeul', '내 답글'])
+              : t(['nae-daesgeul', '내 댓글'])
             : parentId
-            ? t('dabgeul')
-            : t('daesgeul')
+            ? t(['dabgeul', '답글'])
+            : t(['daesgeul', '댓글'])
         }
         actionSheetHash={`${HASH_MORE_ACTION_SHEET}.${id}`}
         onEditClick={() =>
@@ -453,7 +456,7 @@ function Content({
           cursor="pointer"
           onClick={() => setUnfolded((prevState) => !prevState)}
         >
-          {t('...deobogi')}
+          {t(['...deobogi', '…더보기'])}
         </Text>
       ) : null}
     </Container>
@@ -489,15 +492,15 @@ function FeatureActionSheet({
       {isMine ? (
         <>
           <ActionSheetItem onClick={onEditClick}>
-            {t('sujeonghagi')}
+            {t(['sujeonghagi', '수정하기'])}
           </ActionSheetItem>
           <ActionSheetItem onClick={onDeleteClick}>
-            {t('sagjehagi')}
+            {t(['sagjehagi', '삭제하기'])}
           </ActionSheetItem>
         </>
       ) : (
         <ActionSheetItem onClick={onReportClick}>
-          {t('singohagi')}
+          {t(['singohagi', '신고하기'])}
         </ActionSheetItem>
       )}
     </ActionSheet>
@@ -518,8 +521,14 @@ function deriveContent({
   const t = getTranslation('common-web')
 
   const contentText = {
-    deleted: t('jagseongjaga-sagjehan-daesgeulibnida.'),
-    blinded: t('dareun-sayongjayi-singoro-beulraindeu-doeeossseubnida.'),
+    deleted: t([
+      'jagseongjaga-sagjehan-daesgeulibnida.',
+      '작성자가 삭제한 댓글입니다.',
+    ]),
+    blinded: t([
+      'dareun-sayongjayi-singoro-beulraindeu-doeeossseubnida.',
+      '다른 사용자의 신고로 블라인드 되었습니다.',
+    ]),
   }
 
   const type =

--- a/packages/replies/src/register.test.tsx
+++ b/packages/replies/src/register.test.tsx
@@ -22,7 +22,7 @@ describe('Reply 등록 버튼을 테스트합니다.', () => {
       { wrapper: ReplyWithLoginWrapper },
     )
 
-    const registerButtonElement = getByRole('button', { name: /deungrog/ })
+    const registerButtonElement = getByRole('button', { name: /등록/ })
 
     expect(registerButtonElement).toHaveStyleRule(
       'color',
@@ -48,7 +48,7 @@ describe('Reply 등록 버튼을 테스트합니다.', () => {
 
     fireEvent.change(textareaElement, { target: { value: 'Hi' } })
 
-    const registerButtonElement = getByRole('button', { name: /deungrog/ })
+    const registerButtonElement = getByRole('button', { name: /등록/ })
 
     expect(registerButtonElement).toHaveStyleRule('color', 'var(--color-blue)')
   })

--- a/packages/replies/src/register.tsx
+++ b/packages/replies/src/register.tsx
@@ -77,8 +77,10 @@ function Register(
   })
 
   const placeholder = parentMessageId
-    ? placeholders?.childReply || t('dabgeuleul-ibryeoghaseyo.')
-    : placeholders?.reply || t('daesgeuleul-ibryeoghaseyo.')
+    ? placeholders?.childReply ||
+      t(['dabgeuleul-ibryeoghaseyo.', '답글을 입력하세요.'])
+    : placeholders?.reply ||
+      t(['daesgeuleul-ibryeoghaseyo.', '댓글을 입력하세요.'])
 
   return (
     <Container
@@ -112,7 +114,7 @@ function Register(
           }}
           active={!!plaintext}
         >
-          {t('deungrog')}
+          {t(['deungrog', '등록'])}
         </RegisterButton>
       </FlexBox>
 

--- a/packages/replies/src/reply.test.tsx
+++ b/packages/replies/src/reply.test.tsx
@@ -18,15 +18,15 @@ jest.mock('@titicaca/ui-flow')
 jest.mock('./replies-api-client')
 jest.mock('@titicaca/next-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, data: I18nExpressions) => {
-      if (key === 'johayo-likereactioncount') {
+    t: (key: string[], data: I18nExpressions) => {
+      if (key.includes('johayo-likereactioncount')) {
         return `좋아요 ${data.likeReactionCount}`
       }
 
-      return key
+      return key[0]
     },
   }),
-  getTranslation: () => (key: string) => key,
+  getTranslation: () => (key: string[]) => key[0],
 }))
 
 beforeEach(() => {

--- a/packages/resource-list-element/src/extended-resource-list-element.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.tsx
@@ -145,7 +145,7 @@ function ExtendedResourceListElement<R extends ResourceMeta>({
                   margin={{ right: 5 }}
                   verticalAlign="middle"
                 >
-                  {t('gwanggo')}
+                  {t(['gwanggo', '광고'])}
                 </Label>
               ) : null}
               {distance || distance === 0 ? (

--- a/packages/resource-list-element/src/review-scrap-stat.tsx
+++ b/packages/resource-list-element/src/review-scrap-stat.tsx
@@ -32,7 +32,13 @@ function ReviewScrapStat({
         stats={[
           reviewsCount ? `(${formatNumber(reviewsCount)})` : null,
           scrapsCount
-            ? t('jeojang-formattedscrapscount', { formattedScrapsCount })
+            ? t(
+                [
+                  'jeojang-formattedscrapscount',
+                  '저장 {{formattedScrapsCount}}',
+                ],
+                { formattedScrapsCount },
+              )
             : null,
         ]}
         inline

--- a/packages/review/src/components/my-review-action-sheet.tsx
+++ b/packages/review/src/components/my-review-action-sheet.tsx
@@ -76,11 +76,11 @@ export default function MyReviewActionSheet({
       >
         {!myReview.blindedAt ? (
           <ActionSheetItem icon="review" onClick={onReviewEdit}>
-            {t('sujeonghagi')}
+            {t(['sujeonghagi', '수정하기'])}
           </ActionSheetItem>
         ) : null}
         <ActionSheetItem icon="delete" onClick={handleDeleteMenuClick}>
-          {t('sagjehagi')}
+          {t(['sagjehagi', '삭제하기'])}
         </ActionSheetItem>
       </ActionSheet>
 
@@ -98,9 +98,10 @@ export default function MyReviewActionSheet({
                 })
         }
       >
-        {t(
+        {t([
           'sagjehagessseubnigga-sagjehamyeon-jeogribdoen-ribyu-pointeudo-hamgge-sarajibnida.',
-        )}
+          '삭제하겠습니까? 삭제하면 적립된 리뷰 포인트도 함께 사라집니다.',
+        ])}
       </Confirm>
     </>
   )

--- a/packages/review/src/components/others-review-action-sheet.tsx
+++ b/packages/review/src/components/others-review-action-sheet.tsx
@@ -33,7 +33,7 @@ export default function OthersReviewActionSheet({
       onClose={back}
     >
       <ActionSheetItem icon="report" onClick={handleReportClick}>
-        {t('singohagi')}
+        {t(['singohagi', '신고하기'])}
       </ActionSheetItem>
     </ActionSheet>
   )

--- a/packages/review/src/components/recent-checkbox.tsx
+++ b/packages/review/src/components/recent-checkbox.tsx
@@ -83,7 +83,7 @@ export default function RecentCheckBox({
     >
       <FlexBox flex alignItems="center" onClick={onRecentReviewChange}>
         <CheckBox readOnly type="checkbox" checked={isRecentReview} />
-        <Text size={14}>{t('coegeun-yeohaeng')}</Text>
+        <Text size={14}>{t(['coegeun-yeohaeng', '최근 여행'])}</Text>
       </FlexBox>
       <ToolTip />
     </FlexBox>
@@ -121,9 +121,10 @@ function ToolTip() {
             color="gray800"
             padding={{ top: 15, left: 15, bottom: 15, right: 37 }}
           >
-            {t(
+            {t([
               'coegeun-6gaeweol-naee-bangmunhan-yeohaengyi-ribyuman-moa-bol-su-issseubnida.',
-            )}
+              '최근 6개월 내에 방문한 여행의 리뷰만 모아 볼 수 있습니다.',
+            ])}
             <CloseIcon
               width={10}
               height={10}

--- a/packages/review/src/components/review-container.tsx
+++ b/packages/review/src/components/review-container.tsx
@@ -339,7 +339,13 @@ function ReviewContainer({
         {shortened ? (
           <>
             {(totalReviewsCount || 0) > 0 ? (
-              <Trans i18nKey="ribyu-totalreviewscount" ns="common-web">
+              <Trans
+                i18nKey={[
+                  'ribyu-totalreviewscount',
+                  '<0>리뷰</0><1> {{totalReviewsCount}}</1>',
+                ]}
+                ns="common-web"
+              >
                 <Text bold size="huge" color="gray" alpha={1} inline />
                 <Text bold size="huge" color="blue" alpha={1} inline>
                   <>{{ totalReviewsCount: formatNumber(totalReviewsCount) }}</>
@@ -348,7 +354,13 @@ function ReviewContainer({
             ) : null}
           </>
         ) : (
-          <Trans i18nKey="totalreviewscount-gaeyi-ribyu" ns="common-web">
+          <Trans
+            i18nKey={[
+              'totalreviewscount-gaeyi-ribyu',
+              '<0> {{totalReviewsCount}}</0><1>개의 리뷰</1>',
+            ]}
+            ns="common-web"
+          >
             <Text bold size="huge" color="blue" alpha={1} inline>
               <>{{ totalReviewsCount: formatNumber(totalReviewsCount) }}</>
             </Text>
@@ -429,7 +441,13 @@ function ReviewContainer({
                     : handleFullListButtonClick
                 }
               >
-                {t('numofrestreviews-gae-ribyu-deobogi', { numOfRestReviews })}
+                {t(
+                  [
+                    'numofrestreviews-gae-ribyu-deobogi',
+                    '{{numOfRestReviews}}개 리뷰 더보기',
+                  ],
+                  { numOfRestReviews },
+                )}
               </Button>
             </Container>
           ) : null}
@@ -453,12 +471,17 @@ function ReviewContainer({
               }}
             >
               <Text color="gray" size="small" alpha={0.6} lineHeight={1.7}>
-                {t('ribyu-sseumyeon-yeohaengja-keulreob-coedae-3pointeu')}
+                {t([
+                  'ribyu-sseumyeon-yeohaengja-keulreob-coedae-3pointeu',
+                  '리뷰 쓰면 여행자 클럽 최대 3포인트!',
+                ])}
               </Text>
               <Text color="blue" size="small" lineHeight={1.7}>
-                {t('pointeubyeol-hyetaeg-bogi')}
+                {t(['pointeubyeol-hyetaeg-bogi', '포인트별 혜택 보기'])}
               </Text>
-              <BulletRight alt={t('pointeubyeol-hyetaeg-bogi')} />
+              <BulletRight
+                alt={t(['pointeubyeol-hyetaeg-bogi', '포인트별 혜택 보기'])}
+              />
             </MileageButton>
           ) : null}
         </>

--- a/packages/review/src/components/review-element/foldable-comment.tsx
+++ b/packages/review/src/components/review-element/foldable-comment.tsx
@@ -50,7 +50,7 @@ function FoldedComment({
   return (
     <Comment>
       {`${comment} …`}
-      <Unfold onClick={onUnfoldButtonClick}>{t('deobogi')}</Unfold>
+      <Unfold onClick={onUnfoldButtonClick}>{t(['deobogi', '더보기'])}</Unfold>
     </Comment>
   )
 }

--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -206,7 +206,10 @@ function ReviewElement({
           }
         >
           {blindedAt ? (
-            t('singoga-jeobsudoeeo-beulraindeu-ceoridoeeossseubnida.')
+            t([
+              'singoga-jeobsudoeeo-beulraindeu-ceoridoeeossseubnida.',
+              '신고가 접수되어 블라인드 처리되었습니다.',
+            ])
           ) : comment ? (
             unfolded ? (
               comment
@@ -396,16 +399,22 @@ function RecentReviewInfo({
             alt="recent-trip-icon"
           />
           <Text padding={{ left: 4, right: 8 }} size={14} color="blue" bold>
-            {t('coegeun-yeohaeng')}
+            {t(['coegeun-yeohaeng', '최근 여행'])}
           </Text>
         </>
       ) : null}
       {visitDate ? (
         <Text size={14} color="gray700">
-          {t('visityear-nyeon-visitmonth-weol-yeohaeng', {
-            visitYear,
-            visitMonth,
-          })}
+          {t(
+            [
+              'visityear-nyeon-visitmonth-weol-yeohaeng',
+              '{{visitYear}}년 {{visitMonth}}월 여행',
+            ],
+            {
+              visitYear,
+              visitMonth,
+            },
+          )}
         </Text>
       ) : null}
     </FlexBox>

--- a/packages/review/src/components/review-element/user.tsx
+++ b/packages/review/src/components/review-element/user.tsx
@@ -56,7 +56,9 @@ export default function User({
           >
             {level && level > 0 ? `LEVEL${level} / ` : null}
             {reviewsCount
-              ? t('reviewscount-gaeyi-ribyu', { reviewsCount })
+              ? t(['reviewscount-gaeyi-ribyu', '{{reviewsCount}}개의 리뷰'], {
+                  reviewsCount,
+                })
               : null}
           </Text>
         ) : null}

--- a/packages/review/src/components/review-placeholder-with-rating.tsx
+++ b/packages/review/src/components/review-placeholder-with-rating.tsx
@@ -74,7 +74,11 @@ function ReviewsPlaceholder({
       {!recentTrip ? (
         <DefaultPlaceholder
           placeholderText={
-            placeholderText ?? t('igosyi-ceos-beonjjae-ribyureul-olryeojuseyo.')
+            placeholderText ??
+            t([
+              'igosyi-ceos-beonjjae-ribyureul-olryeojuseyo.',
+              '이곳의 첫 번째 리뷰를 올려주세요.',
+            ])
           }
         />
       ) : null}
@@ -122,10 +126,16 @@ function RecentTripPlaceholder({
         lineHeight="21px"
         textAlign="center"
       >
-        {t('seontaeghan-jogeonyi-ribyuga-eobsseubnida.')}
+        {t([
+          'seontaeghan-jogeonyi-ribyuga-eobsseubnida.',
+          '선택한 조건의 리뷰가 없습니다.',
+        ])}
       </Text>
       <Text size={14} lineHeight="19px" textAlign="center" color="gray500">
-        {t('danyeoon-yeohaengjiyi-ribyureul-namgyeoboseyo.')}
+        {t([
+          'danyeoon-yeohaengjiyi-ribyureul-namgyeoboseyo.',
+          '다녀온 여행지의\n리뷰를 남겨보세요.',
+        ])}
       </Text>
     </RecentTripContainer>
   ) : (
@@ -135,7 +145,10 @@ function RecentTripPlaceholder({
       }}
     >
       <Text size={14} color="gray500">
-        {t('seontaeghan-jogeonyi-ribyuga-eobsseubnida.')}
+        {t([
+          'seontaeghan-jogeonyi-ribyuga-eobsseubnida.',
+          '선택한 조건의 리뷰가 없습니다.',
+        ])}
       </Text>
       {hasReviews ? (
         <NavigateToReviewsListButton
@@ -144,7 +157,7 @@ function RecentTripPlaceholder({
           onClick={onClick}
         >
           <Text size={13} color="white" bold>
-            {t('jeonce-ribyu-bogi')}
+            {t(['jeonce-ribyu-bogi', '전체 리뷰 보기'])}
           </Text>
         </NavigateToReviewsListButton>
       ) : null}

--- a/packages/review/src/components/reviews-list.tsx
+++ b/packages/review/src/components/reviews-list.tsx
@@ -71,7 +71,7 @@ export default function ReviewsList({
         })
 
         if (unregister) {
-          showToast(t('taltoehan-sayongjaibnida.'))
+          showToast(t(['taltoehan-sayongjaibnida.', '탈퇴한 사용자입니다.']))
         } else {
           navigateUserDetail(uid)
         }

--- a/packages/review/src/components/sorting-options.tsx
+++ b/packages/review/src/components/sorting-options.tsx
@@ -26,8 +26,8 @@ export default function SortingOptions({
   const { t } = useTranslation('common-web')
 
   const sortingOptions = [
-    { key: ORDER_BY_RECOMMENDATION, text: t('cuceonsun') },
-    { key: ORDER_BY_RECENCY, text: t('coesinsun') },
+    { key: ORDER_BY_RECOMMENDATION, text: t(['cuceonsun', '추천순']) },
+    { key: ORDER_BY_RECENCY, text: t(['coesinsun', '최신순']) },
   ]
 
   return (

--- a/packages/router/src/common/disabled-link-notifier.ts
+++ b/packages/router/src/common/disabled-link-notifier.ts
@@ -34,7 +34,12 @@ export function useDisabledLinkNotifierCreator({
   }: AllowSourceProps) => {
     if (allowSource === 'none') {
       return () => {
-        alert(t('jeobgeunhal-su-eobsneun-ringkeuibnida.'))
+        alert(
+          t([
+            'jeobgeunhal-su-eobsneun-ringkeuibnida.',
+            '접근할 수 없는 링크입니다.',
+          ]),
+        )
       }
     }
 

--- a/packages/social-reviews/src/external-links.tsx
+++ b/packages/social-reviews/src/external-links.tsx
@@ -82,7 +82,7 @@ function ExternalLinkItem<Data>({
               <Image.FixedRatioFrame frame="big">
                 <Image.Img
                   src={imageUrl}
-                  alt={t('title-sseomneil', { title })}
+                  alt={t(['title-sseomneil', '{{title}} 썸네일'], { title })}
                 />
               </Image.FixedRatioFrame>
             </Image>

--- a/packages/social-reviews/src/social-review.tsx
+++ b/packages/social-reviews/src/social-review.tsx
@@ -33,7 +33,7 @@ function SocialReviews({
 
   return (
     <ExternalLinks
-      title={t('sosyeol-ribyu')}
+      title={t(['sosyeol-ribyu', '소셜 리뷰'])}
       externalLinks={socialReviews.map(
         ({ imageUrl, publisher: meta, title, url }) => ({
           data: url,

--- a/packages/standard-action-handler/src/copy-to-clipboard.ts
+++ b/packages/standard-action-handler/src/copy-to-clipboard.ts
@@ -16,7 +16,10 @@ export default async function copyToClipboard({
 
       textClipboardCopier({
         text,
-        message: t('keulribbodeue-bogsadoeeossseubnida.'),
+        message: t([
+          'keulribbodeue-bogsadoeeossseubnida.',
+          '클립보드에 복사되었습니다.',
+        ]),
       })
     }
 

--- a/packages/standard-action-handler/src/services/share.ts
+++ b/packages/standard-action-handler/src/services/share.ts
@@ -65,11 +65,11 @@ function shareNativeInterface({ params }: { params: SharingParams }) {
     imageUrl: image || DEFAULT_IMAGE,
     buttons: [
       {
-        title: t('webeseo-bogi'),
+        title: t(['webeseo-bogi', '웹에서 보기']),
         webUrl: webUrl as string,
       },
       {
-        title: t('teuripeuleseo-bogi'),
+        title: t(['teuripeuleseo-bogi', '트리플에서 보기']),
         webUrl: webUrl as string,
         appUrl,
       },

--- a/packages/standard-action-handler/src/share.ts
+++ b/packages/standard-action-handler/src/share.ts
@@ -10,7 +10,10 @@ export default async function share({ url: { path } = {} }: WebActionParams) {
     const params = getSharingParams()
     const shareUrl = createShareUrl()
 
-    shareUrl({ params, message: t('ringkeureul-bogsahaessseubnida.') })
+    shareUrl({
+      params,
+      message: t(['ringkeureul-bogsahaessseubnida.', '링크를 복사했습니다.']),
+    })
 
     return true
   }

--- a/packages/static-page-contents/src/index.tsx
+++ b/packages/static-page-contents/src/index.tsx
@@ -92,14 +92,23 @@ export function StaticPageContents({
         />
       )
     case !init:
-      return <NoContent>{t('keontenceureul-rodingjungibnida.')}</NoContent>
+      return (
+        <NoContent>
+          {t(['keontenceureul-rodingjungibnida.', '컨텐츠를 로딩중입니다.'])}
+        </NoContent>
+      )
     default:
       if (onFallback) {
         return onFallback()
       }
 
       return (
-        <NoContent>{t('keontenceureul-bulreool-su-eobsseubnida.')}</NoContent>
+        <NoContent>
+          {t([
+            'keontenceureul-bulreool-su-eobsseubnida.',
+            '컨텐츠를 불러올 수 없습니다.',
+          ])}
+        </NoContent>
       )
   }
 }

--- a/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
+++ b/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
@@ -191,7 +191,7 @@ export function CouponDownloadButton({
         disabled={buttonDisabled}
         onClick={handleCouponDownloadButtonClick}
       >
-        {t('kupon-badgi')}
+        {t(['kupon-badgi', '쿠폰 받기'])}
       </BaseCouponDownloadButton>
       <CouponAlertModal identifier={slugId} errorMessage={errorMessage} />
     </>
@@ -359,7 +359,7 @@ export function CouponGroupDownloadButton({
         disabled={buttonDisabled}
         onClick={handleCouponDownloadButtonClick}
       >
-        {t('kupon-badgi')}
+        {t(['kupon-badgi', '쿠폰 받기'])}
       </BaseCouponDownloadButton>
       <CouponAlertModal identifier={groupId} errorMessage={errorMessage} />
     </>

--- a/packages/triple-document/src/elements/coupon/modals.tsx
+++ b/packages/triple-document/src/elements/coupon/modals.tsx
@@ -50,32 +50,53 @@ export function CouponModal({ identifier }: { identifier: string }) {
   const modalHash = uriHash.replace(`${identifier}.`, '')
 
   const titleTypes: HashKeyValue = {
-    [HASH_ALREADY_DOWNLOAD_COUPON]: t('imi-badeun-kuponibnida.'),
-    [HASH_COMPLETE_DOWNLOAD_COUPON]: t('kupon-badgi-wanryo'),
-    [HASH_COMPLETE_DOWNLOAD_COUPON_GROUP]: t('kupon-badgi-wanryo'),
-    [HASH_COMPLETE_DOWNLOAD_PART_OF_COUPON_GROUP]: t('kupon-badgi-wanryo'),
+    [HASH_ALREADY_DOWNLOAD_COUPON]: t([
+      'imi-badeun-kuponibnida.',
+      '이미 받은 쿠폰입니다.',
+    ]),
+    [HASH_COMPLETE_DOWNLOAD_COUPON]: t([
+      'kupon-badgi-wanryo',
+      '쿠폰 받기 완료',
+    ]),
+    [HASH_COMPLETE_DOWNLOAD_COUPON_GROUP]: t([
+      'kupon-badgi-wanryo',
+      '쿠폰 받기 완료',
+    ]),
+    [HASH_COMPLETE_DOWNLOAD_PART_OF_COUPON_GROUP]: t([
+      'kupon-badgi-wanryo',
+      '쿠폰 받기 완료',
+    ]),
   }
 
   const messageTypes: HashKeyValue = {
-    [HASH_COMPLETE_DOWNLOAD_COUPON]: t(
+    [HASH_COMPLETE_DOWNLOAD_COUPON]: t([
       'kuponeul-badassseubnida-kuponhameseo-hwaginhal-su-isseoyo~',
-    ),
+      '쿠폰을 받았습니다!\n쿠폰함에서 확인할 수 있어요~!',
+    ]),
 
-    [HASH_COMPLETE_DOWNLOAD_COUPON_GROUP]: t(
+    [HASH_COMPLETE_DOWNLOAD_COUPON_GROUP]: t([
       'kuponeul-modu-badassseubnida.-kuponhameseo-hwaginhal-su-isseoyo~',
-    ),
+      '쿠폰을 모두 받았습니다.\n쿠폰함에서 확인할 수 있어요~!',
+    ]),
 
-    [HASH_ALREADY_DOWNLOAD_COUPON]: t('kuponhameseo-kuponeul-hwaginhaseyo.'),
-    [HASH_COMPLETE_DOWNLOAD_PART_OF_COUPON_GROUP]: t(
+    [HASH_ALREADY_DOWNLOAD_COUPON]: t([
+      'kuponhameseo-kuponeul-hwaginhaseyo.',
+      '쿠폰함에서 쿠폰을 확인하세요.',
+    ]),
+    [HASH_COMPLETE_DOWNLOAD_PART_OF_COUPON_GROUP]: t([
       'kuponeul-modu-badassseubnida.-imi-badeun-kupon-jeoe-kuponhameseo-hwaginhal-su-isseoyo~',
-    ),
+      '쿠폰을 모두 받았습니다.\n(이미 받은 쿠폰 제외)\n쿠폰함에서 확인할 수 있어요~!',
+    ]),
   }
 
   const confirmMessageTypes: HashKeyValue = {
-    [HASH_ALREADY_DOWNLOAD_COUPON]: t('kuponham-gagi'),
-    [HASH_COMPLETE_DOWNLOAD_COUPON]: t('kupon-hwagin'),
-    [HASH_COMPLETE_DOWNLOAD_COUPON_GROUP]: t('kupon-hwagin'),
-    [HASH_COMPLETE_DOWNLOAD_PART_OF_COUPON_GROUP]: t('kupon-hwagin'),
+    [HASH_ALREADY_DOWNLOAD_COUPON]: t(['kuponham-gagi', '쿠폰함 가기']),
+    [HASH_COMPLETE_DOWNLOAD_COUPON]: t(['kupon-hwagin', '쿠폰 확인']),
+    [HASH_COMPLETE_DOWNLOAD_COUPON_GROUP]: t(['kupon-hwagin', '쿠폰 확인']),
+    [HASH_COMPLETE_DOWNLOAD_PART_OF_COUPON_GROUP]: t([
+      'kupon-hwagin',
+      '쿠폰 확인',
+    ]),
   }
 
   return (
@@ -118,7 +139,7 @@ export function CouponModal({ identifier }: { identifier: string }) {
 
       <Modal.Actions>
         <Modal.Action color="gray" onClick={back}>
-          {t('cwiso')}
+          {t(['cwiso', '취소'])}
         </Modal.Action>
         <Modal.Action
           color="blue"
@@ -152,7 +173,7 @@ export function CouponAlertModal({
 
   return (
     <Alert
-      title={t('kupon-daunrodeu-annae')}
+      title={t(['kupon-daunrodeu-annae', '쿠폰 다운로드 안내'])}
       open={uriHash === `${identifier}.${HASH_ERROR_COUPON}`}
       onConfirm={back}
     >

--- a/packages/triple-document/src/elements/itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary.tsx
@@ -243,7 +243,7 @@ export default function ItineraryElement({ value }: Props) {
           >
             <Download />
             <Text inline size={14} margin={{ left: 3 }} color="white">
-              {t('nae-iljeongeuro-damgi')}
+              {t(['nae-iljeongeuro-damgi', '내 일정으로 담기'])}
             </Text>
           </SaveToItineraryButton>
         ) : null}

--- a/packages/triple-document/src/elements/pois.tsx
+++ b/packages/triple-document/src/elements/pois.tsx
@@ -98,7 +98,9 @@ function renderPoiListActionButton({
     return (
       <PoiPrice>
         <Text bold size="mini">
-          {nightlyPrice ? `₩${nightlyPrice.toLocaleString()}` : t('bogi')}
+          {nightlyPrice
+            ? `₩${nightlyPrice.toLocaleString()}`
+            : t(['bogi', '보기'])}
         </Text>
       </PoiPrice>
     )

--- a/packages/triple-document/src/elements/regions.tsx
+++ b/packages/triple-document/src/elements/regions.tsx
@@ -81,7 +81,7 @@ export function RegionListElement({
           src={style && style.backgroundImageUrl}
         />
         <Name>{nameOverride || names.ko || names.en || names.local}</Name>
-        <Action>{t('barogagi')}</Action>
+        <Action>{t(['barogagi', '바로가기'])}</Action>
       </ResourceListItem>
     )
   }

--- a/packages/triple-document/src/elements/tna/helpers.ts
+++ b/packages/triple-document/src/elements/tna/helpers.ts
@@ -26,9 +26,15 @@ export function generateCoupon({
   )
   const displayPricePolicy =
     applicableCoupon &&
-    t('formattedapplicableamountafterusingcoupon-weon', {
-      formattedApplicableAmountAfterUsingCoupon,
-    })
+    t(
+      [
+        'formattedapplicableamountafterusingcoupon-weon',
+        '{{formattedApplicableAmountAfterUsingCoupon}}원',
+      ],
+      {
+        formattedApplicableAmountAfterUsingCoupon,
+      },
+    )
 
   return {
     hasCoupon,

--- a/packages/triple-document/src/elements/tna/price-policy-coupon-info.tsx
+++ b/packages/triple-document/src/elements/tna/price-policy-coupon-info.tsx
@@ -25,7 +25,7 @@ export function PricePolicyCouponInfo({
       {hasOnlyExpectedApplicableCoupon ? (
         <>
           <Text bold inlineBlock size="tiny" color={emphasisColor}>
-            {t('kuponhalin')}
+            {t(['kuponhalin', '쿠폰할인'])}
           </Text>
           <Text
             bold
@@ -34,13 +34,13 @@ export function PricePolicyCouponInfo({
             color="gray700"
             margin={{ left: 5 }}
           >
-            {t('ganeung')}
+            {t(['ganeung', '가능'])}
           </Text>
         </>
       ) : hasAmountAfterUsingCouponPrice ? (
         <>
           <Text bold inlineBlock size="tiny" color="gray700">
-            {t('kuponhalinga')}
+            {t(['kuponhalinga', '쿠폰할인가'])}
           </Text>
           <Text
             bold
@@ -55,7 +55,7 @@ export function PricePolicyCouponInfo({
       ) : (
         <>
           <Text bold inlineBlock size="tiny" color="gray700">
-            {t('kuponjeogyongsi')}
+            {t(['kuponjeogyongsi', '쿠폰적용시'])}
           </Text>
           <Text
             bold
@@ -64,7 +64,7 @@ export function PricePolicyCouponInfo({
             color={emphasisColor}
             margin={{ left: 5 }}
           >
-            {t('muryo')}
+            {t(['muryo', '무료'])}
           </Text>
         </>
       )}

--- a/packages/triple-document/src/elements/tna/product.tsx
+++ b/packages/triple-document/src/elements/tna/product.tsx
@@ -49,7 +49,9 @@ function Pricing({
 
       <Container>
         <Text inline bold size={18} color="gray">
-          {t('formattedsaleprice-weon', { formattedSalePrice })}
+          {t(['formattedsaleprice-weon', '{{formattedSalePrice}}원'], {
+            formattedSalePrice,
+          })}
         </Text>
 
         {basePrice ? (
@@ -60,7 +62,9 @@ function Pricing({
             strikethrough
             margin={{ left: 5 }}
           >
-            {t('formattedbaseprice-weon', { formattedBasePrice })}
+            {t(['formattedbaseprice-weon', '{{formattedBasePrice}}원'], {
+              formattedBasePrice,
+            })}
           </Text>
         ) : null}
       </Container>
@@ -140,7 +144,7 @@ export function TnaProductWithPrice({
             {heroImage ? (
               <Image.Img
                 src={heroImage}
-                alt={t('title-yi-sseomneil', { title })}
+                alt={t(['title-yi-sseomneil', '{{title}}의 썸네일'], { title })}
               />
             ) : (
               <Image.Placeholder src={PLACEHOLDER_IMAGE_URL} />
@@ -234,7 +238,10 @@ export function TnaProductWithPrice({
 
           {hasSelfPackageBenefit && (
             <Text bold size="small" color="gray700" margin={{ top: 4 }}>
-              {t('selpeupaekiji-cugahalin-ganeung')}
+              {t([
+                'selpeupaekiji-cugahalin-ganeung',
+                '셀프패키지 추가할인 가능',
+              ])}
             </Text>
           )}
         </Container>

--- a/packages/triple-document/src/elements/tna/slot.tsx
+++ b/packages/triple-document/src/elements/tna/slot.tsx
@@ -103,7 +103,7 @@ export function Slot({
           margin={{ top: 20 }}
           onClick={handleShowMoreClick}
         >
-          {t('deobogi')}
+          {t(['deobogi', '더보기'])}
         </Button>
       ) : null}
     </Container>

--- a/packages/user-verification/src/verification-request.tsx
+++ b/packages/user-verification/src/verification-request.tsx
@@ -42,7 +42,7 @@ function VerificationRequest({
     <Modal open={verified === false}>
       <Icon />
       <Text bold center size="big" color="gray" margin={{ bottom: 10 }}>
-        {t('injeungi-pilyohaeyo')}
+        {t(['injeungi-pilyohaeyo', '인증이 필요해요!'])}
       </Text>
       <Text
         center
@@ -52,12 +52,17 @@ function VerificationRequest({
         alpha={0.7}
         margin={{ bottom: 40 }}
       >
-        {t('yeyageul-wihaeseoneun-hyudaepon-injeungi-pilyohabnida.-coeco-1hoe')}
+        {t([
+          'yeyageul-wihaeseoneun-hyudaepon-injeungi-pilyohabnida.-coeco-1hoe',
+          '예약을 위해서는\n휴대폰 인증이 필요합니다. (최초 1회)',
+        ])}
       </Text>
       <Modal.Actions>
-        <Modal.Action onClick={() => onCancel()}>{t('dwirogagi')}</Modal.Action>
+        <Modal.Action onClick={() => onCancel()}>
+          {t(['dwirogagi', '뒤로가기'])}
+        </Modal.Action>
         <Modal.Action onClick={() => initiateVerification()} color="blue">
-          {t('injeunghagi')}
+          {t(['injeunghagi', '인증하기'])}
         </Modal.Action>
       </Modal.Actions>
     </Modal>

--- a/packages/view-utilities/src/convert-price.ts
+++ b/packages/view-utilities/src/convert-price.ts
@@ -7,9 +7,11 @@ export function convertPriceInThousands(price: number) {
 
   const flooredPrice = Math.floor(price / 1000)
   if (flooredPrice === 0) {
-    return t('weon')
+    return t(['weon', '원'])
   } else {
-    return ` ${t('flooredprice-ceonweon', { flooredPrice })}`
+    return ` ${t(['flooredprice-ceonweon', '{{flooredPrice}}천원'], {
+      flooredPrice,
+    })}`
   }
 }
 
@@ -26,19 +28,27 @@ export function convertPrice(price: number) {
 
   switch (true) {
     case price % 1000 !== 0 || price < 1000:
-      return t('formattedprice-weon', { formattedPrice })
+      return t(['formattedprice-weon', '{{formattedPrice}}원'], {
+        formattedPrice,
+      })
 
     case price < 10000:
       return convertPriceInThousands(price)
 
     case price < 10000000:
-      return t('flooredprice-man-convertedprice', {
-        flooredPrice,
-        convertedPrice,
-      })
+      return t(
+        [
+          'flooredprice-man-convertedprice',
+          '{{flooredPrice}}만{{convertedPrice}}',
+        ],
+        {
+          flooredPrice,
+          convertedPrice,
+        },
+      )
 
     default: {
-      return t('coedae-geumaeg-cogwa')
+      return t(['coedae-geumaeg-cogwa', '최대 금액 초과'])
     }
   }
 }

--- a/packages/web-storage/src/boundary.tsx
+++ b/packages/web-storage/src/boundary.tsx
@@ -50,7 +50,10 @@ export const WebStorageErrorBoundary = withTranslation('common-web')(
         return (
           <Alert
             open
-            title={t('munjega-balsaenghaessseubnida.')}
+            title={t([
+              'munjega-balsaenghaessseubnida.',
+              '문제가 발생했습니다.',
+            ])}
             onConfirm={onConfirm}
           >
             {error.userGuideMessage}

--- a/packages/web-storage/src/error.ts
+++ b/packages/web-storage/src/error.ts
@@ -34,20 +34,31 @@ export class WebStorageError extends CustomError {
   public get userGuideMessage() {
     switch (this.type) {
       case 'notBrowser':
-        return this.t('beuraujeoeseo-sayonghaejuseyo.')
+        return this.t([
+          'beuraujeoeseo-sayonghaejuseyo.',
+          '브라우저에서 사용해주세요.',
+        ])
       case 'quotaExceeded':
         if (this.storageType === 'sessionStorage') {
-          return this.t(
+          return this.t([
             'beuraujeoreul-wanjeonhi-jongryohago-dasi-jeobsoghae-juseyo.',
-          )
+            '브라우저를 완전히 종료하고 다시 접속해 주세요.',
+          ])
         }
-        return this.t('beuraujeo-kaesireul-modu-biweojuseyo.')
+        return this.t([
+          'beuraujeo-kaesireul-modu-biweojuseyo.',
+          '브라우저 캐시를 모두 비워주세요.',
+        ])
       case 'unavailable':
-        return this.t('beuraujeoyi-kuki-cadan-seoljeongeul-haejehaejuseyo.')
+        return this.t([
+          'beuraujeoyi-kuki-cadan-seoljeongeul-haejehaejuseyo.',
+          '브라우저의 쿠키 차단 설정을 해제해주세요.',
+        ])
       default:
-        return this.t(
+        return this.t([
           'al-su-eobsneun-ereoga-balsaenghaessseubnida.-jamsi-hu-dasi-sidohae-juseyo.',
-        )
+          '알 수 없는 에러가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+        ])
     }
   }
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
다음과 같이 i18n translation이 사용되는 곳에 한국어 key를 추가하여, 개발할 때 개발도구에서 좀 더 쉽게 검색할 수 있도록 개선합니다.
기능상의 변경은 없습니다.
```ts
// before
t('ganada')

// after
t(['ganada', '가나다'])
```

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
