### PR TITLE
PUBLIC_ROUTELIST_REGEXES에 여행기 상세 주소 추가

### DIFF
--- a/packages/view-utilities/src/routelist/routelist.ts
+++ b/packages/view-utilities/src/routelist/routelist.ts
@@ -17,6 +17,7 @@ const PUBLIC_ROUTELIST_REGEXES = [
   /^\/tna\/regions\/[^/]+\/products\/[^/]+$/,
   /^\/tna\/products\/[^/]+$/,
   /^\/tna\/products\/[^/]+\/display$/,
+  /^\/trips\/lounge\/itineraries\/[^/]+$/,
 ]
 
 export function checkIfRoutable({ href }: { href: string }) {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
`PUBLIC_ROUTELIST_REGEXES`에 여행기 상세 주소를 추가하여 여행기 웹뷰 이동 시 로그인 모달을 띄우지 않게 합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

