### PR TITLE
[TFC-97] 호텔 리뷰 개선 - 더보기 UX 개선

### DIFF
--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -41,7 +41,7 @@ export interface ReviewElementProps {
   onUserClick?: ReviewEventHandler
   onUnfoldButtonClick?: ReviewEventHandler
   onMenuClick: ReviewEventHandler
-  onReviewClick: (e: SyntheticEvent, reviewId: string) => void
+  onReviewClick: (e: SyntheticEvent, reviewId: string) => void | boolean
   onMessageCountClick: (e: SyntheticEvent, reviewId: string) => void
   onShow?: (index: number) => void
   reviewRateDescriptions?: string[]
@@ -200,8 +200,10 @@ function ReviewElement({
                 ...(recentTrip && { recent_trip: '최근여행' }),
               },
             })
-            unfolded && setUnfolded(false)
-            onReviewClick(e, review.id)
+            const reviewClickHandled = onReviewClick(e, review.id)
+            if (reviewClickHandled) {
+              unfolded && setUnfolded(false)
+            }
           }}
         >
           {blindedAt ? (

--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -200,6 +200,7 @@ function ReviewElement({
                 ...(recentTrip && { recent_trip: '최근여행' }),
               },
             })
+            unfolded && setUnfolded(false)
             onReviewClick(e, review.id)
           }}
         >

--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -216,6 +216,7 @@ function ReviewElement({
                 comment={comment}
                 hasImage={(media || []).length > 0}
                 onUnfoldButtonClick={(e) => {
+                  e.stopPropagation()
                   trackEvent({
                     ga: ['리뷰_리뷰글더보기_선택'],
                     fa: {

--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -200,8 +200,8 @@ function ReviewElement({
                 ...(recentTrip && { recent_trip: '최근여행' }),
               },
             })
-            const reviewClickHandled = onReviewClick(e, review.id)
-            if (reviewClickHandled) {
+            const reviewClickHandledOnApp = onReviewClick(e, review.id)
+            if (reviewClickHandledOnApp !== false) {
               unfolded && setUnfolded(false)
             }
           }}

--- a/packages/review/src/components/reviews-list.tsx
+++ b/packages/review/src/components/reviews-list.tsx
@@ -107,6 +107,7 @@ export default function ReviewsList({
       },
       [resourceId, navigateReviewDetail, regionId],
     ),
+    true,
   )
 
   const handleMessageCountClick = useAppCallback(

--- a/packages/review/src/components/reviews-list.tsx
+++ b/packages/review/src/components/reviews-list.tsx
@@ -107,7 +107,7 @@ export default function ReviewsList({
       },
       [resourceId, navigateReviewDetail, regionId],
     ),
-    true,
+    false,
   )
 
   const handleMessageCountClick = useAppCallback(

--- a/packages/ui-flow/src/use-app-callback.ts
+++ b/packages/ui-flow/src/use-app-callback.ts
@@ -11,12 +11,12 @@ import { useTripleClientMetadata } from '@titicaca/react-triple-client-interface
  * const invokeNativeFn= useAppCallback(TransitionType.Some, () => {})
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useAppCallback<FN extends (...args: any[]) => any, V>(
+export function useAppCallback<T extends (...args: any[]) => any, V>(
   transitionType: TransitionType,
-  fn: FN,
+  fn: T,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   returnValue?: V,
-): (...args: Parameters<FN>) => ReturnType<FN> | void | V {
+): (...args: Parameters<T>) => ReturnType<T> | void | V {
   const app = useTripleClientMetadata()
   const { show } = useTransitionModal()
 

--- a/packages/ui-flow/src/use-app-callback.ts
+++ b/packages/ui-flow/src/use-app-callback.ts
@@ -11,12 +11,12 @@ import { useTripleClientMetadata } from '@titicaca/react-triple-client-interface
  * const invokeNativeFn= useAppCallback(TransitionType.Some, () => {})
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useAppCallback<T extends (...args: any[]) => any>(
+export function useAppCallback<FN extends (...args: any[]) => any, V>(
   transitionType: TransitionType,
-  fn: T,
+  fn: FN,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  returnValue?: any,
-): (...args: Parameters<T>) => ReturnType<T> | void {
+  returnValue?: V,
+): (...args: Parameters<FN>) => ReturnType<FN> | void | V {
   const app = useTripleClientMetadata()
   const { show } = useTransitionModal()
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

리뷰 더보기 UX 개선했습니다. 
- [지라](https://titicaca.atlassian.net/browse/TFC-97)
- [리뷰개선 기획 위키](https://titicaca.atlassian.net/wiki/spaces/BUS/pages/3164471344) 
- 관련 레포지토리
  - tna-web-v2 https://github.com/titicacadev/tna-web-v2/pull/1310
  - triple-content-web https://github.com/titicacadev/triple-content-web/pull/1152
  - triple-hotels-web https://github.com/titicacadev/triple-hotels-web/pull/2921
  - triple-reviews-web https://github.com/titicacadev/triple-reviews-web/pull/166

## 변경 내역

- '더보기' 클릭 시 이벤트 버블링으로 인해 '리뷰 내용' 클릭 액션이 트리거 되어 리뷰 상세페이지로 이동하던 부분을 수정해 주었습니다. 
- '리뷰 내용'을 클릭하여 리뷰 상세페이지로 이동 시 더보기가 해제되도록 했습니다. 


## 스크린샷 & URL

- TNA 웹 dev 환경에서 확인할 수 있습니다. [[예시 링크](https://triple-dev.titicaca-corp.com/tna/products/0dfbd6fe-6d4f-4168-8e61-a3392a703aee?type=REGION&regionId=3fc342f5-1900-4352-a35c-91080632dbe7&from=hub&openerId=AA5BBD54-C732-42BB-83D8-2DA7577980FB&_triple_no_navbar=true)]
- 스크린샷
  - 웹
![Jun-23-2023 17-16-04](https://github.com/titicacadev/triple-frontend/assets/133629020/e9f56c9c-d095-4b86-936f-28c7cfa85cbe)

  - 앱
https://github.com/titicacadev/triple-frontend/assets/133629020/898cff2b-777c-47c7-8228-f9568e6834d7

## 체크리스트
- [x] dev QA

