### PR TITLE
[review] 댓글 개수를 표시할 때 pinned message도 포함하여 표시합니다.

### DIFF
--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -278,7 +278,9 @@ function ReviewElement({
             }}
           >
             {replyBoard
-              ? replyBoard.rootMessagesCount + replyBoard.childMessagesCount
+              ? replyBoard.rootMessagesCount +
+                replyBoard.childMessagesCount +
+                replyBoard.pinnedMessagesCount
               : 0}
           </MessageCount>
 

--- a/packages/review/src/components/types.tsx
+++ b/packages/review/src/components/types.tsx
@@ -46,6 +46,7 @@ export interface ReviewData {
     resourceId: string
     resourceType: string
     rootMessagesCount: number
+    pinnedMessagesCount: number
   }
 }
 

--- a/packages/review/src/services/generated/query.ts
+++ b/packages/review/src/services/generated/query.ts
@@ -1036,6 +1036,7 @@ export const BaseReviewFragmentDoc = `
     id
     rootMessagesCount
     childMessagesCount
+    pinnedMessagesCount
   }
   liked
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
리뷰 개수를 표시할 때 아래 사진의 파트너 댓글과 같은 `pinned message`(연회색 백그라운드)도 포함하여 표시하도록 수정합니다.
![스크린샷 2023-02-01 오후 1 58 54](https://user-images.githubusercontent.com/50892653/215955628-601de507-e51c-44e5-9f76-07a1dd1e671f.png)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

