### PR TITLE
플로팅 버튼 디자인을 v1 버전으로 되돌립니다

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47987,7 +47987,6 @@
       "version": "12.15.0",
       "license": "MIT",
       "dependencies": {
-        "@titicaca/color-palette": "^12.15.0",
         "@titicaca/core-elements": "^12.15.0",
         "@titicaca/intersection-observer": "^12.15.0",
         "@titicaca/type-definitions": "^12.15.0",

--- a/packages/app-installation-cta/package.json
+++ b/packages/app-installation-cta/package.json
@@ -34,7 +34,6 @@
     "lint:etc:fix": "prettier src --write"
   },
   "dependencies": {
-    "@titicaca/color-palette": "^12.15.0",
     "@titicaca/core-elements": "^12.15.0",
     "@titicaca/intersection-observer": "^12.15.0",
     "@titicaca/type-definitions": "^12.15.0",

--- a/packages/app-installation-cta/src/elements.tsx
+++ b/packages/app-installation-cta/src/elements.tsx
@@ -142,6 +142,7 @@ const inactiveFloatingButtonStyle = css<{
   fixed?: 1 | 0
   margin?: MarginPadding
 }>`
+  /* stylelint-disable unit-no-unknown */
   transform: translate3d(
     0,
     calc(

--- a/packages/app-installation-cta/src/elements.tsx
+++ b/packages/app-installation-cta/src/elements.tsx
@@ -4,6 +4,7 @@ import {
   MarginPadding,
   layeringMixin,
   LayeringMixinProps,
+  safeAreaInsetMixin,
 } from '@titicaca/core-elements'
 
 export const Overlay = styled.div<LayeringMixinProps>`
@@ -170,6 +171,7 @@ export const FloatingButtonContainer = styled.div<
   height: 84px;
 
   ${layeringMixin(1)}
+  ${safeAreaInsetMixin}
   @media (min-width: ${MIN_DESKTOP_WIDTH}px) {
     display: none;
   }

--- a/packages/app-installation-cta/src/elements.tsx
+++ b/packages/app-installation-cta/src/elements.tsx
@@ -1,42 +1,47 @@
 import styled, { css } from 'styled-components'
 import {
-  FlexBox,
   Text,
   MarginPadding,
   layeringMixin,
   LayeringMixinProps,
-  safeAreaInsetMixin,
 } from '@titicaca/core-elements'
+import { white, blue980, gray500 } from '@titicaca/color-palette'
 
-export const BottomFixedContainer = styled.div<LayeringMixinProps>`
+export const Overlay = styled.div<LayeringMixinProps>`
   position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.07);
+  background-color: ${gray500};
+  ${layeringMixin(1)}
+`
+export const BottomFixedContainer = styled.div<LayeringMixinProps>`
+  position: absolute;
   left: 0;
   bottom: 0;
   width: 100%;
 
-  ${layeringMixin(1)}
-
+  ${layeringMixin(0)}
   > * {
     margin: 0 auto;
   }
 `
-
 const CONTENT_MIN_WIDTH = 320
 const CONTENT_MAX_WIDTH = 768
-
 export const ImageBannerWrapper = styled.div`
+  box-sizing: border-box;
   min-width: ${CONTENT_MIN_WIDTH}px;
   height: 230px;
   padding: 0 20px 20px;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.07);
   background-color: #0179ff;
 `
-
 export const ImageWrapper = styled.div`
   margin: 0 auto;
   height: 130px;
 `
-
 export const BannerImage = styled.img`
   position: relative;
   top: 50%;
@@ -46,9 +51,9 @@ export const BannerImage = styled.img`
   width: 320px;
   height: 130px;
 `
-
 export const InstallLink = styled.a`
   display: block;
+  box-sizing: border-box;
   margin: 5px auto 16px;
   max-width: ${CONTENT_MAX_WIDTH}px;
   height: 44px;
@@ -60,21 +65,26 @@ export const InstallLink = styled.a`
   text-align: center;
   font-size: 14px;
   font-weight: bold;
+  cursor: pointer;
+  text-decoration: none;
 `
-
 export const DismissButton = styled.button`
   display: block;
   margin: 0 auto;
+  border: 0;
+  background-color: transparent;
   opacity: 0.6;
   font-size: 12px;
   font-weight: 500;
+  text-align: center;
   color: white;
   text-decoration: underline;
   outline: none;
+  cursor: pointer;
 `
-
 export const TextBannerWrapper = styled.a`
   display: block;
+  box-sizing: border-box;
   width: 100%;
   height: 54px;
   line-height: 17px;
@@ -85,8 +95,9 @@ export const TextBannerWrapper = styled.a`
   font-size: 14px;
   font-weight: bold;
   text-align: center;
+  cursor: pointer;
+  text-decoration: none;
 `
