### PR TITLE
[triple-document] POI 가격 0원 개선 - 0원일 때 일시품절 텍스트로 노출

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -13,6 +13,7 @@ import { I18nDecorator } from './i18n'
 // Initialize MSW
 initialize({
   onUnhandledRequest: 'bypass',
+  serviceWorker: { url: '/mockServiceWorker.js' },
 })
 
 /** @type { import('@storybook/react').Preview } */

--- a/packages/i18n/src/assets/ja/common-web.ts
+++ b/packages/i18n/src/assets/ja/common-web.ts
@@ -158,6 +158,7 @@ export const jaCommonWeb = {
   'regionname-yeohaeng-junbihareo-gagi': '{{regionName}} 旅行の準備をする',
   'nae-iljeonge-cugahagi': '私の日程に追加',
   'formattedsaleprice-weon': '{{formattedSalePrice}}円',
+  ilsipumjeol: '一時売り切れ',
   'jeojang-formattedscrapscount': '保存{{formattedScrapsCount}}',
   weon: 'ウォン',
   'coedae-geumaeg-cogwa': '最大限度額を超過',

--- a/packages/i18n/src/assets/ko/common-web.ts
+++ b/packages/i18n/src/assets/ko/common-web.ts
@@ -154,6 +154,7 @@ export const koCommonWeb = {
   'regionname-yeohaeng-junbihareo-gagi': '{{regionName}} 여행 준비하러 가기',
   'nae-iljeonge-cugahagi': '내 일정에 추가하기',
   'formattedsaleprice-weon': '{{formattedSalePrice}}원',
+  ilsipumjeol: '일시품절',
   'jeojang-formattedscrapscount': '저장 {{formattedScrapsCount}}',
   weon: '원',
   'coedae-geumaeg-cogwa': '최대 금액 초과',

--- a/packages/i18n/src/assets/zh/common-web.ts
+++ b/packages/i18n/src/assets/zh/common-web.ts
@@ -149,6 +149,7 @@ export const zhCommonWeb = {
   'regionname-yeohaeng-junbihareo-gagi': '準備前往{{regionName}} 的旅行',
   'nae-iljeonge-cugahagi': '新增至我的行程',
   'formattedsaleprice-weon': 'NTW{{formattedSalePrice}}',
+  ilsipumjeol: '暂时缺货',
   'jeojang-formattedscrapscount': '收藏 {{formattedScrapsCount}}',
   weon: 'NTW',
   'coedae-geumaeg-cogwa': '超過最高金額上限',

--- a/packages/triple-document/src/elements/tna/product.tsx
+++ b/packages/triple-document/src/elements/tna/product.tsx
@@ -14,8 +14,8 @@ const PLACEHOLDER_IMAGE_URL =
   'https://assets.triple.guide/images/ico_blank_see@2x.png'
 
 function Pricing({
-  basePrice,
-  salePrice,
+  basePrice, // 판매가
+  salePrice, // 표시가
 }: Parameters<typeof Container>[0] & {
   basePrice?: number
   salePrice: number
@@ -48,11 +48,17 @@ function Pricing({
       ) : null}
 
       <Container>
-        <Text inline bold size={18} color="gray">
-          {t(['formattedsaleprice-weon', '{{formattedSalePrice}}원'], {
-            formattedSalePrice,
-          })}
-        </Text>
+        {salePrice > 0 ? (
+          <Text inline bold size={18} color="gray">
+            {t(['formattedsaleprice-weon', '{{formattedSalePrice}}원'], {
+              formattedSalePrice,
+            })}
+          </Text>
+        ) : (
+          <Text inline bold size={18} color="gray300">
+            {t('ilsipumjeol')}
+          </Text>
+        )}
 
         {basePrice ? (
           <Text

--- a/packages/triple-document/src/mocks/slots.sample.json
+++ b/packages/triple-document/src/mocks/slots.sample.json
@@ -1,113 +1,145 @@
-[
-  {
-    "id": 1561,
-    "title": "에버랜드 예약",
-    "products": [
-      {
-        "id": "cb144134-401d-4450-aa1f-346686cb0f7b",
-        "title": "[경기 용인] 에버랜드+플라이스테이션 패키지★",
-        "tags": [],
-        "salePrice": 116000,
-        "heroImage": "https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/f90fe57e-d2eb-45d2-b204-a652f093e2bf.jpeg",
-        "supplierType": "YANOLJA",
-        "basePrice": 60900,
-        "reviewRating": 0,
-        "reviewsCount": 0,
-        "domesticAreas": [
-          {
-            "id": "4146100000",
-            "name": "경기도 용인시 처인구",
-            "displayName": "경기 용인시",
-            "representative": true
-          },
-          {
-            "id": "4146125000",
-            "name": "경기도 용인시 처인구 포곡읍",
-            "displayName": "용인시 처인구 포곡읍",
-            "representative": false
-          },
-          {
-            "id": "4146000000",
-            "name": "경기도 용인시",
-            "displayName": "경기 용인시",
-            "representative": true
-          },
-          {
-            "id": "4100000000",
-            "name": "경기도",
-            "displayName": "경기",
-            "representative": false
-          }
-        ],
-        "productId": "cb144134-401d-4450-aa1f-346686cb0f7b",
-        "eventTags": [],
-        "orderPrice": 60900,
-        "bestSelfPackageDiscountSpec": {
-          "tripId": 241624,
-          "level": 1,
-          "schedule": {
-            "from": "2022-04-17",
-            "to": "2022-04-19"
-          },
-          "destinations": [
-            {
-              "type": "triple-region",
-              "id": "759174cc-0814-4400-a420-5668a0517edd"
-            }
-          ],
-          "discountPolicy": {
-            "discountRate": 2.0,
-            "maxDiscountAmount": 100000
-          },
-          "token": "token"
+{
+  "id": 1561,
+  "title": "[경기 용인] 에버랜드+플라이스테이션 패키지★",
+  "products": [
+    {
+      "id": "cb144134-401d-4450-aa1f-346686cb0f7b",
+      "title": "[경기 용인] 표시가보다 판매가가 큰 경우 할인율과 표시가가 미노출",
+      "tags": [],
+      "salePrice": 116000,
+      "heroImage": "https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/f90fe57e-d2eb-45d2-b204-a652f093e2bf.jpeg",
+      "supplierType": "YANOLJA",
+      "basePrice": 60900,
+      "reviewRating": 0,
+      "reviewsCount": 0,
+      "domesticAreas": [
+        {
+          "id": "4146100000",
+          "name": "경기도 용인시 처인구",
+          "displayName": "경기 용인시",
+          "representative": true
+        },
+        {
+          "id": "4146125000",
+          "name": "경기도 용인시 처인구 포곡읍",
+          "displayName": "용인시 처인구 포곡읍",
+          "representative": false
+        },
+        {
+          "id": "4146000000",
+          "name": "경기도 용인시",
+          "displayName": "경기 용인시",
+          "representative": true
+        },
+        {
+          "id": "4100000000",
+          "name": "경기도",
+          "displayName": "경기",
+          "representative": false
         }
-      }
-    ]
-  },
-  {
-    "id": 1561,
-    "title": "에버랜드 예약",
-    "products": [
-      {
-        "id": "cb144134-401d-4450-aa1f-346686cb0f7b",
-        "title": "[경기 용인] 에버랜드+플라이스테이션 패키지★",
-        "tags": [],
-        "salePrice": 60900,
-        "heroImage": "https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/f90fe57e-d2eb-45d2-b204-a652f093e2bf.jpeg",
-        "supplierType": "YANOLJA",
-        "basePrice": 116000,
-        "reviewRating": 0,
-        "reviewsCount": 0,
-        "domesticAreas": [
+      ],
+      "productId": "cb144134-401d-4450-aa1f-346686cb0f7b",
+      "eventTags": [],
+      "orderPrice": 60900,
+      "bestSelfPackageDiscountSpec": {
+        "tripId": 241624,
+        "level": 1,
+        "schedule": {
+          "from": "2022-04-17",
+          "to": "2022-04-19"
+        },
+        "destinations": [
           {
-            "id": "4146100000",
-            "name": "경기도 용인시 처인구",
-            "displayName": "경기 용인시",
-            "representative": true
-          },
-          {
-            "id": "4146125000",
-            "name": "경기도 용인시 처인구 포곡읍",
-            "displayName": "용인시 처인구 포곡읍",
-            "representative": false
-          },
-          {
-            "id": "4146000000",
-            "name": "경기도 용인시",
-            "displayName": "경기 용인시",
-            "representative": true
-          },
-          {
-            "id": "4100000000",
-            "name": "경기도",
-            "displayName": "경기",
-            "representative": false
+            "type": "triple-region",
+            "id": "759174cc-0814-4400-a420-5668a0517edd"
           }
         ],
-        "productId": "cb144134-401d-4450-aa1f-346686cb0f7b",
-        "eventTags": [],
-        "orderPrice": 60900
+        "discountPolicy": {
+          "discountRate": 2.0,
+          "maxDiscountAmount": 100000
+        },
+        "token": "token"
       }
-    ]
-  }
-]
+    },
+    {
+      "id": "cb144134-401d-4450-aa1f-346686cb0f7b",
+      "title": "[경기 용인] 표시가보다 판매가가 작은 경우 할인율과 표시가 노출",
+      "tags": [],
+      "salePrice": 60900,
+      "heroImage": "https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/f90fe57e-d2eb-45d2-b204-a652f093e2bf.jpeg",
+      "supplierType": "YANOLJA",
+      "basePrice": 116000,
+      "reviewRating": 0,
+      "reviewsCount": 0,
+      "domesticAreas": [
+        {
+          "id": "4146100000",
+          "name": "경기도 용인시 처인구",
+          "displayName": "경기 용인시",
+          "representative": true
+        },
+        {
+          "id": "4146125000",
+          "name": "경기도 용인시 처인구 포곡읍",
+          "displayName": "용인시 처인구 포곡읍",
+          "representative": false
+        },
+        {
+          "id": "4146000000",
+          "name": "경기도 용인시",
+          "displayName": "경기 용인시",
+          "representative": true
+        },
+        {
+          "id": "4100000000",
+          "name": "경기도",
+          "displayName": "경기",
+          "representative": false
+        }
+      ],
+      "productId": "cb144134-401d-4450-aa1f-346686cb0f7b",
+      "eventTags": [],
+      "orderPrice": 60900
+    },
+    {
+      "id": "cb144134-401d-4450-aa1f-346686cb0f7b",
+      "title": "[경기 용인] 0원일 때 일시품절 텍스트로 노출",
+      "tags": [],
+      "salePrice": 0,
+      "heroImage": "https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/f90fe57e-d2eb-45d2-b204-a652f093e2bf.jpeg",
+      "supplierType": "YANOLJA",
+      "basePrice": 1,
+      "reviewRating": 0,
+      "reviewsCount": 0,
+      "domesticAreas": [
+        {
+          "id": "4146100000",
+          "name": "경기도 용인시 처인구",
+          "displayName": "경기 용인시",
+          "representative": true
+        },
+        {
+          "id": "4146125000",
+          "name": "경기도 용인시 처인구 포곡읍",
+          "displayName": "용인시 처인구 포곡읍",
+          "representative": false
+        },
+        {
+          "id": "4146000000",
+          "name": "경기도 용인시",
+          "displayName": "경기 용인시",
+          "representative": true
+        },
+        {
+          "id": "4100000000",
+          "name": "경기도",
+          "displayName": "경기",
+          "representative": false
+        }
+      ],
+      "productId": "cb144134-401d-4450-aa1f-346686cb0f7b",
+      "eventTags": [],
+      "orderPrice": 60900
+    }
+  ]
+}

--- a/packages/triple-document/src/mocks/slots.sample.json
+++ b/packages/triple-document/src/mocks/slots.sample.json
@@ -108,7 +108,7 @@
       "salePrice": 0,
       "heroImage": "https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/f90fe57e-d2eb-45d2-b204-a652f093e2bf.jpeg",
       "supplierType": "YANOLJA",
-      "basePrice": 1,
+      "basePrice": 0,
       "reviewRating": 0,
       "reviewsCount": 0,
       "domesticAreas": [

--- a/packages/triple-document/src/tna-slot.stories.tsx
+++ b/packages/triple-document/src/tna-slot.stories.tsx
@@ -1,8 +1,9 @@
 import { Meta } from '@storybook/react'
+import { ScrapsProvider } from '@titicaca/react-contexts'
+import { rest } from 'msw'
 
 import SLOTS from './mocks/slots.sample.json'
 import ELEMENTS from './elements'
-import { Slot } from './elements/tna/slot'
 
 const { tnaProducts: TnaProducts } = ELEMENTS
 
@@ -13,19 +14,22 @@ export default {
 
 export function InTripleDocument() {
   return (
-    <TnaProducts
-      value={{
-        slotId: 1546,
-      }}
-    />
+    <ScrapsProvider>
+      <TnaProducts
+        value={{
+          slotId: 1546,
+        }}
+      />
+    </ScrapsProvider>
   )
 }
 InTripleDocument.storyName = 'Triple-document에 포함된 Slot'
-
-export function Slots() {
-  return SLOTS.map((slot, i) => (
-    <Slot key={i} id={slot.id} title={slot.title} products={slot.products} />
-  ))
+InTripleDocument.parameters = {
+  msw: {
+    handlers: [
+      rest.get('/api/tna-v2/slots/:slotId', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(SLOTS))
+      }),
+    ],
+  },
 }
-
-Slots.storyName = 'Slots'


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
- [지라](https://titicaca.atlassian.net/browse/TNA-5591)

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- msw가 설정되어 있길래 triple-documet의 tna-slot 부분에 적용하고 중복 삭제했습니다.
- 0원일 때 일시품절 텍스트로 노출되도록 수정합니다.

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
- [x] dev 확인 완료

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
- [dev](https://triple-dev.titicaca-corp.com/attractions/a86a3f55-9f89-4540-a124-f8c4db07ab34)