### PR TITLE
CHANGELOG 자동화를 구현합니다.

### DIFF
--- a/.github/workflows/add-label.yaml
+++ b/.github/workflows/add-label.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   label-pr:
+    if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/add-label.yaml
+++ b/.github/workflows/add-label.yaml
@@ -1,4 +1,4 @@
-name: Label a PR with its package update
+name: Label a PR with its updated packages
 
 on:
   pull_request:

--- a/.github/workflows/add-label.yaml
+++ b/.github/workflows/add-label.yaml
@@ -1,0 +1,41 @@
+name: Label a PR with its package update
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    # =============== 테스트용. 이후 제거할 예정입니다 ===============
+    if: ${{ github.event.pull_request.head.ref == 'feat/automate-changelog' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Get changed packages
+        run: |
+          RESPONSE=$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.ref }}...${{ github.event.pull_request.head.ref }}")
+
+          if [[ $(echo "$RESPONSE" | jq '.total_commits') == null ]]; then
+            echo $RESPONSE | jq '.message'
+            exit 1
+          fi
+
+          CHANGED_PACKAGES=$(echo "$RESPONSE" | jq '[.files[].filename | capture("packages/(?<packageName>[^/]+)/") .packageName] | unique | tostring')
+          echo "CHANGED_PACKAGES=$CHANGED_PACKAGES" >> $GITHUB_ENV
+
+      - name: Label PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACKAGE_LABELS=$(echo ${{ env.CHANGED_PACKAGES }} | jq .)
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+            -d "{\"labels\": $PACKAGE_LABELS }"

--- a/.github/workflows/add-label.yaml
+++ b/.github/workflows/add-label.yaml
@@ -7,8 +7,6 @@ on:
 jobs:
   label-pr:
     runs-on: ubuntu-latest
-    # =============== 테스트용. 이후 제거할 예정입니다 ===============
-    if: ${{ github.event.pull_request.head.ref == 'feat/automate-changelog' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -31,7 +31,7 @@ jobs:
 
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '[.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}] | group_by(.number) | map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | tostring' | sed 's/^"//;s/"$//')
           echo $PRS_IN_MILESTONE
-          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\nPlease filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. ${package} should only be one package, not multiple packages.)" >> $GITHUB_ENV
+          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\nPlease filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. Note that each package group must not be duplicated.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Commit and push updated CHANGELOG
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRIPLE_BOT_GITHUB_TOKEN }}
         run: |
           git config --local user.email "${{ env.COMMIT_USER_EMAIL }}"
           git config --local user.name "${{ env.COMMIT_USER_NAME }}"

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -45,9 +45,8 @@ jobs:
               map({ title: .[0].title, number: .[0].number, url: .[0].url, packages: [.[].packages] }) | \
               tostring" | \
             sed 's/^"//;s/"$//')
-            echo "CHAT_GPT_PROMPT=$(echo Using the following data, please write a Markdown list in the format of \`\`\`### {{package1}}\\n\\n- {{title1}} [#{{number1}}]\({{url1}}\)\\n\\n### {{package2}}\\n\\n- {{title2}} [#{{number2}}]\({{url2}}\)\\n\\n...\\n\\n### {{packageN}}\\n\\n- {{titleN}} [#{{numberN}}]\({{urlN}}\)\`\`\`. \
-              Substitute \`{{package}}\` with the package name in the \`packages\` field, \`{{title}}\` with the \`title\` field value, \`{{number}}\` with the \`number\` field value, and \`{{url}}\` with the \`url\` field value of a list item. \
-              And also, please filter out any emojis in the package names:\\n\`\`\`$PRS_IN_MILESTONE\`\`\`)" >> $GITHUB_ENV
+            echo "CHAT_GPT_PROMPT=$(echo Using the following data, please write a Markdown list in the format of \`\`\`### {{package1}}\\n\\n- {{title1}} [#{{number1}}]\({{url1}}\)\\n\\n### {{package2}}\\n\\n- {{title2}} [#{{number2}}]\({{url2}}\)\\n\\n...\\n\\n### {{packageN}}\\n\\n- {{titleN}} [#{{numberN}}]\({{urlN}}\)\`\`\` \
+              where \`{{package}}\` is the package name in the \`packages\` field with any emojis removed, and only single package. If there are multiple packages in an item, write each one separately. The \`{{title}}\` field should be used for the title, \`{{number}}\` for the number, and \`{{url}}\` for the url of a list item. The data is:\\n\`\`\`$PRS_IN_MILESTONE\`\`\`)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -40,13 +40,13 @@ jobs:
             jq "[.items[] | \
               select(.pull_request.merged_at != null and \
                      (.labels | map(select(.name == \"release\")) | length == 0)) | \
-              {title: .title, number: .number, url: .html_url, package: .labels[].name}] | \
+              {title: .title, number: .number, url: .html_url, packages: .labels[].name}] | \
               group_by(.number) | \
-              map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | \
+              map({ title: .[0].title, number: .[0].number, url: .[0].url, packages: [.[].packages] }) | \
               tostring" | \
             sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n \
