### PR TITLE
링크선택 이벤트의 특정 URL을 trackEvent의 추가 속성으로 로깅합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20438,9 +20438,9 @@
       "link": true
     },
     "node_modules/@titicaca/triple-web-to-native-interfaces": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@titicaca/triple-web-to-native-interfaces/-/triple-web-to-native-interfaces-1.6.0.tgz",
-      "integrity": "sha512-NSjMVOEr233ZJD/Cj2/+RYPS1o3ou2fmr2IMUfOCyYiOPOdoqWxIz/lUSOfnaggR0RLW6LFg5T8Fdx3cD+GcqQ=="
+      "version": "0.0.0-618e64b",
+      "resolved": "https://registry.npmjs.org/@titicaca/triple-web-to-native-interfaces/-/triple-web-to-native-interfaces-0.0.0-618e64b.tgz",
+      "integrity": "sha512-pLS1mm3oG7v1Hthyogk0h6trYi3Yayp+dii25eZaH3Qa6QeAXJRw2t+opl3BfwINZ7cklj8UToU+KJw2Yz8eCg=="
     },
     "node_modules/@titicaca/type-definitions": {
       "resolved": "packages/type-definitions",
@@ -49739,7 +49739,7 @@
         "@titicaca/intersection-observer": "^12.1.1",
         "@titicaca/react-contexts": "^12.1.1",
         "@titicaca/triple-fallback-action": "^12.1.1",
-        "@titicaca/triple-web-to-native-interfaces": "^1.7.0",
+        "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b",
         "@titicaca/type-definitions": "^12.1.1",
         "@titicaca/view-utilities": "^12.1.1",
         "autolinker": "^4.0.0"
@@ -49752,10 +49752,6 @@
         "react-dom": "^18.0",
         "styled-components": "^5.3.1"
       }
-    },
-    "packages/chat/node_modules/@titicaca/triple-web-to-native-interfaces": {
-      "version": "1.7.0",
-      "license": "ISC"
     },
     "packages/color-palette": {
       "name": "@titicaca/color-palette",
@@ -50537,7 +50533,7 @@
         "firebase": "^9.11.0"
       },
       "peerDependencies": {
-        "@titicaca/triple-web-to-native-interfaces": "*",
+        "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b",
         "firebase": "^9.11.0",
         "next": "^13.0",
         "react": "^18.0",
@@ -50576,7 +50572,7 @@
         "semver": "^7.3.5"
       },
       "devDependencies": {
-        "@titicaca/triple-web-to-native-interfaces": "1.6.0",
+        "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b",
         "@types/qs": "^6.9.5",
         "@types/semver": "^7.3.6"
       },
