### PR TITLE
[triple-document] 표시가보다 판매가가 큰 경우 할인율과 표시가가 미노출되도록 수정합니다.

### DIFF
--- a/packages/triple-document/src/elements/tna/product.tsx
+++ b/packages/triple-document/src/elements/tna/product.tsx
@@ -223,7 +223,7 @@ export function TnaProductWithPrice({
             <Pricing
               salePrice={salePrice}
               basePrice={
-                !!basePrice && salePrice !== basePrice ? basePrice : undefined
+                !!basePrice && salePrice < basePrice ? basePrice : undefined
               }
             />
           ) : null}

--- a/packages/triple-document/src/mocks/slots.sample.json
+++ b/packages/triple-document/src/mocks/slots.sample.json
@@ -7,10 +7,10 @@
         "id": "cb144134-401d-4450-aa1f-346686cb0f7b",
         "title": "[경기 용인] 에버랜드+플라이스테이션 패키지★",
         "tags": [],
-        "salePrice": 60900,
+        "salePrice": 116000,
         "heroImage": "https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/f90fe57e-d2eb-45d2-b204-a652f093e2bf.jpeg",
         "supplierType": "YANOLJA",
-        "basePrice": 116000,
+        "basePrice": 60900,
         "reviewRating": 0,
         "reviewsCount": 0,
         "domesticAreas": [


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
- [관련 스레드](https://titicaca.slack.com/archives/C9WMUE9DX/p1684910046265049)
- 표시가보다 판매가가 큰 경우 할인율과 표시가가 미노출되도록 수정합니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- 할인율이 마이너스 퍼센트로 표시되는 현상을 수정하기 위해 `할인율과 표시가` 표시 조건을 수정합니다. 

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
- as-is
<img width="638" alt="Screenshot 2023-05-24 at 4 04 11 PM" src="https://github.com/titicacadev/triple-frontend/assets/30427711/15f289fc-1454-4e83-81d1-afd8aa18394a">

- to-be
<img width="474" alt="Screenshot 2023-05-24 at 4 19 19 PM" src="https://github.com/titicacadev/triple-frontend/assets/30427711/c09c1a6f-6efc-42e2-871c-639cbe5caebb">
