### PR TITLE
[modals] Panel에 webkit-mask-image 속성 제거

### DIFF
--- a/packages/modals/src/modal/modal.tsx
+++ b/packages/modals/src/modal/modal.tsx
@@ -14,6 +14,7 @@ const ModalPanel = styled(Container)`
   width: 295px;
   background-color: #fff;
   outline: none;
+  border-radius: 6px;
 `
 
 export interface ModalProps extends PropsWithChildren {
@@ -55,12 +56,7 @@ export const Modal = ({ children, open = false, onClose }: ModalProps) => {
             z-index: 9999;
           `}
         >
-          <Dialog.Panel
-            as={ModalPanel}
-            ref={panelRef}
-            tabIndex={-1}
-            borderRadius={6}
-          >
+          <Dialog.Panel as={ModalPanel} ref={panelRef} tabIndex={-1}>
             {children}
           </Dialog.Panel>
         </FlexBox>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

https://titicaca.atlassian.net/browse/TFC-50

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

Modal 내부에서 position: fixed인 요소를 그릴 수 있도록 Container의 borderRadius를 사용하지 않고 css에 직접 border-radius를 사용해서 `webkit-mask-image` 속성을 제거합니다.