### PR TITLE
[ Router ] LocalLink 컴포넌트에 shallow property를 추가합니다.

### DIFF
--- a/packages/router/src/local/href-handler.ts
+++ b/packages/router/src/local/href-handler.ts
@@ -21,6 +21,11 @@ export interface NextjsRoutingOptions {
    * 기본 값 true
    */
   scroll?: boolean
+  /**
+   * 현재창에서 URL을 변경할 때 data fetching(getServerSideProps, getStaticProps, getInitialProps)을 하지 않습니다.
+   * 기본 값 false
+   */
+  shallow?: boolean
 }
 
 export function useLocalHrefHandler() {
@@ -32,13 +37,14 @@ export function useLocalHrefHandler() {
 
   const handleNextjsRouting = async (
     href: string,
-    { replace, scroll = true }: NextjsRoutingOptions,
+    { replace, scroll = true, shallow = false }: NextjsRoutingOptions,
   ): Promise<void> => {
     const success = await router[replace ? 'replace' : 'push'](
       href,
       undefined,
       {
         scroll,
+        shallow,
       },
     )
     if (success && scroll) {
@@ -55,6 +61,7 @@ export function useLocalHrefHandler() {
     swipeToClose,
     replace,
     scroll,
+    shallow,
     isKeyPressing,
     stopDefaultHandler,
   }: HrefProps &
@@ -67,7 +74,7 @@ export function useLocalHrefHandler() {
     if (target === 'current' && isKeyPressing === false) {
       stopDefaultHandler()
 
-      await handleNextjsRouting(href, { replace, scroll })
+      await handleNextjsRouting(href, { replace, scroll, shallow })
 
       return
     }

--- a/packages/router/src/local/link.tsx
+++ b/packages/router/src/local/link.tsx
@@ -28,6 +28,7 @@ export function LocalLink({
   allowSource,
   replace,
   scroll = true,
+  shallow = false,
   lnbTarget,
   noNavbar,
   swipeToClose,
@@ -55,6 +56,7 @@ export function LocalLink({
       swipeToClose,
       replace,
       scroll,
+      shallow,
       isKeyPressing: isKeyPressingClick(e),
       stopDefaultHandler: () => {
         e.preventDefault()


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- LocalLink에서 `target: current`인 경우 [shallow routing](https://nextjs.org/docs/pages/building-your-application/routing/linking-and-navigating#shallow-routing) property를 추가합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 추가 배경
- [통합검색 - 인기 검색어](https://www.figma.com/file/Va0p9Eoaire2lKjQFqK3lG/20230215_%ED%86%B5%ED%95%A9%EA%B2%80%EC%83%89?type=design&node-id=836-79230&t=IvoZGnggjSPDV5cT-4)에서 [Text](https://github.com/titicacadev/triple-frontend/blob/main/packages/core-elements/src/elements/text/text.tsx)에 shallow routing이 필요한데, 이때 `onClick` 함수에 `router.push + shallow`를 선언하는 것보다 `LocalLink`를 이용하는 편이 구현하기 간단하고 사용 목적과 부합하여 추가하게 되었습니다.
