### PR TITLE
[triple-header] layout shift 를 개선합니다.

### DIFF
--- a/packages/triple-header/src/triple-header.tsx
+++ b/packages/triple-header/src/triple-header.tsx
@@ -5,20 +5,22 @@ import styled, { css } from 'styled-components'
 import { Layer } from './layer'
 import { TripleHeader as TripleHeaderProps } from './types'
 
+const MAX_WIDTH = 768
+
 const Canvas = styled(Container).attrs({
   position: 'relative',
   centered: true,
 })<{ clientWidth?: number; width: number; height: number }>`
   overflow: hidden;
-  max-width: 768px;
+  max-width: ${MAX_WIDTH}px;
 
   ${({ clientWidth, width, height }) =>
     width &&
     height &&
     css`
       width: 100%;
-      height: calc(${clientWidth}px * ${height / width});
-      max-height: ${768 * (height / width)}px;
+      height: calc(${clientWidth || MAX_WIDTH}px * ${height / width});
+      max-height: ${MAX_WIDTH * (height / width)}px;
     `}
 `
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

아티클 상세에서 트리플 헤더를 추가했을 때, 레이아웃 쉬프트가 발생합니다. 
- 트리플 헤더를 렌더링할 때 다수의 이미지를 호출하며 영역 비율 계산하기 때문에 본문 영역에 비해 오래 걸립니다.

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

트리플 헤더가 들어갈 공간을 미리 확보해서, 레이아웃 쉬프트가 발생하는 시간을 줄입니다.

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

CLS 성능 테스트
- 네트워크 속도 등 다양한 요인으로 인해 매번 측정되는 시간이 다릅니다.

1. 0.857s -> 0.166s (`80.63%` 감소)
2. 0.857s -> 0.284s (`66.86%` 감소)
3. 0.858s -> 0.519s (`39.43%` 감소)

-> **평균: `62.30%` 감소**


<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

