### PR TITLE
Default Footer 에서 css 속성 사용 가능하도록 수정

### DIFF
--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -67,12 +67,12 @@ const AwardFlexBox = styled(FlexBox).attrs({
 
 export function AwardFooter({
   hideAppDownloadButton = false,
-  className,
+  ...props
 }: AwardFooterProps) {
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
   return (
-    <FooterFrame className={className}>
+    <FooterFrame {...props}>
       <Container
         centered
         css={{

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -67,11 +67,12 @@ const AwardFlexBox = styled(FlexBox).attrs({
 
 export function AwardFooter({
   hideAppDownloadButton = false,
+  className,
 }: AwardFooterProps) {
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
   return (
-    <FooterFrame>
+    <FooterFrame className={className}>
       <Container
         centered
         css={{

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -11,13 +11,17 @@ export const FooterFrame = styled.footer`
 
 export interface DefaultFooterProps {
   hideAppDownloadButton?: boolean
+  className?: string
 }
 
-function DefaultFooter({ hideAppDownloadButton = false }: DefaultFooterProps) {
+function DefaultFooter({
+  hideAppDownloadButton = false,
+  className,
+}: DefaultFooterProps) {
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
   return (
-    <FooterFrame>
+    <FooterFrame className={className}>
       <Container
         centered
         css={{

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -11,17 +11,16 @@ export const FooterFrame = styled.footer`
 
 export interface DefaultFooterProps {
   hideAppDownloadButton?: boolean
-  className?: string
 }
 
 function DefaultFooter({
   hideAppDownloadButton = false,
-  className,
+  ...props
 }: DefaultFooterProps) {
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
   return (
-    <FooterFrame className={className}>
+    <FooterFrame {...props}>
       <Container
         centered
         css={{


### PR DESCRIPTION
## PR 설명

styled-component 로 커스텀 리액트 컴포넌트 스타일링을 가능하도록 하기 위한 className 속성 추가

참고 : https://styled-components.com/docs/basics#styling-any-component


```javascript
/** @example */

<Footer css={{ paddingBottom: '200px' }} />
```

## 변경 내역

+ default-footer 에서 `className` 전달하도록 변경
