### PR TITLE
더 적절한 의존성 사용

### DIFF
--- a/packages/chat/src/chat-bubble/bubble-payload.tsx
+++ b/packages/chat/src/chat-bubble/bubble-payload.tsx
@@ -1,16 +1,8 @@
 import { Autolinker } from 'autolinker'
-import React from 'react'
 
-import {
-  ImageBubble,
-  ImagePayload,
-  MessageType,
-  RichBubble,
-  RichPayload,
-  TextBubble,
-  TextPayload,
-  useChat,
-} from '@titicaca/chat'
+import { ImageBubble, RichBubble, TextBubble } from '../bubbles'
+import { useChat } from '../chat'
+import { ImagePayload, MessageType, RichPayload, TextPayload } from '../types'
 
 interface BubblePayloadProps {
   payload: TextPayload | ImagePayload | RichPayload

--- a/packages/core-elements/src/elements/checkbox/checkbox-group.stories.tsx
+++ b/packages/core-elements/src/elements/checkbox/checkbox-group.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from '@storybook/addons'
+import { useState } from 'react'
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 
 import { Checkbox } from './checkbox'

--- a/packages/react-contexts/src/images-context/images-context.stories.tsx
+++ b/packages/react-contexts/src/images-context/images-context.stories.tsx
@@ -1,6 +1,5 @@
 import { useState, memo } from 'react'
 import styled from 'styled-components'
-import { Button } from '@titicaca/core-elements'
 
 import { ImagesProvider, useImagesContext } from '.'
 
@@ -40,7 +39,7 @@ function ImagesContextMonitor({ onFetched }: { onFetched?: () => void }) {
       <Section>
         <h2>actions</h2>
         <SectionBody>
-          <Button onClick={() => actions.fetch(onFetched)}>fetch()</Button>
+          <button onClick={() => actions.fetch(onFetched)}>fetch()</button>
 
           <div>
             indexOf(


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

더 적절한 의존성 사용

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- [chat] 같은 패키지에서 import path는 relative path를 사용합니다.
- [core-elements] useState를 @storybook/addons 대신 react에서 import 합니다.
- [react-contexts] core-elements 의존성이 없어서 Button 컴포넌트를 뺍니다.