### PR TITLE
[triple-header] 트리플헤더 날아오기 효과의 속도를 변경합니다.

### DIFF
--- a/packages/triple-header/src/frame/effects/common.ts
+++ b/packages/triple-header/src/frame/effects/common.ts
@@ -13,12 +13,17 @@ const COMMON_TRANSITION = {
   duration: 3,
 }
 
-export function generateTransition<T>(options: T & InitialEffectOptions) {
+export function generateTransition<T>(
+  initialOptions: T & InitialEffectOptions,
+) {
+  const { infinity, repeatType, ...options } = initialOptions
+
   const transition = {
     ...COMMON_TRANSITION,
-    ...(options.infinity && { repeat: Infinity }),
-    ...(options.repeatType && {
-      repeatType: options.repeatType,
+    ...options,
+    ...(infinity && { repeat: Infinity }),
+    ...(repeatType && {
+      repeatType,
     }),
   }
 

--- a/packages/triple-header/src/frame/effects/flying.tsx
+++ b/packages/triple-header/src/frame/effects/flying.tsx
@@ -19,7 +19,7 @@ export function Flying({
   children,
   options = {},
 }: PropsWithChildren<FlyingProps>) {
-  const transition = generateTransition(options)
+  const transition = generateTransition({ ...options, duration: 0.3 })
 
   return (
     <MotionContainer


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

날아오기 효과의 속도를 조절합니다.

[관련 스레드](https://titicaca.slack.com/archives/C0J3TT1H8/p1675652416306319?thread_ts=1665985693.829549&cid=C0J3TT1H8)

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- 3000ms -> 300ms 

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