-            Please filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. Note that each package group must not be duplicated.)" >> $GITHUB_ENV
+            echo "CHAT_GPT_PROMPT=$(echo Using the following data, please write a Markdown list in the format of \`\`\`- [packages] title [#number]\(url\)\\n- [packages] title [#number]\(url\)\`\`\`. \
+              And please filter out any emojis in the package names:\\n\`\`\`$PRS_IN_MILESTONE\`\`\`)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:
@@ -57,7 +57,6 @@ jobs:
            -H "Authorization: Bearer $OPENAI_KEY" \
            -d '{
               "model": "gpt-3.5-turbo",
-              "temperature": 0.2,
               "messages": [
                 {
                   "role": "user",

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -11,7 +11,7 @@ env:
   CURRENT_VERSION: ${{ github.event.pull_request.milestone.title }}
 
 jobs:
-  update_changelog:
+  update-changelog:
     runs-on: ubuntu-latest
     if: ${{ github.event.label.name == 'release' }}
     steps:
@@ -29,8 +29,9 @@ jobs:
             exit 1
           fi
 
-          PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n. Please filter out emojis when writing package name in the markdown.)" >> $GITHUB_ENV
+          PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '[.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}] | group_by(.number) | map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | tostring' | sed 's/^"//;s/"$//')
+          echo $PRS_IN_MILESTONE
+          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\nPlease filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. ${package} should only be one package, not multiple packages.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\nAs shown in the format above, please group the list items by their respective package.)" >> $GITHUB_ENV
+          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\nAs you can see from the above format, group list items by their package.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -45,8 +45,9 @@ jobs:
               map({ title: .[0].title, number: .[0].number, url: .[0].url, packages: [.[].packages] }) | \
               tostring" | \
             sed 's/^"//;s/"$//')
-            echo "CHAT_GPT_PROMPT=$(echo Using the following data, please write a Markdown list in the format of \`\`\`- [packages] title [#number]\(url\)\\n- [packages] title [#number]\(url\)\`\`\`. \
-              And please filter out any emojis in the package names:\\n\`\`\`$PRS_IN_MILESTONE\`\`\`)" >> $GITHUB_ENV
+            echo "CHAT_GPT_PROMPT=$(echo Using the following data, please write a Markdown list in the format of \`\`\`### {{package1}}\\n\\n- {{title1}} [#{{number1}}]\({{url1}}\)\\n\\n### {{package2}}\\n\\n- {{title2}} [#{{number2}}]\({{url2}}\)\\n\\n...\\n\\n### {{packageN}}\\n\\n- {{titleN}} [#{{numberN}}]\({{urlN}}\)\`\`\`. \
+              Substitute \`{{package}}\` with the package name in the \`packages\` field, \`{{title}}\` with the \`title\` field value, \`{{number}}\` with the \`number\` field value, and \`{{url}}\` with the \`url\` field value of a list item. \
+              And also, please filter out any emojis in the package names:\\n\`\`\`$PRS_IN_MILESTONE\`\`\`)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_CONTENT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n but with the title name of common coming first, followed by the alphabetically sorted packages.)" >> $GITHUB_ENV
+          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\nAs shown in the format above, please group the list items by their respective package.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:
@@ -45,7 +45,7 @@ jobs:
               "messages": [
                 {
                   "role": "user",
-                  "content": "${{ env.CHAT_GPT_CONTENT }}"
+                  "content": "${{ env.CHAT_GPT_PROMPT }}"
                 }
               ]
             }' 

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -1,0 +1,71 @@
+name: Update CHANGELOG
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+env:
+  COMMIT_USER_EMAIL: developer@triple-corp.com
+  COMMIT_USER_NAME: triple-frontend[bot]
+  CURRENT_VERSION: ${{ github.event.pull_request.milestone.title }}
+
+jobs:
+  update_changelog:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'release' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Fetch PRs in current version's milestone and write a question to ChatGPT
+        run: |
+          RESPONSE=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/search/issues?q=milestone:${{ env.CURRENT_VERSION }}+type:pr+repo:$GITHUB_REPOSITORY")
+
+          if [[ $(echo "$RESPONSE" | jq '.total_count') == null ]]; then
+            echo $RESPONSE | jq '.message'
+            exit 1
+          fi
+
+          PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
+          echo "CHAT_GPT_CONTENT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n but with the title name of common coming first, followed by the alphabetically sorted packages.)" >> $GITHUB_ENV
+
+      - name: Request ChatGPT to write down CHANGELOG
+        env:
+          OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+        run: |
+          RESPONSE=$(curl -X POST https://api.openai.com/v1/chat/completions \
+           -H "Content-Type: application/json" \
+           -H "Authorization: Bearer $OPENAI_KEY" \
+           -d '{
+              "model": "gpt-3.5-turbo",
+              "temperature": 0.2,
+              "messages": [
+                {
+                  "role": "user",
+                  "content": "${{ env.CHAT_GPT_CONTENT }}"
+                }
+              ]
+            }' 
+          )
+
+          echo $RESPONSE | jq
+          changelog_content=$(echo $RESPONSE | jq -r '.choices[].message.content')
+
+          printf '\n%s\n\n' "## ${{ env.CURRENT_VERSION }}" >> changelog_tmp.md
+          echo -e "$changelog_content" >> changelog_tmp.md
+
+          sed -i '1r changelog_tmp.md' CHANGELOG.md
+          rm changelog_tmp.md
+
+      - name: Commit and push updated CHANGELOG
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --local user.email "${{ env.COMMIT_USER_EMAIL }}"
+          git config --local user.name "${{ env.COMMIT_USER_NAME }}"
+          git add CHANGELOG.md
+          git commit -m "Update ${{ env.CURRENT_VERSION }} CHANGELOG"
+          git push

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -29,9 +29,17 @@ jobs:
             exit 1
           fi
 
