### PR TITLE
[ui-flow] authGuard의 refreshInAppSession 실행조건을 수정합니다.

### DIFF
--- a/packages/ui-flow/src/auth-guard/index.test.ts
+++ b/packages/ui-flow/src/auth-guard/index.test.ts
@@ -247,9 +247,8 @@ test('authType을 이용해 로그인 페이지의 Type을 명시할 수 있습�
 })
 
 describe('앱에서', () => {
-  describe('로그인이 필요하면 로그인 페이지 리디렉션 대신 토큰 새로고침을 시도합니다.', () => {
-    const resolvedUrl = '/test-url?_triple_no_navbar'
-
+  const resolvedUrl = '/test-url?_triple_no_navbar'
+  describe('로그인이 필요하면 앱 내 로그인 페이지를 호출합니다.', () => {
     test('쿠키가 없을 때', async () => {
       const oldGssp = jest.fn()
       const newGssp = authGuard(oldGssp)
@@ -260,13 +259,8 @@ describe('앱에서', () => {
       expect(oldGssp).toBeCalledTimes(0)
       expect(result).toEqual({
         redirect: {
-          destination: `/landing/refresh?returnUrl=${encodeURIComponent(
-            generateUrl(
-              {
-                query: 'refreshed=true',
-              },
-              resolvedUrl,
-            ),
+          destination: `/login?returnUrl=${encodeURIComponent(
+            generateUrl({}, resolvedUrl),
           )}`,
           basePath: false,
           permanent: false,
@@ -288,47 +282,13 @@ describe('앱에서', () => {
       expect(oldGssp).toBeCalledTimes(0)
       expect(result).toEqual({
         redirect: {
-          destination: `/landing/refresh?returnUrl=${encodeURIComponent(
-            generateUrl(
-              {
-                query: 'refreshed=true',
-              },
-              resolvedUrl,
-            ),
+          destination: `/login?returnUrl=${encodeURIComponent(
+            generateUrl({}, resolvedUrl),
           )}`,
           basePath: false,
           permanent: false,
         },
       })
-    })
-  })
-
-  describe('토큰 새로고침 이후에도 쿠키가 유효하지 않으면 오류를 던집니다.', () => {
-    test('쿠키가 없을 때', async () => {
-      const oldGssp = jest.fn()
-      const newGssp = authGuard(oldGssp)
-      const context = createContext({
-        userAgent: appUserAgent,
-        resolvedUrl: '/test-url?refreshed=true',
-      })
-
-      await expect(newGssp(context)).rejects.toThrowError()
-
-      expect(oldGssp).toBeCalledTimes(0)
-    })
-
-    test('쿠키가 유효하지 않을 때', async () => {
-      const oldGssp = jest.fn()
-      const newGssp = authGuard(oldGssp)
-      const context = createContext({
-        userAgent: appUserAgent,
-        resolvedUrl: '/test-url?refreshed=true',
-        cookie: invalidCookie,
-      })
-
-      await expect(newGssp(context)).rejects.toThrowError()
-
-      expect(oldGssp).toBeCalledTimes(0)
     })
   })
 })

--- a/packages/ui-flow/src/auth-guard/index.ts
+++ b/packages/ui-flow/src/auth-guard/index.ts
@@ -3,7 +3,7 @@ import { get } from '@titicaca/fetcher'
 import { parseTripleClientUserAgent } from '@titicaca/react-triple-client-interfaces'
 import qs from 'qs'
 import { generateUrl, parseUrl, strictQuery } from '@titicaca/view-utilities'
-import { getSessionIdFromRequest } from '@titicaca/react-contexts/src/session-context/app'
+import { getSessionAvailabilityFromRequest } from '@titicaca/react-contexts'
 
 interface UserResponse {
   uid: string
@@ -59,7 +59,7 @@ export function authGuard<Props>(
         if (
           userAgentString &&
           parseTripleClientUserAgent(userAgentString) &&
-          getSessionIdFromRequest(req)
+          getSessionAvailabilityFromRequest(req)
         ) {
           return refreshInAppSession({ resolvedUrl, returnUrl })
         }

--- a/packages/ui-flow/src/auth-guard/index.ts
+++ b/packages/ui-flow/src/auth-guard/index.ts
@@ -3,6 +3,7 @@ import { get } from '@titicaca/fetcher'
 import { parseTripleClientUserAgent } from '@titicaca/react-triple-client-interfaces'
 import qs from 'qs'
 import { generateUrl, parseUrl, strictQuery } from '@titicaca/view-utilities'
+import { getSessionIdFromRequest } from '@titicaca/react-contexts/src/session-context/app'
 
 interface UserResponse {
   uid: string
@@ -55,7 +56,11 @@ export function authGuard<Props>(
       const { status } = response
 
       if (status === 401) {
-        if (userAgentString && parseTripleClientUserAgent(userAgentString)) {
+        if (
+          userAgentString &&
+          parseTripleClientUserAgent(userAgentString) &&
+          getSessionIdFromRequest(req)
+        ) {
           return refreshInAppSession({ resolvedUrl, returnUrl })
         }
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
- `authGuard`의 `refreshInAppSession` 실행조건을 수정합니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- `refreshInAppSession`은 앱에서 이미 로그인되어있지만 토큰값이 깨진 경우에만 실행되어야 합니다. 
- 따라서 `x-soto-session` 값의 유무를 판별해 주는 `getSessionAvailabilityFromRequest`가 `true`일 경우만 landing web(refreshInAppSession)으로 이동할 수 있도록 합니다.
- 앱에 해당하는 테스트코드를 변경합니다. 
- auth-web에서 app일 경우 접근을 막는 방어코드를 작성했습니다. https://github.com/titicacadev/triple-auth-web/pull/236

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
