### PR TITLE
액션시트 아이템의 클릭 이벤트 조건을 수정합니다.

### DIFF
--- a/packages/action-sheet/src/action-sheet-item.tsx
+++ b/packages/action-sheet/src/action-sheet-item.tsx
@@ -68,7 +68,7 @@ export interface ActionSheetItemProps extends PropsWithChildren {
   buttonLabel?: string
   icon?: string
   checked?: boolean
-  onClick?: () => void | boolean
+  onClick?: () => unknown
 }
 
 export const ActionSheetItem = ({

--- a/packages/action-sheet/src/action-sheet-item.tsx
+++ b/packages/action-sheet/src/action-sheet-item.tsx
@@ -68,7 +68,7 @@ export interface ActionSheetItemProps extends PropsWithChildren {
   buttonLabel?: string
   icon?: string
   checked?: boolean
-  onClick?: () => void
+  onClick?: () => void | boolean
 }
 
 export const ActionSheetItem = ({
@@ -82,8 +82,7 @@ export const ActionSheetItem = ({
   const { onClose } = useActionSheet()
 
   const handleClick = () => {
-    onClick?.()
-    onClose?.()
+    onClick ? !onClick() && onClose && onClose() : onClose && onClose()
   }
 
   return (

--- a/packages/action-sheet/src/action-sheet-item.tsx
+++ b/packages/action-sheet/src/action-sheet-item.tsx
@@ -82,7 +82,7 @@ export const ActionSheetItem = ({
   const { onClose } = useActionSheet()
 
   const handleClick = () => {
-    onClick ? !onClick() && onClose && onClose() : onClose && onClose()
+    onClick ? !onClick() && onClose?.() : onClose?.()
   }
 
   return (


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

TF 12버전을 적용한 후로, 라운지 상세 페이지에서 삭제하기가 정상적으로 동작하지 않는 이슈가 있습니다.
원인으로봤을 때에는, replace와 back이 동시에 이뤄지다보니 모달이 제대로 노출이 안되는 것으로 추정됩니다.

이전에 정의했던 조건이 위의 이슈를 막기 위한 것으로 보입니다.

[관련 스레드](https://titicaca.slack.com/archives/C02UED2AZAP/p1673859332257259?thread_ts=1673859074.038389&cid=C02UED2AZAP)

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

액션시트아이템에 정의한 클릭이벤트의 조건을 롤백합니다.

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
