### PR TITLE
[react-triple-client-interfaces] package.json에 url 추가

### DIFF
--- a/packages/react-triple-client-interfaces/package.json
+++ b/packages/react-triple-client-interfaces/package.json
@@ -2,12 +2,19 @@
   "name": "@titicaca/react-triple-client-interfaces",
   "version": "12.14.0",
   "description": "React module for Triple native client interfaces",
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/react-triple-client-interfaces",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/titicacadev/triple-frontend.git"
+  },
+  "bugs": {
+    "url": "https://github.com/titicacadev/triple-frontend/issues"
+  },
   "main": "lib/index.js",
   "files": [
     "lib/*"
   ],
-  "author": "",
-  "license": "MIT",
   "scripts": {
     "build": "npm run build:cjs && npm run build:types",
     "build:cjs": "swc src -d lib --config-file ../../.swcrc",


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

[react-triple-client-interfaces] package.json에 url 추가

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

renovate가 react-triple-client-interfaces 패키지도 triple-frontend 모노레포에 포함된다고 인식할 수 있도록 package.json에 url 관련 필드를 추가합니다.