-
 export const DownloadIcon = styled.img`
   margin-left: 6px;
   width: 12px;
@@ -94,18 +105,21 @@ export const DownloadIcon = styled.img`
   vertical-align: middle;
   transform: translateY(-1px); /* HACK: 아래로 가있는 이미지 위로 끌어 올림 */
 `
-
 const MIN_DESKTOP_WIDTH = 1142
 export const InstallDescription = styled(Text)`
   height: 21px;
   font-size: 18px;
   font-weight: bold;
-  color: var(--color-white);
+  color: ${white};
 `
 
 export const InstallAnchor = styled.a`
-  display: inline-block;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  display: block;
   text-decoration: none;
+  padding: 23px 0 22px 32px;
 
   &:visited,
   &:hover,
@@ -114,39 +128,21 @@ export const InstallAnchor = styled.a`
   }
 `
 
-export const InstallButton = styled.a`
-  display: block;
-  width: 100%;
-  max-width: 768px;
-  margin: 0 auto;
-  padding: 14px 0;
-  background: var(--color-white);
-  border-radius: 25px;
-  color: var(--color-gray);
-  font-size: 12px;
-  font-weight: 700;
-  text-align: center;
-`
-
 export const GoAppButton = styled.img`
-  margin-left: 4px;
-  vertical-align: middle;
-  opacity: 0.8;
+  width: 20px;
+  height: 20px;
 `
 
 export const CloseButton = styled.img`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  cursor: pointer;
+  width: 30px;
+  height: 30px;
+  margin: 27px 16px 27px 0;
 `
 
 const inactiveFloatingButtonStyle = css<{
   fixed?: 1 | 0
   margin?: MarginPadding
 }>`
-  /* stylelint-disable unit-no-unknown */
   transform: translate3d(
     0,
     calc(
@@ -157,29 +153,23 @@ const inactiveFloatingButtonStyle = css<{
     0
   );
 `
-
 const activeFloatingButtonStyle = `
   transform: translate3d(0, 0, 0);
 `
-
 const floatingButtonTransitionConfig = `
   transition: transform 300ms ease-out;
 `
-
 interface FloatingButtonProps {
   visibility: 1 | 0
   fixed?: 1 | 0
   margin?: MarginPadding
 }
-
 export const FloatingButtonContainer = styled.div<
   FloatingButtonProps & LayeringMixinProps
 >`
-  background-color: rgba(38, 206, 194, 1);
+  height: 84px;
 
   ${layeringMixin(1)}
-  ${safeAreaInsetMixin}
-
   @media (min-width: ${MIN_DESKTOP_WIDTH}px) {
     display: none;
   }
@@ -189,19 +179,17 @@ export const FloatingButtonContainer = styled.div<
     css`
       position: fixed;
       bottom: 0;
-      left: 0;
-      right: 0;
+      left: 10px;
+      right: 10px;
+      margin-bottom: 30px;
     `};
-
   ${({ margin }) =>
     margin &&
     css`
       margin: ${margin.top || 0}px ${margin.right || 0}px
         ${margin.bottom || 0}px ${margin.left || 0}px;
     `};
-
   ${({ visibility }) => (visibility ? 'display: block;' : 'display: none;')}
-
   &.floating-button-slide-exit {
     ${activeFloatingButtonStyle}
   }
@@ -217,16 +205,16 @@ export const FloatingButtonContainer = styled.div<
   }
 `
 
-export const ContentContainer = styled(FlexBox).attrs({
-  flex: true,
-  centered: true,
-  gap: '11px',
-})`
+export const FloatingButton = styled.div`
+  display: flex;
+  border-radius: 42px;
+  box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.07);
+  background-color: ${blue980};
+  overflow: hidden;
+  margin-left: auto;
+  margin-right: auto;
   max-width: 768px;
-  padding: 24px 0 16px;
-  position: relative;
 `
-
 // ChatbotCTA
 export const ChatBalloon = styled.div`
   position: relative;
@@ -235,16 +223,16 @@ export const ChatBalloon = styled.div`
   border-radius: 26px 26px 0;
   padding: 30px;
   margin-right: 50px;
+  box-sizing: border-box;
   min-height: 132px;
 `
-
 export const ChatbotAction = styled.a`
   display: inline-block;
   font-size: 13px;
   font-weight: bold;
   text-decoration: none;
   line-height: 16px;
-  color: var(--color-blue980);
+  color: ${blue980};
   padding-right: 14px;
   background-size: 14px 14px;
   background-image: url('https://assets.triple.guide/images/ico-right-blue-arrow-s@3x.png');
@@ -252,26 +240,30 @@ export const ChatbotAction = styled.a`
   background-position: right 1px;
   margin-top: 10px;
 `
-
 export const ChatbotCloseButton = styled.button`
   position: absolute;
   top: 10px;
   right: 10px;
