### PR TITLE
Lazy load IntersectionObserver를 deprecate 합니다.

### DIFF
--- a/packages/core-elements/src/elements/image/optimized-img.tsx
+++ b/packages/core-elements/src/elements/image/optimized-img.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import styled from 'styled-components'
-import IntersectionObserver from '@titicaca/intersection-observer'
+import { StaticIntersectionObserver } from '@titicaca/intersection-observer'
 import { generateImageUrl, Version, Quality } from '@titicaca/content-utilities'
 
 import { useImageState } from './context'
@@ -119,7 +119,7 @@ export function ImageOptimizedImg({
   )
 
   return (
-    <IntersectionObserver rootMargin="200px" onChange={handleLazyLoad}>
+    <StaticIntersectionObserver rootMargin="200px" onChange={handleLazyLoad}>
       {!isLoad ? (
         <Placeholder absolute={absolute} />
       ) : (
@@ -130,6 +130,6 @@ export function ImageOptimizedImg({
           absolute={absolute}
         />
       )}
-    </IntersectionObserver>
+    </StaticIntersectionObserver>
   )
 }

--- a/packages/intersection-observer/src/lazy-loaded-intersection-observer.tsx
+++ b/packages/intersection-observer/src/lazy-loaded-intersection-observer.tsx
@@ -34,6 +34,9 @@ const SafeObserver = dynamic(importReactIntersectionObserver, {
   ssr: false,
 })
 
+/**
+ * @deprecated StaticIntersectionObserver를 사용해 주세요.
+ */
 export default function IntersectionObserver({
   safe,
   ...props

--- a/packages/scroll-spy/src/index.test.tsx
+++ b/packages/scroll-spy/src/index.test.tsx
@@ -1,29 +1,30 @@
 import { useEffect } from 'react'
-import IntersectionObserver from '@titicaca/intersection-observer'
 import { render } from '@testing-library/react'
 
 import '@testing-library/jest-dom'
 
 import { ScrollSpyContainer, ScrollSpyEntity } from './index'
 
-jest.mock('@titicaca/intersection-observer')
+jest.mock('@titicaca/intersection-observer', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  StaticIntersectionObserver: jest
+    .fn()
+    .mockImplementation(({ onChange, children }) => {
+      useEffect(() => {
+        onChange(
+          { isIntersecting: true } as IntersectionObserverEntry,
+          jest.fn(),
+        )
+      }, [onChange])
+
+      return <div>{children}</div>
+    }),
+}))
 jest.mock('@titicaca/react-hooks', () => ({
   useScrollToElement: () => ({ isScrolling: () => {} }),
 }))
 
 test('ScrollSpyEntity로 감싼 영역이 화면에 들어오면 ScrollSpyContainer의 onChange로 전달한 함수를 호출합니다.', () => {
-  ;(
-    IntersectionObserver as unknown as jest.MockedFunction<
-      typeof IntersectionObserver
-    >
-  ).mockImplementation(({ onChange, children }) => {
-    useEffect(() => {
-      onChange({ isIntersecting: true } as IntersectionObserverEntry, jest.fn())
-    }, [onChange])
-
-    return <div>{children}</div>
-  })
-
   const targetId = 'target-id'
   const handleActiveIdChange = jest.fn()
 

--- a/packages/scroll-spy/src/index.tsx
+++ b/packages/scroll-spy/src/index.tsx
@@ -5,7 +5,7 @@ import {
   PropsWithChildren,
   createContext,
 } from 'react'
-import IntersectionObserver from '@titicaca/intersection-observer'
+import { StaticIntersectionObserver } from '@titicaca/intersection-observer'
 import { useWindowSize } from 'react-use'
 import { useScrollToElement } from '@titicaca/react-hooks'
 
@@ -104,11 +104,11 @@ export function ScrollSpyEntity({
   }px 0px`
 
   return (
-    <IntersectionObserver
+    <StaticIntersectionObserver
       rootMargin={rootMargin}
       onChange={generateScrollSpyIntersectionChangeHandler(id)}
     >
       <div id={id}>{children}</div>
-    </IntersectionObserver>
+    </StaticIntersectionObserver>
   )
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[관련 스레드](https://titicaca.slack.com/archives/CEEPB4TDY/p1676354386689769)
([React Hydration Error](https://nextjs.org/docs/messages/react-hydration-error)의 원인이기도 한) lazy load IntersectionObserver를 deprecate 처리하고 `StaticIntersectionObserver`를 대신 사용합니다.

