### PR TITLE
CHANGELOG 자동화 로직을 수정합니다.

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -49,8 +49,6 @@ jobs:
         run: npx prettier --write CHANGELOG.md
 
       - name: Commit and push updated CHANGELOG
-        env:
-          GITHUB_TOKEN: ${{ secrets.TRIPLE_BOT_GITHUB_TOKEN }}
         run: |
           git config --local user.email "${{ env.COMMIT_USER_EMAIL }}"
           git config --local user.name "${{ env.COMMIT_USER_NAME }}"

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
+          token: ${{ secrets.TRIPLE_BOT_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Setup Node.js ${{ env.NODE_VERSION }}

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -6,8 +6,8 @@ on:
       - labeled
 
 env:
-  COMMIT_USER_EMAIL: developer@triple-corp.com
-  COMMIT_USER_NAME: triple-frontend[bot]
+  COMMIT_USER_EMAIL: triple-bot@interpark.com
+  COMMIT_USER_NAME: TRIPLE Bot
   CURRENT_VERSION: ${{ github.event.pull_request.milestone.title }}
   NODE_VERSION: 'lts/*'
   NPM_REGISTRY_URL: 'https://registry.npmjs.org'

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -37,7 +37,7 @@ jobs:
           registry-url: ${{ env.NPM_REGISTRY_URL }}
           cache: 'npm'
 
-      - run: npm i node-fetch@v2 prettier emoji-regex
+      - run: npm ci node-fetch prettier
 
       - name: Execute Changelog JavaScript
         run: node scripts/changelog.js

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -3,7 +3,6 @@
 const fs = require('fs')
 
 const fetch = require('node-fetch')
-const emojiRegex = require('emoji-regex')
 
 function generateChatGptPrompt(inputData) {
   return `
@@ -122,17 +121,6 @@ Output markdown:
 `
 }
 
-function removeEmojis(str) {
-  const emojiShortCodeRegex = /:.*:/gu
-  const variationSelectorRegex = /[\uFE00-\uFE0F]/g
-
-  return str
-    .replace(emojiRegex(), '')
-    .replace(emojiShortCodeRegex, '')
-    .replace(variationSelectorRegex, '')
-    .trim()
-}
-
 function groupPullRequestsByPackage(pullRequests) {
   const groupedPullRequests = pullRequests.reduce(
     (result, { packages, title, number, url }) => {
@@ -187,7 +175,7 @@ async function fetchPrsInMilestone() {
       title,
       number,
       url,
-      packages: labels.map(({ name }) => removeEmojis(name)),
+      packages: labels.map(({ name }) => name),
     }))
     .sort((a, b) => a.number - b.number)
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

기존 방식에선 GHA에 의해 자동으로 작성된 CHANGELOG가 커밋/푸쉬되면 CI가 정상적으로 돌았음에도 불구하고 아래 사진과 같이 깃헙에서 이를 인지하지 못하게되는 오류가 있었습니다.

<img width="847" alt="스크린샷 2023-05-08 10 27 38" src="https://user-images.githubusercontent.com/50892653/236714612-580f6d8d-4ec1-40b0-bde4-727d43faf919.png">

(비교: 체크가 정상적으로 동작한경우)
<img width="825" alt="스크린샷 2023-05-08 10 29 02" src="https://user-images.githubusercontent.com/50892653/236714669-b88b1193-d1da-44bd-b400-5f1ba364d28a.png">

이를 해결하기 위해, GHA에서 `actions/checkout@v3`를 실행할 때 `TRIPLE_BOT_GITHUB_TOKEN`을 이용하여 checkout하도록 수정했습니다. (-> https://stackoverflow.com/questions/52200096/github-pull-request-waiting-for-status-to-be-reported/69169858#69169858 참고)

그 외 변경사항으로, `COMMIT_USER_EMAIL`, `COMMIT_USER_NAME` env 변수값 등을 수정하고, 이모지를 제거하는 로직을 삭제하고 그 대신 라벨에 붙어있던 이모지들을 제거했습니다.

