### PR TITLE
[review, listing-filter] ui-renewal 디자인 개선사항을 수정합니다.

### DIFF
--- a/packages/i18n/src/assets/ja/common-web.ts
+++ b/packages/i18n/src/assets/ja/common-web.ts
@@ -183,7 +183,6 @@ export const jaCommonWeb = {
   '...deobogi': '…もっと見る',
   'pointeubyeol-hyetaeg-bogi': 'ポイント別特典を見る',
   ribyu: 'レビュー',
-  totalreviewscount: '<0> {{totalReviewsCount}}</0>',
   'totalreviewscount-gaeyi-ribyu':
     '<0> {{totalReviewsCount}}</0><1>個のレビュー</1>',
   'numofrestreviews-gae-ribyu-deobogi':

--- a/packages/i18n/src/assets/ja/common-web.ts
+++ b/packages/i18n/src/assets/ja/common-web.ts
@@ -182,7 +182,8 @@ export const jaCommonWeb = {
   'ijeon-dabgeul-deobogi': '以前のコメントを見る',
   '...deobogi': '…もっと見る',
   'pointeubyeol-hyetaeg-bogi': 'ポイント別特典を見る',
-  'ribyu-totalreviewscount': '<0>レビュー</0><1> {{totalReviewsCount}}</1>',
+  ribyu: 'レビュー',
+  totalreviewscount: '<0> {{totalReviewsCount}}</0>',
   'totalreviewscount-gaeyi-ribyu':
     '<0> {{totalReviewsCount}}</0><1>個のレビュー</1>',
   'numofrestreviews-gae-ribyu-deobogi':

--- a/packages/i18n/src/assets/ko/common-web.ts
+++ b/packages/i18n/src/assets/ko/common-web.ts
@@ -178,7 +178,8 @@ export const koCommonWeb = {
   'ijeon-dabgeul-deobogi': '이전 답글 더보기',
   '...deobogi': '…더보기',
   'pointeubyeol-hyetaeg-bogi': '포인트별 혜택 보기',
-  'ribyu-totalreviewscount': '<0>리뷰</0><1> {{totalReviewsCount}}</1>',
+  ribyu: '리뷰',
+  totalreviewscount: '<0> {{totalReviewsCount}}</0>',
   'totalreviewscount-gaeyi-ribyu':
     '<0> {{totalReviewsCount}}</0><1>개의 리뷰</1>',
   'numofrestreviews-gae-ribyu-deobogi': '{{numOfRestReviews}}개 리뷰 더보기',

--- a/packages/i18n/src/assets/ko/common-web.ts
+++ b/packages/i18n/src/assets/ko/common-web.ts
@@ -179,7 +179,6 @@ export const koCommonWeb = {
   '...deobogi': '…더보기',
   'pointeubyeol-hyetaeg-bogi': '포인트별 혜택 보기',
   ribyu: '리뷰',
-  totalreviewscount: '<0> {{totalReviewsCount}}</0>',
   'totalreviewscount-gaeyi-ribyu':
     '<0> {{totalReviewsCount}}</0><1>개의 리뷰</1>',
   'numofrestreviews-gae-ribyu-deobogi': '{{numOfRestReviews}}개 리뷰 더보기',

--- a/packages/i18n/src/assets/zh/common-web.ts
+++ b/packages/i18n/src/assets/zh/common-web.ts
@@ -174,7 +174,6 @@ export const zhCommonWeb = {
   '...deobogi': '...查看更多',
   'pointeubyeol-hyetaeg-bogi': '查看點數優惠',
   ribyu: '評論',
-  totalreviewscount: '<0> {{totalReviewsCount}}</0>',
   'totalreviewscount-gaeyi-ribyu': '<0> {{totalReviewsCount}}</0><1>個評論</1>',
   'numofrestreviews-gae-ribyu-deobogi': '查看剩餘{{numOfRestReviews}}個評論',
   'ribyu-sseumyeon-yeohaengja-keulreob-coedae-3pointeu':

--- a/packages/i18n/src/assets/zh/common-web.ts
+++ b/packages/i18n/src/assets/zh/common-web.ts
@@ -173,7 +173,8 @@ export const zhCommonWeb = {
   'ijeon-dabgeul-deobogi': '查看更多之前的回覆',
   '...deobogi': '...查看更多',
   'pointeubyeol-hyetaeg-bogi': '查看點數優惠',
-  'ribyu-totalreviewscount': '<0>評論</0><1> {{totalReviewsCount}}</1>',
+  ribyu: '評論',
+  totalreviewscount: '<0> {{totalReviewsCount}}</0>',
   'totalreviewscount-gaeyi-ribyu': '<0> {{totalReviewsCount}}</0><1>個評論</1>',
   'numofrestreviews-gae-ribyu-deobogi': '查看剩餘{{numOfRestReviews}}個評論',
   'ribyu-sseumyeon-yeohaengja-keulreob-coedae-3pointeu':

--- a/packages/listing-filter/src/index.tsx
+++ b/packages/listing-filter/src/index.tsx
@@ -5,6 +5,7 @@ import { HTMLAttributes, ReactNode, PureComponent } from 'react'
 const FilterEntryBase = styled.div<{ active?: boolean; disabled?: boolean }>`
   display: inline-block;
   font-size: 13px;
+  font-weight: ${({ active }) => (active ? 'bold' : 'inherit')};
   line-height: 15px;
   border: 1px solid
     ${({ active }) => (active ? 'var(--color-blue)' : 'var(--color-gray200)')};

--- a/packages/listing-filter/src/index.tsx
+++ b/packages/listing-filter/src/index.tsx
@@ -5,7 +5,6 @@ import { HTMLAttributes, ReactNode, PureComponent } from 'react'
 const FilterEntryBase = styled.div<{ active?: boolean; disabled?: boolean }>`
   display: inline-block;
   font-size: 13px;
-  font-weight: ${({ active }) => (active ? 'bold' : 'inherit')};
   line-height: 15px;
   border: 1px solid
     ${({ active }) => (active ? 'var(--color-blue)' : 'var(--color-gray200)')};
@@ -111,6 +110,7 @@ const RegularFilterEntry = styled(FilterEntryBase)<{
       ? css`
           color: var(--color-white);
           background-color: var(--color-blue);
+          font-weight: bold;
         `
       : css`
           color: var(--color-gray200);

--- a/packages/review/src/components/review-container.tsx
+++ b/packages/review/src/components/review-container.tsx
@@ -342,11 +342,9 @@ function ReviewContainer({
               {t(['ribyu', '리뷰'])}
             </Text>
             {(totalReviewsCount || 0) > 0 ? (
-              <Trans i18nKey={['totalreviewscount']} ns="common-web">
-                <Text bold size="huge" color="blue" alpha={1} inline>
-                  <>{{ totalReviewsCount: formatNumber(totalReviewsCount) }}</>
-                </Text>
-              </Trans>
+              <Text bold size="huge" color="blue" alpha={1} inline>
+                {` ${formatNumber(totalReviewsCount)}`}
+              </Text>
             ) : null}
           </>
         ) : (

--- a/packages/review/src/components/review-container.tsx
+++ b/packages/review/src/components/review-container.tsx
@@ -338,15 +338,11 @@ function ReviewContainer({
 
         {shortened ? (
           <>
+            <Text bold size="huge" color="gray" alpha={1} inline>
+              {t(['ribyu', '리뷰'])}
+            </Text>
             {(totalReviewsCount || 0) > 0 ? (
-              <Trans
-                i18nKey={[
-                  'ribyu-totalreviewscount',
-                  '<0>리뷰</0><1> {{totalReviewsCount}}</1>',
-                ]}
-                ns="common-web"
-              >
-                <Text bold size="huge" color="gray" alpha={1} inline />
+              <Trans i18nKey={['totalreviewscount']} ns="common-web">
                 <Text bold size="huge" color="blue" alpha={1} inline>
                   <>{{ totalReviewsCount: formatNumber(totalReviewsCount) }}</>
                 </Text>

--- a/packages/review/src/components/sorting-options.tsx
+++ b/packages/review/src/components/sorting-options.tsx
@@ -17,6 +17,10 @@ const OptionsContainer = styled(FlexBox)`
   div:not(:first-child) {
     margin-left: 12px;
   }
+
+  span {
+    font-weight: bold;
+  }
 `
 
 export default function SortingOptions({


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- content-web의 ui renewal 디자인 개선사항을 수정합니다. ([피그마](https://www.figma.com/file/qlovwieZox6DTlEP8CqeVY/20230201_%EA%B0%9C%EB%B0%9C-%EC%97%85%EB%8D%B0%EC%9D%B4%ED%8A%B8-%EC%95%84%ED%8B%B0%ED%81%B4-%EA%B2%80%EC%88%98?node-id=0%3A1&t=VAFHdmLO9R4oDXry-0))
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- `ListingFilterEntry`가 active 일 때 텍스트를 볼드 처리합니다.
- 리뷰의 '추천순', '최신순' `SortingOptions`의 텍스트를 볼드 처리합니다.
- 리뷰의 shorten 버전에서 리뷰의 개수가 0일 때 타이틀이 노출되지 않아 레이아웃이 깨지는 현상을 수정합니다.

|as-is|to-be|
|----|----|
|<img width="400" alt="_______________________________2023-02-03______________3 51 09" src="https://user-images.githubusercontent.com/37494848/216537587-4973ffc1-70fb-4074-a30d-f8b2be995b14.png">|<img width="400" alt="_______________________________2023-02-03______________3 52 38" src="https://user-images.githubusercontent.com/37494848/216537599-b33ac464-bc98-4b9c-a9ba-a1d42179826e.png">|
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

