### PR TITLE
CHANGELOG 자동화 구현

### DIFF
--- a/.github/workflows/add-label.yaml
+++ b/.github/workflows/add-label.yaml
@@ -1,4 +1,4 @@
-name: Label a PR with its package update
+name: Label a PR with its updated packages
 
 on:
   pull_request:

--- a/.github/workflows/add-label.yaml
+++ b/.github/workflows/add-label.yaml
@@ -1,0 +1,41 @@
+name: Label a PR with its package update
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    # =============== 테스트용. 이후 제거할 예정입니다 ===============
+    if: ${{ github.event.pull_request.head.ref == 'feat/automate-changelog' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Get changed packages
+        run: |
+          RESPONSE=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.ref }}...${{ github.event.pull_request.head.ref }}")
+
+          if [[ $(echo "$RESPONSE" | jq '.total_commits') == null ]]; then
+            echo $RESPONSE | jq '.message'
+            exit 1
+          fi
+
+          CHANGED_PACKAGES=$(echo "$RESPONSE" | jq '[.files[].filename | capture("packages/(?<packageName>[^/]+)/") .packageName] | unique | tostring')
+          echo "CHANGED_PACKAGES=$CHANGED_PACKAGES" >> $GITHUB_ENV
+
+      - name: Label PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACKAGE_LABELS=$(echo ${{ env.CHANGED_PACKAGES }} | jq .)
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+            -d "{\"labels\": $PACKAGE_LABELS }"

--- a/.github/workflows/add-label.yaml
+++ b/.github/workflows/add-label.yaml
@@ -7,8 +7,6 @@ on:
 jobs:
   label-pr:
     runs-on: ubuntu-latest
-    # =============== 테스트용. 이후 제거할 예정입니다 ===============
-    if: ${{ github.event.pull_request.head.ref == 'feat/automate-changelog' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -31,7 +31,7 @@ jobs:
 
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '[.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}] | group_by(.number) | map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | tostring' | sed 's/^"//;s/"$//')
           echo $PRS_IN_MILESTONE
-          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\nPlease filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. ${package} should only be one package, not multiple packages.)" >> $GITHUB_ENV
+          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\nPlease filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. Note that each package group must not be duplicated.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Commit and push updated CHANGELOG
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRIPLE_BOT_GITHUB_TOKEN }}
         run: |
           git config --local user.email "${{ env.COMMIT_USER_EMAIL }}"
           git config --local user.name "${{ env.COMMIT_USER_NAME }}"

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -40,13 +40,13 @@ jobs:
             jq "[.items[] | \
               select(.pull_request.merged_at != null and \
                      (.labels | map(select(.name == \"release\")) | length == 0)) | \
-              {title: .title, number: .number, url: .html_url, package: .labels[].name}] | \
+              {title: .title, number: .number, url: .html_url, packages: .labels[].name}] | \
               group_by(.number) | \
-              map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | \
+              map({ title: .[0].title, number: .[0].number, url: .[0].url, packages: [.[].packages] }) | \
               tostring" | \
             sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n \
-            Please filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. Note that each package group must not be duplicated.)" >> $GITHUB_ENV
+            echo "CHAT_GPT_PROMPT=$(echo Using the following data, please write a Markdown list in the format of \`\`\`- [packages] title [#number]\(url\)\\n- [packages] title [#number]\(url\)\`\`\`. \
+              And please filter out any emojis in the package names:\\n\`\`\`$PRS_IN_MILESTONE\`\`\`)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:
@@ -57,7 +57,6 @@ jobs:
            -H "Authorization: Bearer $OPENAI_KEY" \
            -d '{
               "model": "gpt-3.5-turbo",
