### PR TITLE
react-transition-group -> headlessui Transition 으로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41401,9 +41401,7 @@
       "dependencies": {
         "@titicaca/app-installation-cta": "^12.11.0",
         "@titicaca/core-elements": "^12.11.0",
-        "@titicaca/popup": "^12.11.0",
-        "@types/react-transition-group": "^4.4.5",
-        "react-transition-group": "^4.4.5"
+        "@titicaca/popup": "^12.11.0"
       },
       "peerDependencies": {
         "react": "^18.0",
@@ -41603,9 +41601,7 @@
         "@titicaca/intersection-observer": "^12.11.0",
         "@titicaca/triple-fallback-action": "^12.11.0",
         "@titicaca/view-utilities": "^12.11.0",
-        "@types/react-transition-group": "^4.4.5",
-        "react-input-mask": "^2.0.4",
-        "react-transition-group": "^4.4.5"
+        "react-input-mask": "^2.0.4"
       },
       "devDependencies": {
         "@titicaca/i18n": "^12.11.0",
@@ -42351,9 +42347,7 @@
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.7.11",
-        "@titicaca/core-elements": "^12.11.0",
-        "@types/react-transition-group": "^4.4.5",
-        "react-transition-group": "^4.4.5"
+        "@titicaca/core-elements": "^12.11.0"
       },
       "peerDependencies": {
         "react": "^18.0",

--- a/packages/action-sheet/package.json
+++ b/packages/action-sheet/package.json
@@ -22,9 +22,7 @@
   "dependencies": {
     "@titicaca/app-installation-cta": "^12.11.0",
     "@titicaca/core-elements": "^12.11.0",
-    "@titicaca/popup": "^12.11.0",
-    "@types/react-transition-group": "^4.4.5",
-    "react-transition-group": "^4.4.5"
+    "@titicaca/popup": "^12.11.0"
   },
   "peerDependencies": {
     "react": "^18.0",

--- a/packages/action-sheet/src/action-sheet-context.tsx
+++ b/packages/action-sheet/src/action-sheet-context.tsx
@@ -1,8 +1,6 @@
 import { createContext, useContext } from 'react'
-import { TransitionStatus } from 'react-transition-group'
 
 export interface ActionSheetContextValue {
-  transitionStatus: TransitionStatus
   open: boolean
   onClose?: () => void
 }

--- a/packages/action-sheet/src/action-sheet-overlay.tsx
+++ b/packages/action-sheet/src/action-sheet-overlay.tsx
@@ -1,8 +1,6 @@
-import { CSSProperties } from 'react'
-import { TransitionStatus } from 'react-transition-group'
 import styled from 'styled-components'
-
-import { useActionSheet } from './action-sheet-context'
+import { Transition } from '@headlessui/react'
+import { Fragment } from 'react'
 
 export const Overlay = styled.div<{ duration: number }>`
   position: fixed;
@@ -13,41 +11,39 @@ export const Overlay = styled.div<{ duration: number }>`
   width: 100vw;
   background-color: rgba(58, 58, 58, 0.7);
   z-index: 9999;
-  transition: opacity ${({ duration }) => duration}ms ease-in;
-  opacity: 0;
-`
 
-const transitionStyles: Record<TransitionStatus, CSSProperties> = {
-  entering: {
-    opacity: 1,
-  },
-  entered: {
-    opacity: 1,
-  },
-  exiting: {
-    opacity: 0,
-    pointerEvents: 'none',
-  },
-  exited: {
-    opacity: 0,
-    pointerEvents: 'none',
-  },
-  unmounted: {},
-}
+  &.enter,
+  &.leave {
+    transition: opacity ${({ duration }) => duration}ms ease-in;
+  }
+
+  &.enter-from,
+  &.leave-to {
+    opacity: 0;
+  }
+
+  &.enter-to,
+  &.leave-from {
+    opacity: 1;
+  }
+`
 
 export interface ActionSheetOverlayProps {
   duration: number
 }
 
 export const ActionSheetOverlay = ({ duration }: ActionSheetOverlayProps) => {
-  const { transitionStatus } = useActionSheet()
-
   return (
-    <Overlay
-      duration={duration}
-      style={{
-        ...transitionStyles[transitionStatus],
-      }}
-    />
+    <Transition.Child
+      as={Fragment}
+      enter="enter"
+      enterFrom="enter-from"
+      enterTo="enter-to"
+      leave="leave"
+      leaveFrom="leave-from"
+      leaveTo="leave-to"
+    >
+      <Overlay duration={duration} />
+    </Transition.Child>
   )
 }

--- a/packages/action-sheet/src/action-sheet.tsx
+++ b/packages/action-sheet/src/action-sheet.tsx
@@ -1,7 +1,5 @@
-import { PropsWithChildren, ReactNode, useRef } from 'react'
-import { Dialog } from '@headlessui/react'
-import { Transition } from 'react-transition-group'
-import { TransitionProps } from 'react-transition-group/Transition'
+import { Fragment, PropsWithChildren, ReactNode, useRef } from 'react'
+import { Dialog, Transition } from '@headlessui/react'
 import { FlexBox } from '@titicaca/core-elements'
 
 import { ActionSheetBody } from './action-sheet-body'
@@ -10,17 +8,7 @@ import { ActionSheetOverlay } from './action-sheet-overlay'
 
 const TRANSITION_DURATION = 120
 
-export interface ActionSheetProps
-  extends PropsWithChildren,
-    Pick<
-      TransitionProps,
-      | 'onEnter'
-      | 'onEntering'
-      | 'onEntered'
-      | 'onExit'
-      | 'onExiting'
-      | 'onExited'
-    > {
+export interface ActionSheetProps extends PropsWithChildren {
   open?: boolean
   title?: ReactNode
   borderRadius?: number
@@ -28,6 +16,10 @@ export interface ActionSheetProps
   from?: 'top' | 'bottom'
   maxContentHeight?: string | number
   onClose?: () => void
+  onEnter?: () => void
+  onEntered?: () => void
+  onExit?: () => void
+  onExited?: () => void
 }
 
 /**
@@ -43,10 +35,8 @@ export const ActionSheet = ({
   maxContentHeight = 'calc(100vh - 256px)',
   onClose,
   onEnter,
-  onEntering,
   onEntered,
   onExit,
-  onExiting,
   onExited,
   ...props
 }: ActionSheetProps) => {
@@ -54,49 +44,38 @@ export const ActionSheet = ({
   const panelRef = useRef(null)
 
   return (
-    <Transition
-      in={open}
-      nodeRef={ref}
-      timeout={TRANSITION_DURATION}
-      appear
-      mountOnEnter
-      unmountOnExit
-      onEnter={onEnter}
-      onEntering={onEntering}
-      onEntered={onEntered}
-      onExit={onExit}
-      onExiting={onExiting}
-      onExited={onExited}
-    >
-      {(transitionStatus) => (
-        <ActionSheetContext.Provider
-          value={{ transitionStatus, open, onClose }}
+    <ActionSheetContext.Provider value={{ open, onClose }}>
+      <Transition
+        show={open}
+        as={Fragment}
+        beforeEnter={onEnter}
+        afterEnter={onEntered}
+        beforeLeave={onExit}
+        afterLeave={onExited}
+      >
+        <Dialog
+          ref={ref}
+          initialFocus={panelRef}
+          static
+          onClose={() => onClose?.()}
         >
-          <Dialog
-            ref={ref}
-            initialFocus={panelRef}
-            static
-            open={open}
-            onClose={() => onClose?.()}
-          >
-            <ActionSheetOverlay duration={TRANSITION_DURATION} />
-            <FlexBox flex justifyContent="center">
-              <ActionSheetBody
-                panelRef={panelRef}
-                borderRadius={borderRadius}
-                bottomSpacing={bottomSpacing}
-                duration={TRANSITION_DURATION}
-                maxContentHeight={maxContentHeight}
-                from={from}
-                title={title}
-                {...props}
-              >
-                {children}
-              </ActionSheetBody>
-            </FlexBox>
-          </Dialog>
-        </ActionSheetContext.Provider>
-      )}
-    </Transition>
+          <ActionSheetOverlay duration={TRANSITION_DURATION} />
+          <FlexBox flex justifyContent="center">
+            <ActionSheetBody
+              panelRef={panelRef}
+              borderRadius={borderRadius}
+              bottomSpacing={bottomSpacing}
+              duration={TRANSITION_DURATION}
+              maxContentHeight={maxContentHeight}
+              from={from}
+              title={title}
+              {...props}
+            >
+              {children}
+            </ActionSheetBody>
+          </FlexBox>
+        </Dialog>
+      </Transition>
+    </ActionSheetContext.Provider>
   )
 }

--- a/packages/action-sheet/src/action-sheet.tsx
+++ b/packages/action-sheet/src/action-sheet.tsx
@@ -47,6 +47,7 @@ export const ActionSheet = ({
     <ActionSheetContext.Provider value={{ open, onClose }}>
       <Transition
         show={open}
+        appear
         as={Fragment}
         beforeEnter={onEnter}
         afterEnter={onEntered}

--- a/packages/core-elements/package.json
+++ b/packages/core-elements/package.json
@@ -34,9 +34,7 @@
     "@titicaca/intersection-observer": "^12.11.0",
     "@titicaca/triple-fallback-action": "^12.11.0",
     "@titicaca/view-utilities": "^12.11.0",
-    "@types/react-transition-group": "^4.4.5",
-    "react-input-mask": "^2.0.4",
-    "react-transition-group": "^4.4.5"
+    "react-input-mask": "^2.0.4"
   },
   "devDependencies": {
     "@titicaca/i18n": "^12.11.0",

--- a/packages/core-elements/src/elements/drawer/drawer.tsx
+++ b/packages/core-elements/src/elements/drawer/drawer.tsx
@@ -61,29 +61,32 @@ export function Drawer({
   return (
     <Transition
       show={active}
+      appear
       as={Fragment}
       beforeEnter={onEnter}
       afterEnter={onEntered}
       beforeLeave={onExit}
       afterLeave={onExited}
     >
-      <Portal>
-        <FlexBox flex justifyContent="center">
-          <Transition.Child
-            as={Fragment}
-            enter="enter"
-            enterFrom="enter-from"
-            enterTo="enter-to"
-            leave="leave"
-            leaveFrom="leave-from"
-            leaveTo="leave-to"
-          >
-            <DrawerContainer duration={duration} overflow={overflow}>
-              {children}
-            </DrawerContainer>
-          </Transition.Child>
-        </FlexBox>
-      </Portal>
+      <div>
+        <Portal>
+          <FlexBox flex justifyContent="center">
+            <Transition.Child
+              as={Fragment}
+              enter="enter"
+              enterFrom="enter-from"
+              enterTo="enter-to"
+              leave="leave"
+              leaveFrom="leave-from"
+              leaveTo="leave-to"
+            >
+              <DrawerContainer duration={duration} overflow={overflow}>
+                {children}
+              </DrawerContainer>
+            </Transition.Child>
+          </FlexBox>
+        </Portal>
+      </div>
     </Transition>
   )
 }

--- a/packages/core-elements/src/elements/drawer/drawer.tsx
+++ b/packages/core-elements/src/elements/drawer/drawer.tsx
@@ -1,8 +1,6 @@
 import styled from 'styled-components'
-import { Transition, TransitionStatus } from 'react-transition-group'
-import { TransitionProps } from 'react-transition-group/Transition'
-import { CSSProperties, PropsWithChildren, useRef } from 'react'
-import { Portal } from '@headlessui/react'
+import { Fragment, PropsWithChildren } from 'react'
+import { Portal, Transition } from '@headlessui/react'
 
 import { FlexBox } from '../flex-box'
 
@@ -20,40 +18,31 @@ const DrawerContainer = styled.div<DrawerContainerProps>`
   bottom: 0;
   overflow: ${({ overflow }) => overflow || 'hidden'};
   z-index: 9999;
-  transition: transform ${({ duration }) => duration}ms ease-in-out;
-  transform: 'translateY(100%)';
+
+  &.enter,
+  &.leave {
+    transition: transform ${({ duration }) => duration}ms ease-in-out;
+  }
+
+  &.enter-from,
+  &.leave-to {
+    transform: translateY(100%);
+  }
+
+  &.enter-to,
+  &.leave-from {
+    transform: translateY(0);
+  }
 `
 
-const transitionStyles: Record<TransitionStatus, CSSProperties> = {
-  entering: {
-    transform: 'translateY(0%)',
-  },
-  entered: {
-    transform: 'translateY(0%)',
-  },
-  exiting: {
-    transform: 'translateY(100%)',
-  },
-  exited: {
-    transform: 'translateY(100%)',
-  },
-  unmounted: {},
-}
-
-export interface DrawerProps
-  extends PropsWithChildren,
-    Pick<
-      TransitionProps,
-      | 'onEnter'
-      | 'onEntering'
-      | 'onEntered'
-      | 'onExit'
-      | 'onExiting'
-      | 'onExited'
-    > {
+export interface DrawerProps extends PropsWithChildren {
   active?: boolean
   duration?: number
   overflow?: string
+  onEnter?: () => void
+  onEntered?: () => void
+  onExit?: () => void
+  onExited?: () => void
 }
 
 /**
@@ -65,45 +54,36 @@ export function Drawer({
   overflow,
   children,
   onEnter,
-  onEntering,
   onEntered,
   onExit,
-  onExiting,
   onExited,
 }: DrawerProps) {
-  const drawerContainerRef = useRef(null)
-
   return (
     <Transition
-      nodeRef={drawerContainerRef}
-      in={active}
-      appear
-      timeout={duration}
-      mountOnEnter
-      unmountOnExit
-      onEnter={onEnter}
-      onEntering={onEntering}
-      onEntered={onEntered}
-      onExit={onExit}
-      onExiting={onExiting}
-      onExited={onExited}
+      show={active}
+      as={Fragment}
+      beforeEnter={onEnter}
+      afterEnter={onEntered}
+      beforeLeave={onExit}
+      afterLeave={onExited}
     >
-      {(transitionStatus) => (
-        <Portal>
-          <FlexBox flex justifyContent="center">
-            <DrawerContainer
-              ref={drawerContainerRef}
-              duration={duration}
-              overflow={overflow}
-              style={{
-                ...transitionStyles[transitionStatus],
-              }}
-            >
+      <Portal>
+        <FlexBox flex justifyContent="center">
+          <Transition.Child
+            as={Fragment}
+            enter="enter"
+            enterFrom="enter-from"
+            enterTo="enter-to"
+            leave="leave"
+            leaveFrom="leave-from"
+            leaveTo="leave-to"
+          >
+            <DrawerContainer duration={duration} overflow={overflow}>
               {children}
             </DrawerContainer>
-          </FlexBox>
-        </Portal>
-      )}
+          </Transition.Child>
+        </FlexBox>
+      </Portal>
     </Transition>
   )
 }

--- a/packages/drawer-button/src/index.tsx
+++ b/packages/drawer-button/src/index.tsx
@@ -21,10 +21,8 @@ function DrawerButton({
   active = false,
   duration,
   onEnter,
-  onEntering,
   onEntered,
   onExit,
-  onExiting,
   onExited,
   ...props
 }: DrawerButtonProps) {
@@ -34,10 +32,8 @@ function DrawerButton({
       duration={duration}
       overflow="hidden"
       onEnter={onEnter}
-      onEntering={onEntering}
       onEntered={onEntered}
       onExit={onExit}
-      onExiting={onExiting}
       onExited={onExited}
     >
       <Container backgroundColor="white">

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -25,9 +25,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.11",
-    "@titicaca/core-elements": "^12.11.0",
-    "@types/react-transition-group": "^4.4.5",
-    "react-transition-group": "^4.4.5"
+    "@titicaca/core-elements": "^12.11.0"
   },
   "peerDependencies": {
     "react": "^18.0",

--- a/packages/popup/src/index.tsx
+++ b/packages/popup/src/index.tsx
@@ -94,6 +94,7 @@ function Popup({
   return (
     <Transition
       show={open}
+      appear
       as={Fragment}
       beforeEnter={onEnter}
       afterEnter={onEntered}

--- a/packages/popup/src/index.tsx
+++ b/packages/popup/src/index.tsx
@@ -31,7 +31,7 @@ const PopupContainer = styled.div`
 
   &.enter,
   &.leave {
-    transition: transform ${TRANSITION_DURATION}ms ease-in;
+    transition: transform ${TRANSITION_DURATION}ms ease-out;
   }
 
   &.enter-from,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

react-transition-group -> headlessui Transition 으로 변경

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

react-transition-group이 최초 Mount 될 때 애니메이션을 트리거하지 못하고 있습니다.
headlessui의 Transition 컴포넌트로 변경해서 애니메이션이 항상 트리거 되도록 변경합니다.