### PR TITLE
CHANGELOG 작성 시 PR url이 잘못 달리던 버그를 수정합니다.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,17 @@
 
 ### core-elements
 
-- [core-elements] CheckboxGroup, RadioGroup 접근성 수정 [#2581](https://github.com/jaehyeon48/github-actions-test/pull/2581)
-- [core-elements] Fieldset 추가 [#2582](https://github.com/jaehyeon48/github-actions-test/pull/2582)
+- [core-elements] CheckboxGroup, RadioGroup 접근성 수정 [#2581](https://github.com/titicacadev/triple-frontend/pull/2581)
+- [core-elements] Fieldset 추가 [#2582](https://github.com/titicacadev/triple-frontend/pull/2582)
 
 ### review
 
-- PinnedMessage의 text 필드를 추가합니다. [#2606](https://github.com/jaehyeon48/github-actions-test/pull/2606)
+- PinnedMessage의 text 필드를 추가합니다. [#2606](https://github.com/titicacadev/triple-frontend/pull/2606)
 
 ### triple-email-document
 
-- [triple-email-document] 이메일에서 도메인이 없는 링크 클릭 시, 정상적으로 랜딩되지 않는 이슈를 수정합니다. [#2559](https://github.com/jaehyeon48/github-actions-test/pull/2559)
-- [triple-email-document] 링크 Element에 존재하는 URL 변환하는 로직을 제거합니다. [#2610](https://github.com/jaehyeon48/github-actions-test/pull/2610)
+- [triple-email-document] 이메일에서 도메인이 없는 링크 클릭 시, 정상적으로 랜딩되지 않는 이슈를 수정합니다. [#2559](https://github.com/titicacadev/triple-frontend/pull/2559)
+- [triple-email-document] 링크 Element에 존재하는 URL 변환하는 로직을 제거합니다. [#2610](https://github.com/titicacadev/triple-frontend/pull/2610)
 
 ## v12.16.0
 

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -93,25 +93,25 @@ Example output markdown:
 \`\`\`
 ### ab-experiments
 
-- [core-elements] story title을 소문자로 변경 [#2345](https://github.com/jaehyeon48/github-actions-test/pull/2345)
-- css prop과 centered prop이 충돌하는 문제 수정 [#2352](https://github.com/jaehyeon48/github-actions-test/pull/2352)
-- Rating 컴포넌트에 최대값,최소값 설정 추가 [#2364](https://github.com/jaehyeon48/github-actions-test/pull/2364)
+- [core-elements] story title을 소문자로 변경 [#2345](https://github.com/titicacadev/triple-frontend/pull/2345)
+- css prop과 centered prop이 충돌하는 문제 수정 [#2352](https://github.com/titicacadev/triple-frontend/pull/2352)
+- Rating 컴포넌트에 최대값,최소값 설정 추가 [#2364](https://github.com/titicacadev/triple-frontend/pull/2364)
 
 ### anchor
 
-- css prop과 centered prop이 충돌하는 문제 수정 [#2352](https://github.com/jaehyeon48/github-actions-test/pull/2352)
+- css prop과 centered prop이 충돌하는 문제 수정 [#2352](https://github.com/titicacadev/triple-frontend/pull/2352)
 
 ### common
 
-- cd workflow 에러 수정 [#2351](https://github.com/jaehyeon48/github-actions-test/pull/2351)
-- css prop과 centered prop이 충돌하는 문제 수정 [#2352](https://github.com/jaehyeon48/github-actions-test/pull/2352)
-- Rating 컴포넌트에 최대값,최소값 설정 추가 [#2364](https://github.com/jaehyeon48/github-actions-test/pull/2364)
+- cd workflow 에러 수정 [#2351](https://github.com/titicacadev/triple-frontend/pull/2351)
+- css prop과 centered prop이 충돌하는 문제 수정 [#2352](https://github.com/titicacadev/triple-frontend/pull/2352)
+- Rating 컴포넌트에 최대값,최소값 설정 추가 [#2364](https://github.com/titicacadev/triple-frontend/pull/2364)
 
 ### core-elements
 
-- [core-elements] story title을 소문자로 변경 [#2345](https://github.com/jaehyeon48/github-actions-test/pull/2345)
-- [core-elements] ConfirmSelector 디자인 수정 [#2359](https://github.com/jaehyeon48/github-actions-test/pull/2359)
-- Rating 컴포넌트에 최대값,최소값 설정 추가 [#2364](https://github.com/jaehyeon48/github-actions-test/pull/2364)
+- [core-elements] story title을 소문자로 변경 [#2345](https://github.com/titicacadev/triple-frontend/pull/2345)
+- [core-elements] ConfirmSelector 디자인 수정 [#2359](https://github.com/titicacadev/triple-frontend/pull/2359)
+- Rating 컴포넌트에 최대값,최소값 설정 추가 [#2364](https://github.com/titicacadev/triple-frontend/pull/2364)
 \`\`\`
 Input JSON data:
 \`\`\`


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

ChatGPT로 CHANGELOG를 작성할 때, PR 링크가 TF가 아니라 제 개인 레포의 링크로 작성되던 이슈를 수정합니다.
요걸 사전에 발견했었어야 하는데 죄송합니다 ㅠㅠ 🙇
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
