### PR TITLE
[meta-tags] ThemeColorMeta의 기본 props color와 README를 일부 수정합니다.

### DIFF
--- a/packages/meta-tags/README.md
+++ b/packages/meta-tags/README.md
@@ -199,7 +199,7 @@ return (
 - 사용가이드
   - 콘텐츠 타입
     - name: theme-color, msapplication-TileColor
-    - content: 색상 (`ex) #ffffff, rgb(0, 0, 0), rgba(0, 0, 0, 0)`)
+    - content: 색상 (default: `#1FC1B6`, e.g. `#ffffff`, `rgb(0, 0, 0)`, `rgba(0, 0, 0, 0)`)
 
 ## 구조화된 데이터
 

--- a/packages/meta-tags/src/theme-color-meta.tsx
+++ b/packages/meta-tags/src/theme-color-meta.tsx
@@ -8,7 +8,7 @@ type HEX = `#${string}`
 type Color = RGB | RGBA | HEX | Global
 
 export function ThemeColorMeta({
-  content = '#ffffff',
+  content = '#1FC1B6',
 }: {
   content?: Color | string
 }) {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- ThemeColorMeta의 기본 props color를 `#1FC1B6`으로 변경합니다.(사유: [common-meta](https://github.com/titicacadev/triple-frontend/blob/main/packages/meta-tags/src/common-meta.tsx#L16)의 기본값과 색상을 통일하기 위함)
- README의 내용을 일부 수정합니다.(기본값 변경)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->