### PR TITLE
[triple-email-document] 링크 Element에 존재하는 URL 변환하는 로직을 제거합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53239,8 +53239,7 @@
       "license": "MIT",
       "dependencies": {
         "@titicaca/core-elements": "^12.16.0",
-        "@titicaca/type-definitions": "^12.16.0",
-        "@titicaca/view-utilities": "^12.16.0"
+        "@titicaca/type-definitions": "^12.16.0"
       },
       "peerDependencies": {
         "react": "^18.0",

--- a/packages/triple-email-document/package.json
+++ b/packages/triple-email-document/package.json
@@ -28,8 +28,7 @@
   },
   "dependencies": {
     "@titicaca/core-elements": "^12.16.0",
-    "@titicaca/type-definitions": "^12.16.0",
-    "@titicaca/view-utilities": "^12.16.0"
+    "@titicaca/type-definitions": "^12.16.0"
   },
   "peerDependencies": {
     "react": "^18.0",

--- a/packages/triple-email-document/src/elements/links.tsx
+++ b/packages/triple-email-document/src/elements/links.tsx
@@ -1,7 +1,6 @@
 import { HTMLAttributes, PropsWithChildren } from 'react'
 import { Container } from '@titicaca/core-elements'
 import styled from 'styled-components'
-import { parseUrl, checkIfRoutable } from '@titicaca/view-utilities'
 
 import { FluidTable, Box as DefaultBox } from '../common'
 
@@ -9,7 +8,7 @@ interface Link {
   id?: string
   label?: string
   href: string
-  target?: 'browser'
+  target?: string
 }
 
 export interface LinksDocument {
@@ -91,14 +90,10 @@ const LINK_ELEMENTS = {
   largeCompactButton: LargeCompactLink,
 }
 
-const TRIPLE_PROD_DOMAIN = 'https://triple.guide'
-
 export default function LinksView({
   value: { display, links },
-  webUrlBase,
 }: {
   value: LinksDocument['value']
-  webUrlBase?: string
 }) {
   const Box = LINK_BOXES[display] || ButtonBox
   const Element = LINK_ELEMENTS[display] || ButtonLink
@@ -107,13 +102,6 @@ export default function LinksView({
     <FluidTable>
       <tbody>
         {links.map((link, index) => {
-          const href = canonizeTargetAddress({
-            href: link.href,
-            webUrlBase,
-          })
-
-          const targetHref = checkIfRoutable({ href }) ? href : ''
-
           return (
             <tr key={index}>
               <Box>
@@ -122,7 +110,7 @@ export default function LinksView({
                     textAlign: 'center',
                   }}
                 >
-                  <Element href={targetHref} ses:tags={`link:${link.id}`}>
+                  <Element href={link.href} ses:tags={`link:${link.id}`}>
                     {link.label}
                   </Element>
                 </Container>
@@ -157,20 +145,4 @@ function LargeBox({ children }: PropsWithChildren<unknown>) {
       {children}
     </DefaultBox>
   )
-}
-
-function canonizeTargetAddress({
-  href: rawHref,
-  webUrlBase = TRIPLE_PROD_DOMAIN,
-}: {
-  href: string
-  webUrlBase?: string
-}) {
-  const { host, path } = parseUrl(rawHref)
-
-  if (host) {
-    return rawHref
-  } else {
-    return `${webUrlBase}${path}`
-  }
 }

--- a/packages/triple-email-document/src/links.stories.tsx
+++ b/packages/triple-email-document/src/links.stories.tsx
@@ -59,7 +59,7 @@ function generateSampleData(type: LinkDisplay) {
         {
           id: 'Link_ID',
           label: `${type} 디자인 형식`,
-          href: '/regions/e3803739-d1c4-441e-a3f7-5a057fa851c8/articles/991aea4e-4645-4682-9bb5-f0e070e1f169',
+          href: '',
         },
       ],
       display: type,

--- a/packages/triple-email-document/src/triple-email-document.tsx
+++ b/packages/triple-email-document/src/triple-email-document.tsx
@@ -12,11 +12,9 @@ interface ElementSet {
 export function TripleEmailDocument({
   elements,
   customElements = {},
-  ...props
 }: {
   elements: TripleEmailElementData[]
   customElements?: ElementSet
-  webUrlBase?: string
 }) {
   return (
     <FluidTable>
@@ -36,7 +34,7 @@ export function TripleEmailDocument({
           return (
             <tr key={index}>
               <td>
-                <Element value={value} {...props} />
+                <Element value={value} />
               </td>
             </tr>
           )

--- a/packages/triple-email-document/tsconfig.json
+++ b/packages/triple-email-document/tsconfig.json
@@ -4,8 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "@titicaca/core-elements": ["../core-elements/src"],
-      "@titicaca/type-definitions": ["../type-definitions/src"],
-      "@titicaca/view-utilities": ["../view-utilities/src"]
+      "@titicaca/type-definitions": ["../type-definitions/src"]
     }
   },
   "exclude": ["**/node_modules", "lib"]


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

해당 로직은 다음과 같은 사이드 이펙트가 있어서 롤백합니다.
- 뉴스레터에 삽입되는 아티클의 링크가 도시 메인(앱 딥링크)일 경우 랜딩이 안되는 이슈가 있습니다.

배경 지식
- 아티클 어드민에 삽입되는 링크는 WEB_URL_BASE이 아니라 APP_URL_BASE 기준입니다.

변환 로직은 newsletter-api 에서 관리합니다. (관련 [PR](https://github.com/titicacadev/triple-newsletter-api/pull/39))

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

https://github.com/titicacadev/triple-frontend/pull/2559 롤백
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->


