### PR TITLE
[ui-flow] authGuard에 needRefreshInAppSessionError 옵션을 추가합니다.

### DIFF
--- a/packages/ui-flow/src/auth-guard/index.ts
+++ b/packages/ui-flow/src/auth-guard/index.ts
@@ -56,7 +56,7 @@ export function authGuard<Props>(
 
       if (status === 401) {
         if (userAgentString && parseTripleClientUserAgent(userAgentString)) {
-          return refreshInAppSession({ resolvedUrl, returnUrl })
+          return refreshInAppSession<Props>({ resolvedUrl, returnUrl })
         }
 
         return redirectToLogin({ returnUrl, authType: options?.authType })
@@ -77,7 +77,7 @@ export function authGuard<Props>(
   }
 }
 
-function refreshInAppSession({
+function refreshInAppSession<Props>({
   resolvedUrl,
   returnUrl,
 }: {
@@ -94,7 +94,11 @@ function refreshInAppSession({
     .use()
 
   if (refreshed) {
-    throw new Error('세션 갱신에 실패했습니다.')
+    return {
+      props: {
+        requireAppLogin: true,
+      },
+    } as unknown as GetServerSidePropsResult<Props>
   }
 
   const destinationQuery = qs.stringify({


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
- authGuard에 needRefreshInAppSessionError 옵션을 추가합니다. 해당 옵션이 있으면 refreshInAppSession에서 throw Error대신 props를 전달합니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- 앱의 로그인 화면으로 이동하기 위해서는 server side의 redirect 기능이 아닌 client side에서의 navigate (useHistoryContext) 적용이 필요합니다. 
- 따라서 needRefreshInAppSessionError옵션이 false로 있을 경우 prop 전달을 하도록 변경합니다. 
- 기존에 사용하던 곳들이 있기 때문에 default 옵션을 주고 필요한 곳에만 전달하면 되도록 수정했습니다.
- 관련되어 있는 triple-landing-web도 일부 수정했습니다. https://github.com/titicacadev/triple-landing-web/pull/73

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
