### PR TITLE
[action-sheet, modals] @react/aria에서 리랜더를 유발하는 usePreventScroll 제거

### DIFF
--- a/packages/action-sheet/src/action-sheet-base.tsx
+++ b/packages/action-sheet/src/action-sheet-base.tsx
@@ -1,10 +1,10 @@
 import { Portal } from '@titicaca/core-elements'
-import { useOverlay, usePreventScroll } from '@react-aria/overlays'
 import { PropsWithChildren, ReactNode, useRef } from 'react'
+import { useOverlay } from '@react-aria/overlays'
 
-import { useActionSheet } from './action-sheet-context'
 import { ActionSheetOverlay } from './action-sheet-overlay'
 import { ActionSheetBody } from './action-sheet-body'
+import { useActionSheet } from './action-sheet-context'
 
 const TRANSITION_DURATION = 120
 
@@ -27,7 +27,6 @@ export const ActionSheetBase = ({
 }: ActionSheetBaseProps) => {
   const overlayRef = useRef<HTMLDivElement>(null)
   const sheetRef = useRef<HTMLDivElement>(null)
-
   const { open, onClose } = useActionSheet()
 
   const { overlayProps, underlayProps } = useOverlay(
@@ -39,8 +38,6 @@ export const ActionSheetBase = ({
     },
     sheetRef,
   )
-
-  usePreventScroll({ isDisabled: !open })
 
   return (
     <Portal>

--- a/packages/modals/src/modal/modal-base.tsx
+++ b/packages/modals/src/modal/modal-base.tsx
@@ -6,8 +6,8 @@ import {
   Portal,
 } from '@titicaca/core-elements'
 import { FocusScope } from '@react-aria/focus'
-import { useOverlay, usePreventScroll } from '@react-aria/overlays'
 import { css } from 'styled-components'
+import { useOverlay } from '@react-aria/overlays'
 
 import { useModal } from './modal-context'
 
@@ -16,12 +16,11 @@ export type ModalBaseProps = PropsWithChildren
 export const ModalBase = ({ children }: ModalBaseProps) => {
   const ref = useRef(null)
   const { open, titleId, descriptionId, onClose } = useModal()
+
   const { overlayProps, underlayProps } = useOverlay(
     { isDismissable: true, isOpen: open, onClose },
     ref,
   )
-
-  usePreventScroll({ isDisabled: !open })
 
   if (!open) {
     return null


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
- @react/aria에서 리랜더를 유발하는 usePreventScroll를 제거합니다.
- [관련 컨플루언스 문서](https://titicaca.atlassian.net/wiki/spaces/dev/pages/3287122066/triple-frontend+12+UI)

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- ios 모바일에서만 발생하기 때문에 preventScrollMobileSafari에서 스크롤을 막으면서 document에 event를 넣고 있어서 리랜더가 발생해 버리는 게 아닐까 싶네요 [코드 링크](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/overlays/src/usePreventScroll.ts#L106)
- useOverlay는 리랜더는 유발하지 않고 onClose를 가지고 실행하는 부분이 있어서 여기서 여행기 삭제 오류로 이어지는 것 같습니다. 
- 이전버전 확인해보면 scroll 막는것은 기존에 있던 기능은 아닌 것 같아서 우선은 제거하고 이슈 등록 후 다시 살펴보겠습니다. 



## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
trips-web 적용버전

- https://triple-dev.titicaca-corp.com/trips/lounge/itineraries/d626a7ae-04cf-4368-93a1-bb772d2a3fdd?_triple_no_navbar&_safe_area_bottom
- https://triple-dev.titicaca-corp.com/trips/intro