### PR TITLE
ci: delete-tag-and-release 버전 수정

### DIFF
--- a/.github/workflows/pr-closed.yaml
+++ b/.github/workflows/pr-closed.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "::set-output name=status::$(cat status)"
 
       - name: Delete release tag of this pull request
-        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
         with:
           delete_release: true
           tag_name: ${{ env.TAG_NAME }}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

ci: delete-tag-and-release 버전 수정

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

PR Closed job이 실패하고 있습니다. https://github.com/titicacadev/triple-frontend/actions/runs/4506894128/jobs/7934157788

이 job에서 쓰고 있는 delete-tag-and-release 액션이 0.2.1 미만 버전을 모두 지워버려서 버전을 찾을 수 없는 문제입니다. 버전을 0.2.1로 수정합니다.

https://github.com/dev-drprasad/delete-tag-and-release/issues/20