@@ -50768,7 +50764,7 @@
       },
       "peerDependencies": {
         "@titicaca/react-contexts": "*",
-        "@titicaca/triple-web-to-native-interfaces": "*",
+        "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b",
         "react": "^18.0",
         "react-dom": "^18.0",
         "styled-components": "^5.3.1"
@@ -50854,7 +50850,7 @@
       },
       "peerDependencies": {
         "@titicaca/next-i18next": "*",
-        "@titicaca/triple-web-to-native-interfaces": "*"
+        "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b"
       }
     },
     "packages/static-map": {
@@ -67081,16 +67077,11 @@
         "@titicaca/intersection-observer": "^12.1.1",
         "@titicaca/react-contexts": "^12.1.1",
         "@titicaca/triple-fallback-action": "^12.1.1",
-        "@titicaca/triple-web-to-native-interfaces": "^1.7.0",
+        "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b",
         "@titicaca/type-definitions": "^12.1.1",
         "@titicaca/view-utilities": "^12.1.1",
         "@types/isomorphic-fetch": "^0.0.36",
         "autolinker": "^4.0.0"
-      },
-      "dependencies": {
-        "@titicaca/triple-web-to-native-interfaces": {
-          "version": "1.7.0"
-        }
       }
     },
     "@titicaca/color-palette": {
@@ -67584,7 +67575,7 @@
     "@titicaca/react-triple-client-interfaces": {
       "version": "file:packages/react-triple-client-interfaces",
       "requires": {
-        "@titicaca/triple-web-to-native-interfaces": "1.6.0",
+        "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b",
         "@types/qs": "^6.9.5",
         "@types/semver": "^7.3.6",
         "qs": "^6.9.4",
@@ -67808,9 +67799,9 @@
       }
     },
     "@titicaca/triple-web-to-native-interfaces": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@titicaca/triple-web-to-native-interfaces/-/triple-web-to-native-interfaces-1.6.0.tgz",
-      "integrity": "sha512-NSjMVOEr233ZJD/Cj2/+RYPS1o3ou2fmr2IMUfOCyYiOPOdoqWxIz/lUSOfnaggR0RLW6LFg5T8Fdx3cD+GcqQ=="
+      "version": "0.0.0-618e64b",
+      "resolved": "https://registry.npmjs.org/@titicaca/triple-web-to-native-interfaces/-/triple-web-to-native-interfaces-0.0.0-618e64b.tgz",
+      "integrity": "sha512-pLS1mm3oG7v1Hthyogk0h6trYi3Yayp+dii25eZaH3Qa6QeAXJRw2t+opl3BfwINZ7cklj8UToU+KJw2Yz8eCg=="
     },
     "@titicaca/type-definitions": {
       "version": "file:packages/type-definitions"

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -32,7 +32,7 @@
     "@titicaca/intersection-observer": "^12.1.1",
     "@titicaca/react-contexts": "^12.1.1",
     "@titicaca/triple-fallback-action": "^12.1.1",
-    "@titicaca/triple-web-to-native-interfaces": "^1.7.0",
+    "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b",
     "@titicaca/type-definitions": "^12.1.1",
     "@titicaca/view-utilities": "^12.1.1",
     "autolinker": "^4.0.0"

--- a/packages/react-contexts/package.json
+++ b/packages/react-contexts/package.json
@@ -34,7 +34,7 @@
     "firebase": "^9.11.0"
   },
   "peerDependencies": {
-    "@titicaca/triple-web-to-native-interfaces": "*",
+    "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b",
     "firebase": "^9.11.0",
     "next": "^13.0",
     "react": "^18.0",

--- a/packages/react-contexts/src/event-tracking-context/event-metadata-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-metadata-context.tsx
@@ -41,11 +41,13 @@ export function useEventTrackerWithMetadata() {
     ga?: GoogleAnalyticsParams
     fa?: Partial<FirebaseAnalyticsParams>
     pixel?: PixelParams
+    additionalMetadata?: { [key: string]: string }
   }) => {
     trackEvent({
       ga: getGoogleAnalyticsWithMetadata(params.ga, eventMetadata),
       fa: getFirebaseAnalyticsWithMetadata(params.fa, eventMetadata),
       pixel: getPixelWithMetadata(params.pixel, eventMetadata),
+      additionalMetadata: params.additionalMetadata,
     })
   }
 }