-              "temperature": 0.2,
               "messages": [
                 {
                   "role": "user",

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -11,7 +11,7 @@ env:
   CURRENT_VERSION: ${{ github.event.pull_request.milestone.title }}
 
 jobs:
-  update_changelog:
+  update-changelog:
     runs-on: ubuntu-latest
     if: ${{ github.event.label.name == 'release' }}
     steps:
@@ -29,8 +29,9 @@ jobs:
             exit 1
           fi
 
-          PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n. Please filter out emojis when writing package name in the markdown.)" >> $GITHUB_ENV
+          PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '[.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}] | group_by(.number) | map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | tostring' | sed 's/^"//;s/"$//')
+          echo $PRS_IN_MILESTONE
+          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\nPlease filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. ${package} should only be one package, not multiple packages.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\nAs shown in the format above, please group the list items by their respective package.)" >> $GITHUB_ENV
+          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\nAs you can see from the above format, group list items by their package.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -45,8 +45,9 @@ jobs:
               map({ title: .[0].title, number: .[0].number, url: .[0].url, packages: [.[].packages] }) | \
               tostring" | \
             sed 's/^"//;s/"$//')
-            echo "CHAT_GPT_PROMPT=$(echo Using the following data, please write a Markdown list in the format of \`\`\`- [packages] title [#number]\(url\)\\n- [packages] title [#number]\(url\)\`\`\`. \
-              And please filter out any emojis in the package names:\\n\`\`\`$PRS_IN_MILESTONE\`\`\`)" >> $GITHUB_ENV
+            echo "CHAT_GPT_PROMPT=$(echo Using the following data, please write a Markdown list in the format of \`\`\`### {{package1}}\\n\\n- {{title1}} [#{{number1}}]\({{url1}}\)\\n\\n### {{package2}}\\n\\n- {{title2}} [#{{number2}}]\({{url2}}\)\\n\\n...\\n\\n### {{packageN}}\\n\\n- {{titleN}} [#{{numberN}}]\({{urlN}}\)\`\`\`. \
+              Substitute \`{{package}}\` with the package name in the \`packages\` field, \`{{title}}\` with the \`title\` field value, \`{{number}}\` with the \`number\` field value, and \`{{url}}\` with the \`url\` field value of a list item. \
+              And also, please filter out any emojis in the package names:\\n\`\`\`$PRS_IN_MILESTONE\`\`\`)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_CONTENT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n but with the title name of common coming first, followed by the alphabetically sorted packages.)" >> $GITHUB_ENV
+          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\nAs shown in the format above, please group the list items by their respective package.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:
@@ -45,7 +45,7 @@ jobs:
               "messages": [
                 {
                   "role": "user",
-                  "content": "${{ env.CHAT_GPT_CONTENT }}"
+                  "content": "${{ env.CHAT_GPT_PROMPT }}"
                 }
               ]
             }' 

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -1,0 +1,71 @@
+name: Update CHANGELOG
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+env:
+  COMMIT_USER_EMAIL: developer@triple-corp.com
+  COMMIT_USER_NAME: triple-frontend[bot]
+  CURRENT_VERSION: ${{ github.event.pull_request.milestone.title }}
+
+jobs:
+  update_changelog:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'release' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Fetch PRs in current version's milestone and write a question to ChatGPT
+        run: |
+          RESPONSE=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/search/issues?q=milestone:${{ env.CURRENT_VERSION }}+type:pr+repo:$GITHUB_REPOSITORY")
+
+          if [[ $(echo "$RESPONSE" | jq '.total_count') == null ]]; then
+            echo $RESPONSE | jq '.message'
+            exit 1
+          fi
+
+          PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
+          echo "CHAT_GPT_CONTENT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n but with the title name of common coming first, followed by the alphabetically sorted packages.)" >> $GITHUB_ENV
+
+      - name: Request ChatGPT to write down CHANGELOG
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+        run: |
+          RESPONSE=$(curl -X POST https://api.openai.com/v1/chat/completions \
+           -H "Content-Type: application/json" \
+           -H "Authorization: Bearer $OPENAI_KEY" \
+           -d '{
+              "model": "gpt-3.5-turbo",
+              "temperature": 0.2,
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "${{ env.CHAT_GPT_CONTENT }}"
+                }
+              ]
+            }' 
+          )
+
+          echo $RESPONSE | jq
+          changelog_content=$(echo $RESPONSE | jq -r '.choices[].message.content')
+
+          printf '\n%s\n\n' "## ${{ env.CURRENT_VERSION }}" >> changelog_tmp.md
+          echo -e "$changelog_content" >> changelog_tmp.md
+
+          sed -i '1r changelog_tmp.md' CHANGELOG.md
+          rm changelog_tmp.md
+
+      - name: Commit and push updated CHANGELOG
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --local user.email "${{ env.COMMIT_USER_EMAIL }}"
+          git config --local user.name "${{ env.COMMIT_USER_NAME }}"
+          git add CHANGELOG.md
+          git commit -m "Update ${{ env.CURRENT_VERSION }} CHANGELOG"
+          git push

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -29,9 +29,17 @@ jobs:
             exit 1
           fi
 
