### PR TITLE
[Footer] 로그인 버튼 a -> button으로 수정

### DIFF
--- a/packages/footer/src/company-info.tsx
+++ b/packages/footer/src/company-info.tsx
@@ -34,6 +34,10 @@ const Button = styled.a`
   border-radius: 4px;
   background-color: rgba(250, 250, 250, 1);
 
+  &:first-child {
+    margin-right: 6px;
+  }
+
   img {
     width: 16px;
     margin-left: 6px;
@@ -65,10 +69,6 @@ const AccordionArrow = styled.img`
 `
 
 const ButtonContainer = styled(FlexBox)`
-  a:first-child {
-    margin-right: 6px;
-  }
-
   @media (max-width: ${MAX_PHONE_WIDTH}px) {
     width: 100%;
     margin-bottom: 20px;
@@ -112,6 +112,8 @@ export function CompanyInfo({
         {!hideAppDownloadButton ? (
           <ButtonContainer flex>
             <Button
+              as="button"
+              type="button"
               onClick={() => {
                 if (sessionAvailable) {
                   logout()


### PR DESCRIPTION
## PR 설명

Footer 내 '로그인/로그아웃' 링크(`a`)가 href가 아닌 onClick으로 동작하고 있어 `hover` 시 포인터 커서 누락 및 탭으로 접근이 불가능 하여 `button` 태그로 렌더될 수 있도록 수정했습니다.

## 스크린샷 & URL

<img width="1268" alt="스크린샷 2023-05-18 오후 6 34 34" src="https://github.com/titicacadev/triple-frontend/assets/133629020/2d8c4fed-cad0-43ef-b41b-cb840e7d79d2">

