### PR TITLE
css prop과 centered prop이 충돌하는 문제 수정

### DIFF
--- a/packages/directions-finder/src/ask-to-the-local.tsx
+++ b/packages/directions-finder/src/ask-to-the-local.tsx
@@ -67,7 +67,7 @@ export default function AskToTheLocal({
     <Popup open={open} onClose={onClose} borderless>
       <Section
         css={{
-          margin: '20px 0 0',
+          marginTop: 20,
         }}
       >
         <Text maxLines={2} textStyle="M4" color="blue">

--- a/packages/poi-detail/src/recommended-articles/recommended-articles.tsx
+++ b/packages/poi-detail/src/recommended-articles/recommended-articles.tsx
@@ -115,7 +115,8 @@ function RecommendedArticles({
     <Section
       divider="top"
       css={{
-        margin: '50px 0',
+        marginTop: 50,
+        marginBottom: 50,
         padding: '0',
       }}
     >


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
관련 스레드: https://titicaca.slack.com/archives/CEEPB4TDY/p1673512116458689?thread_ts=1672202321.110669&cid=CEEPB4TDY

TF [RecommendedArticles](https://github.com/titicacadev/triple-frontend/blob/main/packages/poi-detail/src/recommended-articles/recommended-articles.tsx#L118) 의 경우와 같이, [Section](https://github.com/titicacadev/triple-frontend/blob/main/packages/core-elements/src/elements/section/section.tsx) 컴포넌트에 css prop으로 마진값을 주는 경우 [Section 컴포넌트에서 사용하는 Container 에 적용된 centered 속성](https://github.com/titicacadev/triple-frontend/blob/main/packages/core-elements/src/elements/section/section.tsx#L21)이 덮어씌워지는 버그를 수정합니다 (mixin prop이 먼저 적용되고 css prop이 이후에 적용되어 mixin prop의 스타일이 덮어씌워지는게 이유인듯 합니다).
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
