### PR TITLE
popup 에 FocusScope 를 제거합니다.

### DIFF
--- a/packages/popup/src/index.tsx
+++ b/packages/popup/src/index.tsx
@@ -3,7 +3,6 @@ import { CSSTransition } from 'react-transition-group'
 import styled from 'styled-components'
 import { Navbar, Portal } from '@titicaca/core-elements'
 import { CSSTransitionProps } from 'react-transition-group/CSSTransition'
-import { FocusScope } from '@react-aria/focus'
 import { useOverlay } from '@react-aria/overlays'
 
 type NavbarIcon = 'close' | 'back'
@@ -137,31 +136,28 @@ function Popup({
 
   return (
     <Portal>
-      {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
-      <FocusScope autoFocus contain restoreFocus>
-        <div {...underlayProps}>
-          <CSSTransition
-            nodeRef={popupRef}
-            timeout={TRANSITION_DURATION}
-            in={open}
-            classNames="popup-slide"
-            appear
-            mountOnEnter={unmountOnExit}
-            unmountOnExit={unmountOnExit}
-            {...restProps}
-          >
-            <PopupContainer {...overlayProps} ref={popupRef}>
-              {noNavbar ? null : (
-                <Navbar borderless={borderless} title={title}>
-                  <Navbar.Item floated="left" icon={icon} onClick={onClose} />
-                </Navbar>
-              )}
+      <div {...underlayProps}>
+        <CSSTransition
+          nodeRef={popupRef}
+          timeout={TRANSITION_DURATION}
+          in={open}
+          classNames="popup-slide"
+          appear
+          mountOnEnter={unmountOnExit}
+          unmountOnExit={unmountOnExit}
+          {...restProps}
+        >
+          <PopupContainer {...overlayProps} ref={popupRef}>
+            {noNavbar ? null : (
+              <Navbar borderless={borderless} title={title}>
+                <Navbar.Item floated="left" icon={icon} onClick={onClose} />
+              </Navbar>
+            )}
 
-              {children}
-            </PopupContainer>
-          </CSSTransition>
-        </div>
-      </FocusScope>
+            {children}
+          </PopupContainer>
+        </CSSTransition>
+      </div>
     </Portal>
   )
 }


### PR DESCRIPTION
## PR 설명

popup 하위에 focusable 한 input 컴포넌트가 존재할 경우 시스템 키보드 닫기가 불가능한 이슈를 수정합니다.

## 변경 내역

+ Popup 에 FocusScope 를 제거합니다.

## 제보영상

https://user-images.githubusercontent.com/37819666/220565271-68c15371-5df1-4a41-9498-867e2e9b5d96.MP4



