### PR TITLE
Select, fixed-pricing 스타일 버그 픽스

### DIFF
--- a/packages/core-elements/src/elements/select/select.tsx
+++ b/packages/core-elements/src/elements/select/select.tsx
@@ -20,6 +20,7 @@ const BaseSelect = styled.select`
   font-weight: 500;
   border: 1px solid var(--color-gray100);
   border-radius: 4px;
+  background-color: var(--color-white);
   color: var(--color-gray);
 
   &:disabled {

--- a/packages/pricing/src/fixed-pricing.tsx
+++ b/packages/pricing/src/fixed-pricing.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   Button,
   MarginPadding,
+  paddingMixin,
 } from '@titicaca/core-elements'
 import { formatNumber } from '@titicaca/view-utilities'
 
@@ -33,6 +34,7 @@ const FloatedFrame = styled(Container)<{ padding: MarginPadding }>`
   border-top: 1px solid #efefef;
   background: #fff;
 
+  ${paddingMixin}
   @supports (padding: max(0px)) and (padding: env(safe-area-inset-bottom)) {
     ${({ padding }) =>
       padding?.bottom


### PR DESCRIPTION
## PR 설명

TF12에서 발생한 스타일 에러를 수정합니다.

## 변경 내역

1. Select 컴포넌트를 `div` -> `select` 태그로 수정하면서, ios 환경에서 기본 background-color(회색)가 적용되기에 배경색을 통일합니다.
2. fixed-pricing에서 top, left, right padding이 적용되지 않는 문제를 해결합니다.