### PR TITLE
[poi-detail] POI 상세페이지에서 사용되는 Actions 컴포넌트 하단 HR1 너비를 수정합니다.

### DIFF
--- a/packages/poi-detail/src/actions.tsx
+++ b/packages/poi-detail/src/actions.tsx
@@ -116,7 +116,7 @@ function Actions({
           {t(['gongyuhagi', '공유하기'])}
         </ActionButton>
       </ButtonGroup>
-      {!noDivider && <HR1 css={{ marginTop: 8, marginBottom: 0 }} />}
+      {!noDivider && <HR1 css={{ margin: '8px 0 0' }} />}
     </Section>
   )
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
POI 상세페이지 `Actions`컴포넌트 하단에서 사용되는 `<HR1>`에 넘기는 margin css prop값을 수정하여 `<HR1>`컴포넌트에 기본값으로 적용된 `margin: 50px 30px`에 의해 `<HR1>`의 너비가 줄어드는 현상을 해결합니다.

## 변경 내역

|As-is|To-be|
|-|-|
|<img width="333" alt="스크린샷 2023-02-01 오전 11 56 33" src="https://user-images.githubusercontent.com/50892653/215936086-61bace96-4857-4c48-a31a-9211745886ec.png">|<img width="334" alt="스크린샷 2023-02-01 오전 11 59 01" src="https://user-images.githubusercontent.com/50892653/215936116-4629adc6-e702-4312-bdd5-6d58687b3e68.png">|

