### PR TITLE
[core-elements] story title을 소문자로 변경

### DIFF
--- a/packages/core-elements/src/elements/accordion/accordion.stories.tsx
+++ b/packages/core-elements/src/elements/accordion/accordion.stories.tsx
@@ -9,7 +9,7 @@ import { AccordionFolded } from './accordion-folded'
 import { AccordionTitle } from './accordion-title'
 
 export default {
-  title: 'Core-Elements / Accordion',
+  title: 'core-elements / Accordion',
   component: Accordion,
   subcomponents: {
     AccordionContent,

--- a/packages/core-elements/src/elements/button/button.stories.tsx
+++ b/packages/core-elements/src/elements/button/button.stories.tsx
@@ -11,7 +11,7 @@ import { ButtonGroup } from './button-group'
 import { ButtonIcon } from './button-icon'
 
 export default {
-  title: 'Core-Elements / Button',
+  title: 'core-elements / Button',
   component: Button,
   subcomponents: {
     ButtonContainer,

--- a/packages/core-elements/src/elements/checkbox/checkbox-group.stories.tsx
+++ b/packages/core-elements/src/elements/checkbox/checkbox-group.stories.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from './checkbox'
 import { CheckboxGroup } from './checkbox-group'
 
 export default {
-  title: 'Core-Elements / CheckboxGroup',
+  title: 'core-elements / CheckboxGroup',
   component: CheckboxGroup,
 } as ComponentMeta<typeof CheckboxGroup>
 

--- a/packages/core-elements/src/elements/checkbox/checkbox.stories.tsx
+++ b/packages/core-elements/src/elements/checkbox/checkbox.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Checkbox } from './checkbox'
 
 export default {
-  title: 'Core-Elements / Checkbox',
+  title: 'core-elements / Checkbox',
   component: Checkbox,
 } as ComponentMeta<typeof Checkbox>
 

--- a/packages/core-elements/src/elements/container/container.stories.tsx
+++ b/packages/core-elements/src/elements/container/container.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from '@storybook/react'
 import { Container } from './container'
 
 export default {
-  title: 'Core-Elements / Container',
+  title: 'core-elements / Container',
   component: Container,
 } as Meta
 

--- a/packages/core-elements/src/elements/drawer/drawer.stories.tsx
+++ b/packages/core-elements/src/elements/drawer/drawer.stories.tsx
@@ -7,7 +7,7 @@ import { Text } from '../text'
 import { Drawer } from './drawer'
 
 export default {
-  title: 'Core-Elements / Drawer',
+  title: 'core-elements / Drawer',
   component: Drawer,
 } as Meta
 

--- a/packages/core-elements/src/elements/flex-box/flex-box.stories.tsx
+++ b/packages/core-elements/src/elements/flex-box/flex-box.stories.tsx
@@ -5,7 +5,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { FlexBox, FlexBoxItem } from '../flex-box'
 
 export default {
-  title: 'Core-Elements / FlexBox',
+  title: 'core-elements / FlexBox',
   components: FlexBox,
   subcomponents: {
     FlexBoxItem,

--- a/packages/core-elements/src/elements/label/label.stories.tsx
+++ b/packages/core-elements/src/elements/label/label.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStoryObj, Meta } from '@storybook/react'
 import { Label } from './label'
 
 export default {
-  title: 'Core-Elements / Label',
+  title: 'core-elements / Label',
   component: Label,
 } as Meta
 

--- a/packages/core-elements/src/elements/long-clickable/long-clickable.stories.tsx
+++ b/packages/core-elements/src/elements/long-clickable/long-clickable.stories.tsx
@@ -4,7 +4,7 @@ import { HR1 } from '../hr'
 import { longClickable } from './long-clickable'
 
 export default {
-  title: 'Core-Elements / longClickable',
+  title: 'core-elements / longClickable',
   component: longClickable,
 }
 

--- a/packages/core-elements/src/elements/navbar/navbar.stories.tsx
+++ b/packages/core-elements/src/elements/navbar/navbar.stories.tsx
@@ -24,7 +24,7 @@ const Toc = styled.div`
 // ] as const
 
 export default {
-  title: 'Core-Elements / Navbar',
+  title: 'core-elements / Navbar',
 }
 
 export function twoButtons() {

--- a/packages/core-elements/src/elements/radio/radio-group.stories.tsx
+++ b/packages/core-elements/src/elements/radio/radio-group.stories.tsx
@@ -6,7 +6,7 @@ import { Radio } from '../radio/radio'
 import { RadioGroup } from './radio-group'
 
 export default {
-  title: 'Core-Elements / RadioGroup',
+  title: 'core-elements / RadioGroup',
   component: RadioGroup,
 } as ComponentMeta<typeof RadioGroup>
 

--- a/packages/core-elements/src/elements/radio/radio.stories.tsx
+++ b/packages/core-elements/src/elements/radio/radio.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Radio } from './radio'
 
 export default {
-  title: 'Core-Elements / Radio',
+  title: 'core-elements / Radio',
   component: Radio,
 } as ComponentMeta<typeof Radio>
 

--- a/packages/core-elements/src/elements/rating/rating.stories.tsx
+++ b/packages/core-elements/src/elements/rating/rating.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStoryObj, Meta } from '@storybook/react'
 import { Rating } from './rating'
 
 export default {
-  title: 'Core-Elements / Rating',
+  title: 'core-elements / Rating',
   component: Rating,
 } as Meta
 

--- a/packages/core-elements/src/elements/section/section.stories.tsx
+++ b/packages/core-elements/src/elements/section/section.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/react'
 import { Section, SectionProps } from './section'
 
 export default {
-  title: 'Core-Elements / Section',
+  title: 'core-elements / Section',
   component: Section,
 } as Meta
 

--- a/packages/core-elements/src/elements/spinner/spinner.stories.tsx
+++ b/packages/core-elements/src/elements/spinner/spinner.stories.tsx
@@ -2,7 +2,7 @@ import { RollingSpinner } from './rolling-spinner'
 import { Spinner } from './spinner'
 
 export default {
-  title: 'Core-Elements / Spinner',
+  title: 'core-elements / Spinner',
 }
 
 export function BaseSpinner() {

--- a/packages/core-elements/src/elements/stack/stack.stories.tsx
+++ b/packages/core-elements/src/elements/stack/stack.stories.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { Stack } from './stack'
 
 export default {
-  title: 'Core-Elements / Stack',
+  title: 'core-elements / Stack',
   component: Stack,
 } as ComponentMeta<typeof Stack>
 

--- a/packages/core-elements/src/elements/sticky-header/sticky-header.stories.tsx
+++ b/packages/core-elements/src/elements/sticky-header/sticky-header.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, Story } from '@storybook/react'
 import { StickyHeader } from './sticky-header'
 
 export default {
-  title: 'Core-Elements / StickyHeader',
+  title: 'core-elements / StickyHeader',
   component: StickyHeader,
 } as Meta
 

--- a/packages/core-elements/src/elements/table/table.stories.tsx
+++ b/packages/core-elements/src/elements/table/table.stories.tsx
@@ -3,7 +3,7 @@ import SAMPLE from '../../mocks/table.sample.json'
 import { Table, TableProps } from './table'
 
 export default {
-  title: 'Core-Elements / Table',
+  title: 'core-elements / Table',
   component: Table,
 }
 

--- a/packages/core-elements/src/elements/tooltip/tooltip.stories.tsx
+++ b/packages/core-elements/src/elements/tooltip/tooltip.stories.tsx
@@ -6,7 +6,7 @@ import { Navbar } from '../navbar'
 import { Tooltip } from './tooltip'
 
 export default {
-  title: 'Core-Elements / Tooltip',
+  title: 'core-elements / Tooltip',
   component: Tooltip,
 } as Meta
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

[core-elements] story title을 소문자로 변경

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

core-elements 패키지의 story title이 `Core-Elements`인 것과 `core-elements` 인 것이 섞여있어서 chromatic에서 섹션이 두개로 구분되고 있습니다.

![image](https://user-images.githubusercontent.com/11497500/213092591-bd9607e5-e79d-47f2-8460-a3bf405c9c43.png)

소문자로 통일해서 하나로 합쳐지게 합니다.
