### PR TITLE
PinnedMessage의 text 필드를 추가합니다.

### DIFF
--- a/packages/review/src/components/review-element/pinned-message.tsx
+++ b/packages/review/src/components/review-element/pinned-message.tsx
@@ -18,7 +18,11 @@ export function PinnedMessage({
   const textRef = useRef<HTMLDivElement>(null)
   const [isTextClamped, setIsTextClamped] = useState(false)
 
-  const { content, writer, updatedAt } = pinnedMessage
+  const {
+    content: { text, markdownText },
+    writer,
+    updatedAt,
+  } = pinnedMessage
 
   useEffect(() => {
     if (!textRef.current) {
@@ -29,7 +33,7 @@ export function PinnedMessage({
     setIsTextClamped(textElement.scrollHeight > textElement.clientHeight)
   }, [])
 
-  if (!content.markdownText) {
+  if (!text && !markdownText) {
     return null
   }
 
@@ -78,7 +82,7 @@ export function PinnedMessage({
         maxLines={2}
         css={{ fontSize: 15, lineHeight: '20px' }}
       >
-        {content.markdownText}
+        {text ?? markdownText}
       </Text>
       {isTextClamped ? (
         <Text css={{ color: 'var(--color-blue)' }}>

--- a/packages/review/src/components/types.tsx
+++ b/packages/review/src/components/types.tsx
@@ -33,7 +33,8 @@ export interface PinnedMessageData {
     profileImage?: string
   }
   content: {
-    markdownText?: string
+    text: string | null
+    markdownText: string | null
   }
   createAt: string
   updatedAt: string

--- a/packages/review/src/services/generated/query.ts
+++ b/packages/review/src/services/generated/query.ts
@@ -1044,6 +1044,7 @@ export const BaseReviewFragmentDoc = `
         profileImage
       }
       content {
+        text
         markdownText
       }
       createdAt


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

pinnedMessage의 인터페이스가 변경에 대응합니다.
`replyBoard.pinnedMessage.content.text` 필드에 먼저 접근하여 `text` 필드가 있으면 `text` 필드값을 보여주고, 없으면 기존처럼 `markdownText` 값을 보여줍니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