--- a/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
@@ -210,13 +210,21 @@ export function EventTrackingProvider({
       try {
         if (window.ga && ga) {
           const [action, label] = ga
-          window.ga('send', 'event', pageLabel, action, label)
+          const metadata = Object.entries(additionalMetadata || {})
+            .map((data) => data.join(':'))
+            .join('_')
+
+          window.ga('send', 'event', pageLabel, action, label, metadata)
         }
 
         if (window.fbq && pixel) {
           const { type = 'trackCustom', action, payload } = pixel
 
-          window.fbq(type, action, { pageLabel, ...payload })
+          window.fbq(type, action, {
+            pageLabel,
+            ...payload,
+            ...additionalMetadata,
+          })
         }
 
         const firebaseAnalyticsWebInstance = getFirebaseAnalyticsWebInstance()
@@ -225,6 +233,7 @@ export function EventTrackingProvider({
           logFirebaseEvent(firebaseAnalyticsWebInstance, WEB_FA_EVENT_NAME, {
             category: pageLabel,
             ...fa,
+            ...additionalMetadata,
           })
         }
 

--- a/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
@@ -49,6 +49,7 @@ export interface EventTrackingContextValue {
      * 그리고 type을 생략하면 맞춤 이벤트를 사용합니다.
      */
     pixel?: PixelParams
+    additionalMetadata?: { [key: string]: string }
   }) => void
   /**
    * 하나의 파라미터로 GA, FA 이벤트를 기록합니다.
@@ -205,7 +206,7 @@ export function EventTrackingProvider({
   )
 
   const trackEvent: EventTrackingContextValue['trackEvent'] = useCallback(
-    ({ ga, fa, pixel }) => {
+    ({ ga, fa, pixel, additionalMetadata }) => {
       try {
         if (window.ga && ga) {
           const [action, label] = ga
@@ -234,6 +235,7 @@ export function EventTrackingProvider({
             event_name: DEFAULT_EVENT_NAME,
             ...fa,
           },
+          ...additionalMetadata,
         })
       } catch (error) {
         onErrorRef.current?.(error as Error)

--- a/packages/react-triple-client-interfaces/package.json
+++ b/packages/react-triple-client-interfaces/package.json
@@ -17,7 +17,7 @@
     "semver": "^7.3.5"
   },
   "devDependencies": {
-    "@titicaca/triple-web-to-native-interfaces": "1.6.0",
+    "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b",
     "@types/qs": "^6.9.5",
     "@types/semver": "^7.3.6"
   },

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
-    "@titicaca/triple-web-to-native-interfaces": "*",
+    "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b",
     "react": "^18.0",
     "react-dom": "^18.0",
     "styled-components": "^5.3.1"

--- a/packages/standard-action-handler/package.json
+++ b/packages/standard-action-handler/package.json
@@ -32,6 +32,6 @@
   },
   "peerDependencies": {
     "@titicaca/next-i18next": "*",
-    "@titicaca/triple-web-to-native-interfaces": "*"
+    "@titicaca/triple-web-to-native-interfaces": "v0.0.0-618e64b"
   }
 }

--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -77,9 +77,9 @@ export function TripleDocument({
         fa: {
           action: '링크선택',
           url: href,
-          ...linkParams,
         },
         ga: ['링크선택', href],
+        additionalMetadata: linkParams,
       })
       handleAction(href, { target })
     },

--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -63,7 +63,7 @@ export function TripleDocument({
         return
       }
 
-      const linkParams = Object.keys(query || {})
+      const additionalMetadata = Object.keys(query || {})
         .filter((key) => key.match(/^triple_link_param_/i))
         .reduce(
           (params, key) => ({
@@ -79,7 +79,7 @@ export function TripleDocument({
           url: href,
         },
         ga: ['링크선택', href],
-        additionalMetadata: linkParams,
+        additionalMetadata,
       })
       handleAction(href, { target })
     },

--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -3,6 +3,7 @@ import { useEventTrackerWithMetadata } from '@titicaca/react-contexts'
 import { initialize } from '@titicaca/standard-action-handler'
 import { useNavigate, useExternalRouter } from '@titicaca/router'
 import { ContextOptions } from '@titicaca/standard-action-handler/src/types'
+import { useRouter } from 'next/router'
 
 import {
   TripleElementData,
@@ -39,6 +40,7 @@ export function TripleDocument({
   children: TripleElementData[]
   cta?: string
 } & TripleDocumentContext) {
+  const { query } = useRouter()
   const trackEventWithMetadata = useEventTrackerWithMetadata()
   const trackResourceEvent = useEventResourceTracker()
   const navigate = useNavigate()
@@ -60,16 +62,28 @@ export function TripleDocument({
         // TODO: triple-document 에러 처리 방법 설계
         return
       }
+
+      const linkParams = Object.keys(query || {})
+        .filter((key) => key.match(/^triple_link_param_/i))
+        .reduce(
+          (params, key) => ({
+            ...params,
+            [key.replace(/^triple_link_param_/i, '')]: query[key],
+          }),
+          {},
+        )
+
       trackEventWithMetadata({
         fa: {
           action: '링크선택',
           url: href,
+          ...linkParams,
         },
         ga: ['링크선택', href],
       })
       handleAction(href, { target })
     },
-    [handleAction, trackEventWithMetadata],
+    [handleAction, trackEventWithMetadata, query],
   )
 
   const defaultHandleResourceClick: ResourceClickHandler = useCallback(


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

### ❑ PR 설명
- trackEvent에 additionalMetadata property를 추가합니다.

## 변경 내역
- `triple-document`에 특정 param(`triple_link_param_`)를 파싱하는 로직을 생성하고, `trackEventWithMetadata`에 `props`로 넘겨줍니다.

## 스크린샷 & URL
- [관련 스레드](https://titicaca.slack.com/archives/C8QE1TG95/p1673421773309249?thread_ts=1673325610.004569&cid=C8QE1TG95)
- 이전 PR: triple-web-to-native-interfaces [#103](https://github.com/titicacadev/triple-web-to-native-interfaces/pull/103)