### PR TITLE
List 에 marker prop 을 추가합니다.

### DIFF
--- a/packages/core-elements/src/elements/input/input.stories.tsx
+++ b/packages/core-elements/src/elements/input/input.stories.tsx
@@ -1,5 +1,7 @@
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react'
 
+import { List } from '../list'
+
 import { Input } from './input'
 
 export default {
@@ -34,5 +36,22 @@ export const Mask: ComponentStoryObj<typeof Input> = {
     ...Default.args,
     mask: '99/99',
     value: 1230,
+  },
+}
+
+export const MultilineHelp: ComponentStoryObj<typeof Input> = {
+  args: {
+    ...Default.args,
+    help: (
+      <List marker verticalGap={4}>
+        <List.Item>연락 가능한 전화번호를 입력해주세요.</List.Item>
+        <List.Item>
+          예약 변경, 이슈가 있는 경우 입력한 번호로 연락드립니다.
+        </List.Item>
+        <List.Item>
+          {`카카오톡 ID는 카카오 프로필 > 설정 > 프로필 관리에서 확인가능합니다.`}
+        </List.Item>
+      </List>
+    ),
   },
 }

--- a/packages/core-elements/src/elements/list/list.stories.tsx
+++ b/packages/core-elements/src/elements/list/list.stories.tsx
@@ -1,0 +1,47 @@
+import { ComponentMeta, ComponentStoryObj } from '@storybook/react'
+
+import { List } from './list'
+
+export default {
+  title: 'core-elements / List',
+  component: List,
+} as ComponentMeta<typeof List>
+
+export const Default: ComponentStoryObj<typeof List> = {
+  args: {
+    children: (
+      <>
+        <List.Item>1</List.Item>
+        <List.Item>2</List.Item>
+        <List.Item>3</List.Item>
+      </>
+    ),
+  },
+}
+
+export const Marker: ComponentStoryObj<typeof List> = {
+  args: {
+    marker: true,
+    children: (
+      <>
+        <List.Item>1</List.Item>
+        <List.Item>2</List.Item>
+        <List.Item>3</List.Item>
+      </>
+    ),
+  },
+}
+
+export const Divided: ComponentStoryObj<typeof List> = {
+  args: {
+    divided: true,
+    dividerWeight: 10,
+    children: (
+      <>
+        <List.Item>1</List.Item>
+        <List.Item>2</List.Item>
+        <List.Item>3</List.Item>
+      </>
+    ),
+  },
+}

--- a/packages/core-elements/src/elements/list/list.test.tsx
+++ b/packages/core-elements/src/elements/list/list.test.tsx
@@ -1,0 +1,46 @@
+import renderer from 'react-test-renderer'
+
+import { List } from './list'
+
+import 'jest-styled-components'
+
+it('should accept weight divided prop', () => {
+  const tree = renderer
+    .create(
+      <List divided dividerWeight={10}>
+        <List.Item />
+      </List>,
+    )
+    .toJSON()
+
+  expect(tree).toHaveStyleRule('border-bottom', 'solid 10px #efefef', {
+    modifier: '> li:not(:last-child)::after',
+  })
+  expect(tree).toHaveStyleRule('content', "''", {
+    modifier: '> li:not(:last-child)::after',
+  })
+})
+
+it('should accept marker prop', () => {
+  const tree = renderer
+    .create(
+      <List marker>
+        <List.Item />
+      </List>,
+    )
+    .toJSON()
+
+  expect(tree).toHaveStyleRule('content', "'·'", { modifier: '> li::before' })
+})
+
+it('should override style with css prop', () => {
+  const tree = renderer
+    .create(
+      <List css={{ color: 'red' }}>
+        <List.Item />
+      </List>,
+    )
+    .toJSON()
+
+  expect(tree).toHaveStyleRule('color', 'red')
+})

--- a/packages/core-elements/src/elements/list/list.tsx
+++ b/packages/core-elements/src/elements/list/list.tsx
@@ -8,6 +8,7 @@ interface ListBaseProp {
   margin?: MarginPadding
   verticalGap?: number
   clearing?: boolean
+  marker?: boolean
 }
 
 interface DividerOptions {
@@ -30,6 +31,21 @@ const ListBase = styled.ul<ListBaseProp & DividerOptions>`
       margin-top: ${divided ? verticalGap / 2 : verticalGap}px;
     `};
   }
+
+  ${({ marker }) =>
+    marker &&
+    css`
+      & {
+        padding-left: 0.6em;
+      }
+
+      > li::before {
+        content: '·';
+        position: absolute;
+        top: 0;
+        left: -0.6em;
+      }
+    `}
 
   ${({ clearing }) =>
     clearing


### PR DESCRIPTION
## PR 설명

List 컴포넌트에 `marker` 를 노출할 수 있는 props 을 추가합니다.
기본 `disc marker` 대신 스타일 커스텀이 용이한 pseudo-element 로 추가했습니다.

해당 List 를 이용해서 `Input` 에 다중 도움말 문구를 노출하는 케이스를 추가합니다.

[JIRA](https://titicaca.atlassian.net/browse/TFC-13)

## 변경 내역

+ `List` 컴포넌트에 `marker` 속성 추가
+ `List` 유닛 테스트 추가
+ `Input` 컴포넌트 스토리 파일에 `multiline-help` 케이스 추가

## 스크린샷 & URL
적용 예시

![스크린샷 2023-03-10 오후 5 58 39](https://user-images.githubusercontent.com/37819666/224273230-cd584cbe-f7cb-42f1-bc42-1be831075464.png)

