### PR TITLE
[review] 최근여행 리뷰 개수 표시 오류를 수정합니다.

### DIFF
--- a/packages/review/src/components/review-container.tsx
+++ b/packages/review/src/components/review-container.tsx
@@ -161,7 +161,11 @@ function ReviewContainer({
   })
   const descriptionsData = useDescriptions({ resourceId, resourceType })
   const myReviewData = useMyReview({ resourceId, resourceType })
-  const reviewsCountData = useReviewCount({ resourceId, resourceType })
+  const reviewsCountData = useReviewCount({
+    resourceId,
+    resourceType,
+    recentTrip: isRecentTrip,
+  })
 
   const setMyReview = useCallback(
     (review: ReviewData | undefined) =>
@@ -330,9 +334,7 @@ function ReviewContainer({
     })
   }, [isRecentTrip, trackEvent])
 
-  const recentReviewsCount = reviewsData.length
-  const reviewsCount = isRecentTrip ? recentReviewsCount : totalReviewsCount
-  const numOfRestReviews = reviewsCount - SHORTENED_REVIEWS_COUNT_PER_PAGE
+  const numOfRestReviews = totalReviewsCount - SHORTENED_REVIEWS_COUNT_PER_PAGE
 
   return (
     <Section anchor={REVIEWS_SECTION_ID}>
@@ -391,7 +393,7 @@ function ReviewContainer({
 
       {isLoaded ? (
         <>
-          {reviewsCount > 0 ? (
+          {totalReviewsCount > 0 ? (
             <ReviewsList
               maxLength={
                 shortened ? SHORTENED_REVIEWS_COUNT_PER_PAGE : undefined
@@ -425,7 +427,7 @@ function ReviewContainer({
             />
           )}
 
-          {reviewsCount > SHORTENED_REVIEWS_COUNT_PER_PAGE && shortened ? (
+          {totalReviewsCount > SHORTENED_REVIEWS_COUNT_PER_PAGE && shortened ? (
             <Container
               css={{
                 margin: '40px 0 0',

--- a/packages/review/src/services/generated/query.ts
+++ b/packages/review/src/services/generated/query.ts
@@ -988,6 +988,7 @@ export type GetReviewSpecificationQuery = {
 export type GetReviewsCountQueryVariables = Exact<{
   resourceType: Scalars['String']
   resourceId: Scalars['String']
+  recentTrip: Scalars['Boolean']
 }>
 
 export type GetReviewsCountQuery = {
@@ -1261,10 +1262,11 @@ export const useGetReviewSpecificationQuery = <
     options,
   )
 export const GetReviewsCountDocument = `
-    query GetReviewsCount($resourceType: String!, $resourceId: String!) {
+    query GetReviewsCount($resourceType: String!, $resourceId: String!, $recentTrip: Boolean) {
   reviewsCount: getReviewsCount(
     resourceType: $resourceType
     resourceId: $resourceId
+    recentTrip: $recentTrip
   )
 }
     `

--- a/packages/review/src/services/use-reviews.ts
+++ b/packages/review/src/services/use-reviews.ts
@@ -122,12 +122,14 @@ export function useReviews({
 export function useReviewCount({
   resourceType,
   resourceId,
-}: Pick<UseReviewsProps, 'resourceType' | 'resourceId'>) {
+  recentTrip,
+}: Pick<UseReviewsProps, 'resourceType' | 'resourceId' | 'recentTrip'>) {
   const { data: reviewsCountData } = useGetReviewsCountQuery(
     graphqlClient,
     {
       resourceType,
       resourceId,
+      recentTrip,
     },
     {
       refetchOnReconnect: false,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[관련 스레드](https://titicaca.slack.com/archives/C01CHRQBP1U/p1676253558034269)
`최근 여행` 리뷰의 개수가 5개 이상임에도 불구하고, `리뷰 더보기` 버튼이 무조건 `1개 리뷰 더보기` 로 표시되는 버그를 수정합니다.

## 변경 내역

최근 여행 리뷰의 경우, `getLatestReviews` graphql 쿼리를 통해 가져오는 데이터(`reviewsData`) 배열의 길이를 이용하여 리뷰 개수를 표시하고 있었습니다. 이때, `getLatestReviews` 쿼리에 인자로 넘기는 `size`의 값이 5로 설정되어 있어 5 - 4(한 페이지에 보여주는 리뷰 개수 디폴트값) = 1이 되어 최근 여행의 경우 항상 `1개의 리뷰 더보기` 로 표시되는 버그가 있었습니다.

따라서 (기존에도 잘 동작하던) 최근 여행이 아닌 리뷰와 마찬가지로, 최근 여행 리뷰 개수를 표시할 때 [getReviewsCount](https://triple-dev.titicaca-corp.com/api/graphql?query=%7B%0A++getReviewsCount%28resourceType%3A+%22poi%22%2C+resourceId%3A+%2207c94508-bcad-48fb-9b0e-b17bea8a547f%22%2C+recentTrip%3A+true%29%0A%7D%0A) 쿼리를 통해 리뷰 개수를 표시하도록 수정합니다.


