### PR TITLE
[action-sheet] 액션시트 열고 닫히는 transition이 일부 브라우저에서 layout shift 되지 않도록 수정

### DIFF
--- a/packages/action-sheet/src/action-sheet-body.tsx
+++ b/packages/action-sheet/src/action-sheet-body.tsx
@@ -40,9 +40,7 @@ interface SheetProps {
 
 const Sheet = styled.div<SheetProps>`
   position: fixed;
-  left: 0;
-  right: 0;
-  margin: 0 auto;
+  width: 100%;
   max-width: 768px;
   background-color: var(--color-white);
 

--- a/packages/action-sheet/src/action-sheet-overlay.tsx
+++ b/packages/action-sheet/src/action-sheet-overlay.tsx
@@ -23,6 +23,10 @@ export const Overlay = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100vw;
   background-color: rgba(58, 58, 58, 0.7);
 
   &:not([class*='action-sheet-fade-']) {


### PR DESCRIPTION

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

https://titicaca.slack.com/archives/C02UED2AZAP/p1674608190699989

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

ActionSheet가 열고 닫힐 때 사용되는 usePreventScroll이 일부 브라우저에서(macOS 크롬 등) 비정상적인 layout shift를 유발합니다.
ActionSheet의 css를 변경해서 열고 닫힐 때도 가운데 정렬을 유지할 수 있도록 수정합니다.

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->

https://user-images.githubusercontent.com/11497500/214770600-ff88ff18-b521-4602-b317-c079e607595d.mov