-          PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '[.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}] | group_by(.number) | map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | tostring' | sed 's/^"//;s/"$//')
-          echo $PRS_IN_MILESTONE
-          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\nPlease filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. Note that each package group must not be duplicated.)" >> $GITHUB_ENV
+          PRS_IN_MILESTONE=$(echo "$RESPONSE" | \
+            jq "[.items[] | \
+              select(.pull_request.merged_at != null and \
+                     (.labels | map(select(.name == \"release\")) | length == 0)) | \
+              {title: .title, number: .number, url: .html_url, package: .labels[].name}] | \
+              group_by(.number) | \
+              map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | \
+              tostring" | \
+            sed 's/^"//;s/"$//')
+          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n \
+            Please filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. Note that each package group must not be duplicated.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -15,6 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.label.name == 'release' }}
     steps:
+      - name: Check if a milestone exists on PR
+        run: |
+          if [[ $(echo ${{ github.event.pull_request.milestone }}) == "" ]]; then
+            echo "마일스톤을 등록해 주세요."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\nAs you can see from the above format, group list items by their package.)" >> $GITHUB_ENV
+          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n.)" >> $GITHUB_ENV
+          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n. Please filter out emojis when writing package name in the markdown.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -45,7 +45,7 @@ jobs:
               map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | \
               tostring" | \
             sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n \
+          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n \
             Please filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. Note that each package group must not be duplicated.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # CHANGELOG
 
