### PR TITLE
useNavigate에 transitionModalType, appAuthReturnUrl props를 추가합니다

### DIFF
--- a/packages/router/src/navigate/index.ts
+++ b/packages/router/src/navigate/index.ts
@@ -16,7 +16,11 @@ import canonizeTargetAddress from './canonization'
 
 export function useNavigate({
   changeLocationHref = defaultChangeLocationHref,
-}: { changeLocationHref?: (href: string) => void } = {}) {
+  transitionModalType = TransitionType.General,
+}: {
+  changeLocationHref?: (href: string) => void
+  transitionModalType?: TransitionType
+} = {}) {
   const { webUrlBase } = useEnv()
   const sessionAvailable = useSessionAvailability()
   const { show: showTransitionModal } = useTransitionModal()
@@ -37,7 +41,7 @@ export function useNavigate({
         return
       }
 
-      showTransitionModal(TransitionType.General)
+      showTransitionModal(transitionModalType)
     },
     [changeLocationHref, showTransitionModal, webUrlBase],
   )

--- a/packages/router/src/navigate/index.ts
+++ b/packages/router/src/navigate/index.ts
@@ -17,9 +17,11 @@ import canonizeTargetAddress from './canonization'
 export function useNavigate({
   changeLocationHref = defaultChangeLocationHref,
   transitionModalType = TransitionType.General,
+  appAuthReturnUrl,
 }: {
   changeLocationHref?: (href: string) => void
   transitionModalType?: TransitionType
+  appAuthReturnUrl?: string
 } = {}) {
   const { webUrlBase } = useEnv()
   const sessionAvailable = useSessionAvailability()
@@ -60,7 +62,7 @@ export function useNavigate({
         sessionAvailable === false &&
         !checkIfRoutable({ href: canonizedHref })
       ) {
-        showLoginCtaModal()
+        showLoginCtaModal(appAuthReturnUrl)
 
         return
       }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
1. transitionModalType : navigate 안에서 사용하는 transition modal의 이벤트 트래킹 타입을 설정할 수 있도록
useNavigate에 transitionModalType props를 추가합니다.
2.  navigate에서 로그인 후 적용할 수 있는 appAuthReturnUrl props를 추가합니다. ([관련 스레드](https://titicaca.slack.com/archives/C7XGZTMFX/p1687397887257589))

