### PR TITLE
[ Modals ] Confirm body에 css prop을 추가합니다.

### DIFF
--- a/packages/modals/src/alert/alert.tsx
+++ b/packages/modals/src/alert/alert.tsx
@@ -18,6 +18,7 @@ export const Alert = ({
   confirmText = '확인',
   onClose,
   onConfirm,
+  ...props
 }: AlertProps) => {
   const handleConfirm = () => {
     onConfirm ? !onConfirm() && onClose?.() : onClose?.()
@@ -25,7 +26,7 @@ export const Alert = ({
 
   return (
     <Modal open={open} onClose={onClose}>
-      <Modal.Body>
+      <Modal.Body {...props}>
         {title && <Modal.Title>{title}</Modal.Title>}
         {children && <Modal.Description>{children}</Modal.Description>}
       </Modal.Body>

--- a/packages/modals/src/confirm/confirm.tsx
+++ b/packages/modals/src/confirm/confirm.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from 'react'
-import { CSSProp } from 'styled-components'
 
 import { Modal } from '../modal'
 
@@ -9,8 +8,6 @@ export interface ConfirmProps {
   open?: boolean
   cancelText?: string
   confirmText?: string
-  BodyProps?: CSSProp
-  ActionsProps?: CSSProp
   onClose?: () => void
   onCancel?: () => boolean | unknown
   onConfirm?: () => boolean | unknown

--- a/packages/modals/src/confirm/confirm.tsx
+++ b/packages/modals/src/confirm/confirm.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react'
+import { CSSProp } from 'styled-components'
 
 import { Modal } from '../modal'
 
@@ -8,6 +9,8 @@ export interface ConfirmProps {
   open?: boolean
   cancelText?: string
   confirmText?: string
+  BodyProps?: CSSProp
+  ActionsProps?: CSSProp
   onClose?: () => void
   onCancel?: () => boolean | unknown
   onConfirm?: () => boolean | unknown
@@ -22,6 +25,7 @@ export const Confirm = ({
   onClose,
   onCancel,
   onConfirm,
+  ...props
 }: ConfirmProps) => {
   const handleCancel = () => {
     onCancel ? !onCancel() && onClose?.() : onClose?.()
@@ -33,7 +37,7 @@ export const Confirm = ({
 
   return (
     <Modal open={open} onClose={onClose}>
-      <Modal.Body>
+      <Modal.Body {...props}>
         {title && <Modal.Title>{title}</Modal.Title>}
         {children && <Modal.Description>{children}</Modal.Description>}
       </Modal.Body>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- Confirm.body에 css를 적용 할 수 있게 props를 추가합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->