### PR TITLE
underlayProps, overlayProps,  FocusScope 위치 변경

### DIFF
--- a/packages/action-sheet/src/action-sheet-base.tsx
+++ b/packages/action-sheet/src/action-sheet-base.tsx
@@ -42,12 +42,12 @@ export const ActionSheetBase = ({
   return (
     <Portal>
       <ActionSheetOverlay
-        {...overlayProps}
+        {...underlayProps}
         ref={overlayRef}
         duration={TRANSITION_DURATION}
       >
         <ActionSheetBody
-          {...underlayProps}
+          {...overlayProps}
           ref={sheetRef}
           borderRadius={borderRadius}
           bottomSpacing={bottomSpacing}

--- a/packages/action-sheet/src/action-sheet-base.tsx
+++ b/packages/action-sheet/src/action-sheet-base.tsx
@@ -44,25 +44,27 @@ export const ActionSheetBase = ({
     <Portal>
       {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
       <FocusScope contain restoreFocus autoFocus>
-        <ActionSheetOverlay
-          {...underlayProps}
-          ref={overlayRef}
-          duration={TRANSITION_DURATION}
-        >
-          <ActionSheetBody
-            {...overlayProps}
-            ref={sheetRef}
-            borderRadius={borderRadius}
-            bottomSpacing={bottomSpacing}
+        <div>
+          <ActionSheetOverlay
+            {...underlayProps}
+            ref={overlayRef}
             duration={TRANSITION_DURATION}
-            maxContentHeight={maxContentHeight}
-            from={from}
-            title={title}
-            {...props}
           >
-            {children}
-          </ActionSheetBody>
-        </ActionSheetOverlay>
+            <ActionSheetBody
+              {...overlayProps}
+              ref={sheetRef}
+              borderRadius={borderRadius}
+              bottomSpacing={bottomSpacing}
+              duration={TRANSITION_DURATION}
+              maxContentHeight={maxContentHeight}
+              from={from}
+              title={title}
+              {...props}
+            >
+              {children}
+            </ActionSheetBody>
+          </ActionSheetOverlay>
+        </div>
       </FocusScope>
     </Portal>
   )

--- a/packages/action-sheet/src/action-sheet-base.tsx
+++ b/packages/action-sheet/src/action-sheet-base.tsx
@@ -1,5 +1,6 @@
 import { Portal } from '@titicaca/core-elements'
 import { PropsWithChildren, ReactNode, useRef } from 'react'
+import { FocusScope } from '@react-aria/focus'
 import { useOverlay } from '@react-aria/overlays'
 
 import { ActionSheetOverlay } from './action-sheet-overlay'
@@ -41,25 +42,28 @@ export const ActionSheetBase = ({
 
   return (
     <Portal>
-      <ActionSheetOverlay
-        {...underlayProps}
-        ref={overlayRef}
-        duration={TRANSITION_DURATION}
-      >
-        <ActionSheetBody
-          {...overlayProps}
-          ref={sheetRef}
-          borderRadius={borderRadius}
-          bottomSpacing={bottomSpacing}
+      {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+      <FocusScope contain restoreFocus autoFocus>
+        <ActionSheetOverlay
+          {...underlayProps}
+          ref={overlayRef}
           duration={TRANSITION_DURATION}
-          maxContentHeight={maxContentHeight}
-          from={from}
-          title={title}
-          {...props}
         >
-          {children}
-        </ActionSheetBody>
-      </ActionSheetOverlay>
+          <ActionSheetBody
+            {...overlayProps}
+            ref={sheetRef}
+            borderRadius={borderRadius}
+            bottomSpacing={bottomSpacing}
+            duration={TRANSITION_DURATION}
+            maxContentHeight={maxContentHeight}
+            from={from}
+            title={title}
+            {...props}
+          >
+            {children}
+          </ActionSheetBody>
+        </ActionSheetOverlay>
+      </FocusScope>
     </Portal>
   )
 }

--- a/packages/action-sheet/src/action-sheet-body.tsx
+++ b/packages/action-sheet/src/action-sheet-body.tsx
@@ -145,31 +145,31 @@ export const ActionSheetBody = forwardRef<HTMLDivElement, ActionSheetBodyProps>(
         mountOnEnter
         unmountOnExit
       >
-        {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
-        <FocusScope contain restoreFocus autoFocus>
-          <Sheet
-            ref={ref}
-            borderRadius={borderRadius}
-            bottomSpacing={bottomSpacing}
-            duration={duration}
-            from={from}
-            padding={{ bottom: bottomSpacing }}
-            role="dialog"
-            aria-labelledby={titleId}
-            aria-modal
-            {...props}
+        <Sheet
+          ref={ref}
+          borderRadius={borderRadius}
+          bottomSpacing={bottomSpacing}
+          duration={duration}
+          from={from}
+          padding={{ bottom: bottomSpacing }}
+          role="dialog"
+          aria-labelledby={titleId}
+          aria-modal
+          {...props}
+        >
+          {title && <ActionSheetTitle>{title}</ActionSheetTitle>}
+          <Content
+            css={{
+              maxHeight: maxContentHeight,
+              padding: '0 25px',
+            }}
           >
-            {title && <ActionSheetTitle>{title}</ActionSheetTitle>}
-            <Content
-              css={{
-                maxHeight: maxContentHeight,
-                padding: '0 25px',
-              }}
-            >
+            {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+            <FocusScope contain restoreFocus autoFocus>
               {children}
-            </Content>
-          </Sheet>
-        </FocusScope>
+            </FocusScope>
+          </Content>
+        </Sheet>
       </CSSTransition>
     )
   },

--- a/packages/action-sheet/src/action-sheet-body.tsx
+++ b/packages/action-sheet/src/action-sheet-body.tsx
@@ -1,4 +1,3 @@
-import { FocusScope } from '@react-aria/focus'
 import {
   Container,
   MarginPadding,
@@ -164,10 +163,7 @@ export const ActionSheetBody = forwardRef<HTMLDivElement, ActionSheetBodyProps>(
               padding: '0 25px',
             }}
           >
-            {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
-            <FocusScope contain restoreFocus autoFocus>
-              {children}
-            </FocusScope>
+            {children}
           </Content>
         </Sheet>
       </CSSTransition>

--- a/packages/modals/src/modal/modal-base.tsx
+++ b/packages/modals/src/modal/modal-base.tsx
@@ -29,7 +29,7 @@ export const ModalBase = ({ children }: ModalBaseProps) => {
   return (
     <Portal>
       <FlexBox
-        {...overlayProps}
+        {...underlayProps}
         flex
         alignItems="center"
         justifyContent="center"
@@ -44,24 +44,24 @@ export const ModalBase = ({ children }: ModalBaseProps) => {
           ${layeringMixin(99)}
         `}
       >
-        {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
-        <FocusScope autoFocus contain restoreFocus>
-          <Container
-            {...underlayProps}
-            ref={ref}
-            role="dialog"
-            aria-labelledby={titleId}
-            aria-describedby={descriptionId}
-            aria-modal
-            borderRadius={6}
-            css={css`
-              width: 295px;
-              background-color: #fff;
-            `}
-          >
+        <Container
+          {...overlayProps}
+          ref={ref}
+          role="dialog"
+          aria-labelledby={titleId}
+          aria-describedby={descriptionId}
+          aria-modal
+          borderRadius={6}
+          css={css`
+            width: 295px;
+            background-color: #fff;
+          `}
+        >
+          {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+          <FocusScope autoFocus contain restoreFocus>
             {children}
-          </Container>
-        </FocusScope>
+          </FocusScope>
+        </Container>
       </FlexBox>
     </Portal>
   )

--- a/packages/modals/src/modal/modal-base.tsx
+++ b/packages/modals/src/modal/modal-base.tsx
@@ -30,38 +30,40 @@ export const ModalBase = ({ children }: ModalBaseProps) => {
     <Portal>
       {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
       <FocusScope autoFocus contain restoreFocus>
-        <FlexBox
-          {...underlayProps}
-          flex
-          alignItems="center"
-          justifyContent="center"
-          css={css`
-            position: fixed;
-            top: 0;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            background-color: rgba(58, 58, 58, 0.5);
-
-            ${layeringMixin(99)}
-          `}
-        >
-          <Container
-            {...overlayProps}
-            ref={ref}
-            role="dialog"
-            aria-labelledby={titleId}
-            aria-describedby={descriptionId}
-            aria-modal
-            borderRadius={6}
+        <div>
+          <FlexBox
+            {...underlayProps}
+            flex
+            alignItems="center"
+            justifyContent="center"
             css={css`
-              width: 295px;
-              background-color: #fff;
+              position: fixed;
+              top: 0;
+              bottom: 0;
+              left: 0;
+              right: 0;
+              background-color: rgba(58, 58, 58, 0.5);
+
+              ${layeringMixin(99)}
             `}
           >
-            {children}
-          </Container>
-        </FlexBox>
+            <Container
+              {...overlayProps}
+              ref={ref}
+              role="dialog"
+              aria-labelledby={titleId}
+              aria-describedby={descriptionId}
+              aria-modal
+              borderRadius={6}
+              css={css`
+                width: 295px;
+                background-color: #fff;
+              `}
+            >
+              {children}
+            </Container>
+          </FlexBox>
+        </div>
       </FocusScope>
     </Portal>
   )

--- a/packages/modals/src/modal/modal-base.tsx
+++ b/packages/modals/src/modal/modal-base.tsx
@@ -28,41 +28,41 @@ export const ModalBase = ({ children }: ModalBaseProps) => {
 
   return (
     <Portal>
-      <FlexBox
-        {...underlayProps}
-        flex
-        alignItems="center"
-        justifyContent="center"
-        css={css`
-          position: fixed;
-          top: 0;
-          bottom: 0;
-          left: 0;
-          right: 0;
-          background-color: rgba(58, 58, 58, 0.5);
-
-          ${layeringMixin(99)}
-        `}
-      >
-        <Container
-          {...overlayProps}
-          ref={ref}
-          role="dialog"
-          aria-labelledby={titleId}
-          aria-describedby={descriptionId}
-          aria-modal
-          borderRadius={6}
+      {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+      <FocusScope autoFocus contain restoreFocus>
+        <FlexBox
+          {...underlayProps}
+          flex
+          alignItems="center"
+          justifyContent="center"
           css={css`
-            width: 295px;
-            background-color: #fff;
+            position: fixed;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background-color: rgba(58, 58, 58, 0.5);
+
+            ${layeringMixin(99)}
           `}
         >
-          {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
-          <FocusScope autoFocus contain restoreFocus>
+          <Container
+            {...overlayProps}
+            ref={ref}
+            role="dialog"
+            aria-labelledby={titleId}
+            aria-describedby={descriptionId}
+            aria-modal
+            borderRadius={6}
+            css={css`
+              width: 295px;
+              background-color: #fff;
+            `}
+          >
             {children}
-          </FocusScope>
-        </Container>
-      </FlexBox>
+          </Container>
+        </FlexBox>
+      </FocusScope>
     </Portal>
   )
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

underlayProps, overlayProps, FocusScope 위치 변경

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- useOverlay의 underlayProps, overlayProps의 위치를 서로 바꿉니다. underlay가 뒷 배경, overlay가 그 위에 떠 있는 요소를 의미합니다. (https://react-spectrum.adobe.com/react-aria/useModalOverlay.html)
- FocusScope를 base 쪽으로 옮깁니다. body를 시각적인 ui만 담당하게 하고 base가 포커스같은 기능을 담당하도록 합니다.