+  margin: 0;
+  padding: 0;
   width: 24px;
   height: 24px;
   overflow: hidden;
   text-indent: -1000px;
   border-radius: 12px;
+  box-sizing: border-box;
+  background-color: transparent;
   background-image: url('https://assets.triple-dev.titicaca-corp.com/images/btn-gray-close-circle-s@3x.png');
   background-size: 24px 24px;
   background-position: left top;
   background-repeat: no-repeat;
+  border: none;
+  cursor: pointer;
 
   &:focus {
     outline: none;
   }
 `
-
 export const ChatbotIcon = styled.a`
   position: absolute;
   z-index: 1;
@@ -282,28 +274,24 @@ export const ChatbotIcon = styled.a`
   height: 40px;
   overflow: hidden;
   text-indent: -1000px;
+  background-color: transparent;
   background-image: url('https://assets.triple-dev.titicaca-corp.com/images/ico-circle-triple-bi@3x.png');
   background-size: 40px 40px;
   background-position: left top;
   background-repeat: no-repeat;
 `
-
 const inactiveChatbotContainerStyle = `
   transform: translate3d(0, calc(100% + 10px), 0);
-
   @media (min-width: 768px) {
     transform: translate3d(0, calc(100% + 30px), 0);
   }
 `
-
 const activeChatbotContainerStyle = `
   transform: translate3d(0, 0, 0);
 `
-
 const chatbotContainerTransitionStyle = `
   transition: transform 300ms ease-out;
 `
-
 export const ChatbotContainer = styled.div<
   { visibility: 1 | 0 } & LayeringMixinProps
 >`
@@ -311,9 +299,7 @@ export const ChatbotContainer = styled.div<
   bottom: 10px;
   left: 10px;
   right: 10px;
-
   ${layeringMixin(1)}
-
   ${ChatBalloon} {
     ${({ visibility }) =>
       visibility ? 'box-shadow: 0 30px 100px 0 rgba(0, 0, 0, 0.3);' : ''}

--- a/packages/app-installation-cta/src/elements.tsx
+++ b/packages/app-installation-cta/src/elements.tsx
@@ -5,7 +5,6 @@ import {
   layeringMixin,
   LayeringMixinProps,
 } from '@titicaca/core-elements'
-import { white, blue980, gray500 } from '@titicaca/color-palette'
 
 export const Overlay = styled.div<LayeringMixinProps>`
   position: fixed;
@@ -14,7 +13,7 @@ export const Overlay = styled.div<LayeringMixinProps>`
   left: 0;
   right: 0;
   box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.07);
-  background-color: ${gray500};
+  background-color: var(--color-gray500);
   ${layeringMixin(1)}
 `
 export const BottomFixedContainer = styled.div<LayeringMixinProps>`
@@ -110,7 +109,7 @@ export const InstallDescription = styled(Text)`
   height: 21px;
   font-size: 18px;
   font-weight: bold;
-  color: ${white};
+  color: var(--color-white);
 `
 
 export const InstallAnchor = styled.a`
@@ -209,7 +208,7 @@ export const FloatingButton = styled.div`
   display: flex;
   border-radius: 42px;
   box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.07);
-  background-color: ${blue980};
+  background-color: var(--color-blue980);
   overflow: hidden;
   margin-left: auto;
   margin-right: auto;
@@ -232,7 +231,7 @@ export const ChatbotAction = styled.a`
   font-weight: bold;
   text-decoration: none;
   line-height: 16px;
-  color: ${blue980};
+  color: var(--color-blue980);
   padding-right: 14px;
   background-size: 14px 14px;
   background-image: url('https://assets.triple.guide/images/ico-right-blue-arrow-s@3x.png');

--- a/packages/app-installation-cta/tsconfig.json
+++ b/packages/app-installation-cta/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@titicaca/color-palette": ["../color-palette/src"],
       "@titicaca/core-elements": ["../core-elements/src"],
       "@titicaca/intersection-observer": ["../intersection-observer/src"],
       "@titicaca/type-definitions": ["../type-definitions/src"],


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[관련 스레드](https://titicaca.slack.com/archives/CE1TS26GK/p1681117980027519?thread_ts=1672730534.784689&cid=CE1TS26GK)

플로팅 A/B 테스팅 결과, 기존의 v1 버전(파란색) 플로팅 버튼을 사용하기로 하여 플로팅 버튼 디자인을 v1 버전으로 되돌립니다.
https://github.com/titicacadev/triple-frontend/pull/2262 요 PR을 참고했습니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