+## v12.2.0
+
+### common
+
+- ci 속도 개선 [#2340](https://github.com/titicacadev/triple-frontend/pull/2340)
+- cd workflow 에러 수정 [#2351](https://github.com/titicacadev/triple-frontend/pull/2351)
+- css prop과 centered prop이 충돌하는 문제 수정 [#2352](https://github.com/titicacadev/triple-frontend/pull/2352)
+
+### core-elements
+
+- [core-elements] story title을 소문자로 변경 [#2345](https://github.com/titicacadev/triple-frontend/pull/2345)
+- [core-elements] ConfirmSelector 디자인 수정 [#2359](https://github.com/titicacadev/triple-frontend/pull/2359)
+- [core-elements] Rating 컴포넌트에 최대값,최소값 설정 추가 [#2364](https://github.com/titicacadev/triple-frontend/pull/2364)
+
+### poi-detail
+
+- [poi-detail] Actions 스토리가 빌드마다 변경되는 현상 수정 [#2346](https://github.com/titicacadev/triple-frontend/pull/2346)
+
+### modals
+
+- [Modals] modal handler onClose 실행 분기문 이전 버전과 동일하게 변경 [#2347](https://github.com/titicacadev/triple-frontend/pull/2347)
+
+### view-utilities
+
+- [view-utilities] public route list에 `/redirect`를 추가합니다. [#2355](https://github.com/titicacadev/triple-frontend/pull/2355)
+
+### action-sheet
+
+- [action-sheet] 액션시트 열고 닫히는 transition이 일부 브라우저에서 layout shift 되지 않도록 수정 [#2358](https://github.com/titicacadev/triple-frontend/pull/2358)
+
+### version-up
+
+- 🚀 Release v12.2.0 [#2366](https://github.com/titicacadev/triple-frontend/pull/2366)
+
+### anchor
+
+- css prop과 centered prop이 충돌하는 문제 수정 [#2352](https://github.com/titicacadev/triple-frontend/pull/2352)
+
+### color-palette
+
+- css prop과 centered prop이 충돌하는 문제 수정 [#2352](https://github.com/titicacadev/triple-frontend/pull/2352)
+
+### theme
+
+- css prop과 centered prop이 충돌하는 문제 수정 [#2352](https://github.com/titicacadev/triple-frontend/pull/2352)
+
+### ab-experiments
+
+- [core-elements] Rating 컴포넌트에 최대값,최소값 설정 추가 [#2364](https://github.com/titicacadev/triple-frontend/pull/2364)
+- 🚀 Release v12.2.0 [#2366](https://github.com/titicacadev/triple-frontend/pull/2366)
+
 ## 12.14.0
 
 - lint 캐시 가능하도록 설정 [#2471](https://github.com/titicacadev/triple-frontend/pull/2471)


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
### 기존 TF 배포 프로세스
1. 로컬에서 릴리즈 브랜치 생성 (e.g., `release/v12.0.0`)
2. `npm run version`
3. 해당 버전의 마일스톤에 등록된 PR들을 기반으로 하여 수동으로 CHANGELOG 작성
4. push 후 release PR 작성
5. release PR을 main에 머지후 배포

### 변경될 TF 배포 프로세스
1. 로컬에서 릴리즈 브랜치 생성 (e.g., `release/v12.0.0`)
2. `npm run version`
3. **push 후 release PR 작성. 이때 _반드시_ `release` 라벨과, release PR을 해당 버전의 마일스톤에 등록하여 PR 오픈.**
4. **GHA가 CHANGELOG를 자동으로 작성한 다음 release PR에 업데이트된 CHANGELOG를 push**
5. release PR을 main에 머지후 배포
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

현재 구성한 GHA의 로직 초안은 다음과 같습니다:
1. GHA가 `release` 라벨을 감지하여 `release` 라벨이 달린 PR이 등록(?)될 경우 update changelog 워크플로우 실행 -> PR 상태(드래프트/오픈)에 관계없이 `release` 라벨이 달리기만 하면 실행됩니다.
2. 깃헙 API를 이용하여, 해당 PR의 마일스톤에 있는 _머지된_ PR들의 정보를 모읍니다. 현재 각 PR의 제목, 번호, url, 라벨을 수집하고 있으며, release PR이 마일스톤에 등록되지 않은 경우 오동작합니다 (어떤 마일스톤으로 부터 정보를 가져올 지 알 수 없으므로..)
3. (2)에서 모은 PR 데이터를 바탕으로 ChatGPT에게 현재 CHANGELOG 형식에 맞게 내용을 작성해달라고 요청합니다.
4. ChatGPT로 부터 받은 내용을 기존의 CHANGELOG에 추가한 뒤, release PR에 이 내용을 push하여 반영합니다.

## 논의할 점
- 현재 CHANGELOG 형식처럼, CHANGELOG 내에서 PR 제목을 각각의 패키지별로 분류하기 위해선 PR에 패키지 라벨을 (반드시) 달아야 할 듯 합니다. 우선 지금 GHA 로직에선 라벨이 달려있지 않은 PR(-> renovate PR을 필터링하는 효과) 및 `release` 라벨이 달려있는 PR은 CHANGELOG 내용에 포함하지 않도록 했습니다. 두 개 이상의 패키지 변경이 있는 PR은 `common` 라벨을 다는것으로 가정했습니다.
- release PR을 올릴 때 반드시 `release` 라벨과 마일스톤을 등록해야 할 듯 합니다.