-          PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '[.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}] | group_by(.number) | map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | tostring' | sed 's/^"//;s/"$//')
-          echo $PRS_IN_MILESTONE
-          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\nPlease filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. Note that each package group must not be duplicated.)" >> $GITHUB_ENV
+          PRS_IN_MILESTONE=$(echo "$RESPONSE" | \
+            jq "[.items[] | \
+              select(.pull_request.merged_at != null and \
+                     (.labels | map(select(.name == \"release\")) | length == 0)) | \
+              {title: .title, number: .number, url: .html_url, package: .labels[].name}] | \
+              group_by(.number) | \
+              map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | \
+              tostring" | \
+            sed 's/^"//;s/"$//')
+          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n \
+            Please filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. Note that each package group must not be duplicated.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -15,6 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.label.name == 'release' }}
     steps:
+      - name: Check if a milestone exists on PR
+        run: |
+          if [[ $(echo ${{ github.event.pull_request.milestone }}) == "" ]]; then
+            echo "마일스톤을 등록해 주세요."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\nAs you can see from the above format, group list items by their package.)" >> $GITHUB_ENV
+          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | jq '.items[] | select(.pull_request.merged_at != null and (.labels | map(select(.name == "release")) | length == 0)) | {title: .title, number: .number, url: .html_url, package: .labels[].name}' | jq -s tostring | sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n.)" >> $GITHUB_ENV
+          echo "CHAT_GPT_PROMPT=$(echo Write down a markdown content based on this data\\n $PRS_IN_MILESTONE \\nin the following format:\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### other package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n. Please filter out emojis when writing package name in the markdown.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG
         env:

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -45,7 +45,7 @@ jobs:
               map({ title: .[0].title, number: .[0].number, url: .[0].url, package: [.[].package] }) | \
               tostring" | \
             sed 's/^"//;s/"$//')
-          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n \
+          echo "CHAT_GPT_PROMPT=$(echo Please write me a markdown using this data\\n$PRS_IN_MILESTONE\\nin the following format\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n### package\\n\\n- title [#number]\(url\)\\n- title [#number]\(url\)\\n\\n \
             Please filter out emojis when writing package name in the markdown, and if the item has multiple packages write it in multiple package group. Note that each package group must not be duplicated.)" >> $GITHUB_ENV
 
       - name: Request ChatGPT to write down CHANGELOG


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

GHA를 이용하여 기존에 마일스톤을 참고해서 수동으로 `CHANGELOG`를 작성하는 과정을 자동화합니다.
### CHANGELOG 작성 자동화

로컬에서 릴리즈 브랜치(`release/v1.2.3`)를 만들고 `npm run version`을 통해 새로운 버전으로 올린다음 `CHANGELOG`를 작성할 필요 없이, 릴리즈 PR을 오픈하면 GHA가 자동으로 릴리즈 PR이 등록된 마일스톤에 있는 _머지된_ PR들을 참고하여 `CHANGELOG`를 작성합니다.

릴리즈 PR을 오픈할 때 `release` 라벨과 마일스톤을 지정해주어야 GHA가 정상적으로 작동합니다. 마일스톤에 있는 PR 중에 라벨이 달려있지 않거나 머지되지 않은 PR은 `CHANGELOG` 작성 대상에서 제외됩니다.

### PR 라벨 자동화

변경된 파일들의 경로를 읽어 해당 PR이 어느 패키지를 변경했는지 파악하여 변경된 패키지 이름에 맞는 라벨을 부착하는 GHA를 추가합니다. 예를 들어, 어떤 PR이 `ab-experiments`와 `action-sheet`를 변경한 경우 해당 PR에 `ab-experiments`, `action-sheet` 라벨을 부착합니다. 패키지 변경 사항(`packages`로 시작하는 디렉토리)만 확인하며, `.storybook`, `package.json`과 같이 패키지 이외의 변경사항은 확인하지 않습니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

### 예시

https://github.com/titicacadev/triple-frontend/pull/2521 PR에서 작동 예시를 보실 수 있습니다!
`ab-experiments`, `core-elements` 패키지를 수정해서 그에 맞는 라벨이 자동으로 부착되었으며, 패키지 이외의 변경사항(`jest.config.js`)에 대해선 라벨이 달리지 않은것을 확인하실 수 있습니다.
