### PR TITLE
TripleClientMetadataContext에 `shouldUpdateUserAgentOnMount` props를 추가합니다

### DIFF
--- a/packages/react-triple-client-interfaces/README.md
+++ b/packages/react-triple-client-interfaces/README.md
@@ -32,12 +32,12 @@ class CustomNextjsApp() {
 ```
 
 static page의 경우 서버사이드의 User-Agent 값을 가져오지 못하므로
-해당 페이지의 `getStaticProps`의 리턴 객체에 `isStaticPage`를 true로 설정해야 합니다.
+해당 페이지의 `getStaticProps`의 리턴 객체에 `shouldUpdateUserAgentOnMount`를 true로 설정해야 합니다.
 
 ```tsx
 // pages/example.tsx
 interface PageProps {
-  isStaticPage: boolean
+  shouldUpdateUserAgentOnMount: boolean
 }
 
 export default function ExampleComponent(props: PageProps) {
@@ -46,7 +46,7 @@ export default function ExampleComponent(props: PageProps) {
 
 export async function getStaticProps() {
   return {
-    isStaticPage: true,
+    shouldUpdateUserAgentOnMount: true,
   }
 }
 
@@ -59,7 +59,7 @@ function MyApp({
   return (
     <TripleClientMetadataProvider
       {...tripleClientMetadataProviderProps}
-      isStaticPage={pageProps.isStaticPage}
+      shouldUpdateUserAgentOnMount={pageProps.shouldUpdateUserAgentOnMount}
     >
       <Component {...pageProps} />
     </TripleClientMetadataProvider>

--- a/packages/react-triple-client-interfaces/README.md
+++ b/packages/react-triple-client-interfaces/README.md
@@ -38,7 +38,7 @@ class CustomNextjsApp() {
 ```tsx
 // pages/example.tsx
 interface PageProps {
-  shouldUpdateUserAgentOnMount: boolean
+  isStaticPage: true
 }
 
 export default function ExampleComponent(props: PageProps) {

--- a/packages/react-triple-client-interfaces/README.md
+++ b/packages/react-triple-client-interfaces/README.md
@@ -33,7 +33,7 @@ class CustomNextjsApp() {
 
 클라이언트에서 UserAgent를 업데이트해야하는 경우(ex. getStaticProps를 사용한 스테틱 페이지) shouldUpdateUserAgentOnMount props를 사용합니다.
 
-- 예) 스테틱 페이지에서 UserAgent를 사용할 경우, 해당 페이지의 `getStaticProps`의 리턴 객체에 `shouldUpdateUserAgentOnMount`를 true로 설정해야 합니다.
+- 예) 스테틱 페이지에서 UserAgent를 사용할 경우, 해당 페이지의 `getStaticProps`의 리턴 객체에서 Static Page 여부를 노출하고, 그 속성을 이용해 `shouldUpdateUserAgentOnMount`를 true로 설정해야 합니다.
 
 ```tsx
 // pages/example.tsx

--- a/packages/react-triple-client-interfaces/README.md
+++ b/packages/react-triple-client-interfaces/README.md
@@ -60,7 +60,7 @@ function MyApp({
   return (
     <TripleClientMetadataProvider
       {...tripleClientMetadataProviderProps}
-      shouldUpdateUserAgentOnMount={pageProps.shouldUpdateUserAgentOnMount}
+      shouldUpdateUserAgentOnMount={pageProps.isStaticPage}
     >
       <Component {...pageProps} />
     </TripleClientMetadataProvider>

--- a/packages/react-triple-client-interfaces/README.md
+++ b/packages/react-triple-client-interfaces/README.md
@@ -31,8 +31,9 @@ class CustomNextjsApp() {
 }
 ```
 
-static page의 경우 서버사이드의 User-Agent 값을 가져오지 못하므로
-해당 페이지의 `getStaticProps`의 리턴 객체에 `shouldUpdateUserAgentOnMount`를 true로 설정해야 합니다.
+클라이언트에서 UserAgent를 업데이트해야하는 경우(ex. getStaticProps를 사용한 스테틱 페이지) shouldUpdateUserAgentOnMount props를 사용합니다.
+
+- 예) 스테틱 페이지에서 UserAgent를 사용할 경우, 해당 페이지의 `getStaticProps`의 리턴 객체에 `shouldUpdateUserAgentOnMount`를 true로 설정해야 합니다.
 
 ```tsx
 // pages/example.tsx

--- a/packages/react-triple-client-interfaces/README.md
+++ b/packages/react-triple-client-interfaces/README.md
@@ -31,6 +31,42 @@ class CustomNextjsApp() {
 }
 ```
 
+static page의 경우 서버사이드의 User-Agent 값을 가져오지 못하므로
+해당 페이지의 `getStaticProps`의 리턴 객체에 `isStaticPage`를 true로 설정해야 합니다.
+
+```tsx
+// pages/example.tsx
+interface PageProps {
+  isStaticPage: boolean
+}
+
+export default function ExampleComponent(props: PageProps) {
+  return <div>example</div>
+}
+
+export async function getStaticProps() {
+  return {
+    isStaticPage: true,
+  }
+}
+
+// _app.tsx
+function MyApp({
+  Component,
+  pageProps,
+  tripleClientMetadataProviderProps,
+}: AppProps & CustomAppProps) {
+  return (
+    <TripleClientMetadataProvider
+      {...tripleClientMetadataProviderProps}
+      isStaticPage={pageProps.isStaticPage}
+    >
+      <Component {...pageProps} />
+    </TripleClientMetadataProvider>
+  )
+}
+```
+
 ### `useTripleClientMetadata`
 
 `TripleClientMetadataProvider`가 제공하는 클라이언트 정보를 Hook으로 노출합니다.

--- a/packages/react-triple-client-interfaces/src/triple-client-metadata-context.tsx
+++ b/packages/react-triple-client-interfaces/src/triple-client-metadata-context.tsx
@@ -39,7 +39,7 @@ export function TripleClientMetadataProvider({
     if (isStaticPage) {
       setApp(extractTripleClientAppUserAgentFromNextPageContext({}))
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const value = app
 

--- a/packages/react-triple-client-interfaces/src/triple-client-metadata-context.tsx
+++ b/packages/react-triple-client-interfaces/src/triple-client-metadata-context.tsx
@@ -1,6 +1,13 @@
 import type { IncomingMessage } from 'http'
 
-import { createContext, useContext, PropsWithChildren, useMemo } from 'react'
+import {
+  createContext,
+  useContext,
+  PropsWithChildren,
+  useMemo,
+  useState,
+  useEffect,
+} from 'react'
 
 import { parseTripleClientUserAgent } from './triple-client-user-agent'
 import type { App } from './types'
@@ -13,9 +20,10 @@ const TripleClientMetadataContext =
 export function TripleClientMetadataProvider({
   appName,
   appVersion,
+  isStaticPage,
   children,
-}: PropsWithChildren<Partial<App>>) {
-  const value: App | null = useMemo(
+}: PropsWithChildren<Partial<App> & { isStaticPage?: boolean }>) {
+  const initialApp: App | null = useMemo(
     () =>
       appName && appVersion
         ? {
@@ -25,6 +33,15 @@ export function TripleClientMetadataProvider({
         : null,
     [appName, appVersion],
   )
+  const [app, setApp] = useState<App | null>(initialApp)
+
+  useEffect(() => {
+    if (isStaticPage) {
+      setApp(extractTripleClientAppUserAgentFromNextPageContext({}))
+    }
+  }, [])
+
+  const value = app
 
   return (
     <TripleClientMetadataContext.Provider value={value}>

--- a/packages/react-triple-client-interfaces/src/triple-client-metadata-context.tsx
+++ b/packages/react-triple-client-interfaces/src/triple-client-metadata-context.tsx
@@ -4,7 +4,6 @@ import {
   createContext,
   useContext,
   PropsWithChildren,
-  useMemo,
   useState,
   useEffect,
 } from 'react'
@@ -20,31 +19,29 @@ const TripleClientMetadataContext =
 export function TripleClientMetadataProvider({
   appName,
   appVersion,
-  isStaticPage,
+  shouldUpdateUserAgentOnMount,
   children,
-}: PropsWithChildren<Partial<App> & { isStaticPage?: boolean }>) {
-  const initialApp: App | null = useMemo(
-    () =>
-      appName && appVersion
-        ? {
-            appName,
-            appVersion,
-          }
-        : null,
-    [appName, appVersion],
-  )
+}: PropsWithChildren<
+  Partial<App> & { shouldUpdateUserAgentOnMount?: boolean }
+>) {
+  const initialApp: App | null =
+    appName && appVersion
+      ? {
+          appName,
+          appVersion,
+        }
+      : null
+
   const [app, setApp] = useState<App | null>(initialApp)
 
   useEffect(() => {
-    if (isStaticPage) {
+    if (shouldUpdateUserAgentOnMount) {
       setApp(extractTripleClientAppUserAgentFromNextPageContext({}))
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const value = app
-
   return (
-    <TripleClientMetadataContext.Provider value={value}>
+    <TripleClientMetadataContext.Provider value={app}>
       {children}
     </TripleClientMetadataContext.Provider>
   )


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
static page의 경우 서버사이드의 User-Agent 값을 가져오지 못하므로 TripleClientMetadataContext에 shouldUpdateUserAgentOnMount 플래그를 추가합니다.
스테틱 페이지의 경우 useEffect를 통해 클라이언트에서 window.nagivation의 userAgent 값을 읽어옵니다.

- 사용방법 : 스테틱 페이지의 `getStaticProps`의 리턴 객체에 `shouldUpdateUserAgentOnMount `를 true로 설정하고, _app.tsx 파일에서 TripleClientMetadataContext의 props로 appContext.pageProps.shouldUpdateUserAgentOnMount를 추가하면 됩니다.

```tsx
// pages/example.tsx
interface PageProps {
  isStaticPage: boolean
}
export default function ExampleComponent(props: PageProps) {
  return <div>example</div>
}
export async function getStaticProps() {
  return {
    isStaticPage: true,
  }
}
// _app.tsx
function MyApp({
  Component,
  pageProps,
  tripleClientMetadataProviderProps,
}: AppProps & CustomAppProps) {
  return (
    <TripleClientMetadataProvider
      {...tripleClientMetadataProviderProps}
      shouldUpdateUserAgentOnMount ={pageProps.isStaticPage}
    >
      <Component {...pageProps} />
    </TripleClientMetadataProvider>
  )
}
```
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 스크린샷 & URL
- 적용 예시: triple-trips-web
<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
