### PR TITLE
CHANGELOG 자동화를 개선합니다.

### DIFF
--- a/.github/workflows/add-label.yaml
+++ b/.github/workflows/add-label.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   label-pr:
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.user.login != 'triple-bot' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Fetch PRs in current version's milestone and write a question to ChatGPT
         run: |
-          RESPONSE=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/search/issues?q=milestone:${{ env.CURRENT_VERSION }}+type:pr+repo:$GITHUB_REPOSITORY")
+          RESPONSE=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/search/issues?q=milestone:${{ env.CURRENT_VERSION }}+type:pr+repo:$GITHUB_REPOSITORY&per_page=100")
 
           if [[ $(echo "$RESPONSE" | jq '.total_count') == null ]]; then
             echo $RESPONSE | jq '.message'

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -39,7 +39,7 @@ jobs:
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | \
             jq "[.items[] | \
               select(.pull_request.merged_at != null and \
-                     (.labels | map(select(.name == \"release\")) | length == 0)) | \
+                     (.labels | map(select(.name == \"release\" or .name == \"renovate\")) | length == 0)) | \
               {title: .title, number: .number, url: .html_url, packages: .labels[].name}] | \
               group_by(.number) | \
               map({ title: .[0].title, number: .[0].number, url: .[0].url, packages: [.[].packages] }) | \

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -39,7 +39,7 @@ jobs:
           PRS_IN_MILESTONE=$(echo "$RESPONSE" | \
             jq "[.items[] | \
               select(.pull_request.merged_at != null and \
-                     (.labels | map(select(.name == \"release\" or .name == \"renovate\")) | length == 0)) | \
+                     (.labels | map(select(.name == \"release\")) | length == 0)) | \
               {title: .title, number: .number, url: .html_url, packages: .labels[].name}] | \
               group_by(.number) | \
               map({ title: .[0].title, number: .[0].number, url: .[0].url, packages: [.[].packages] }) | \


### PR DESCRIPTION
## 변경 내역

- renovate PR을 라벨 자동화 대상에서 제외합니다.
- 깃헙 API를 이용하여 PR 목록을 가져올 때 최대 100개를 가져오도록 합니다 (기존 30개)
