### PR TITLE
feat: debounce에 leading, trailing 옵션 추가

### DIFF
--- a/packages/view-utilities/src/debounce.ts
+++ b/packages/view-utilities/src/debounce.ts
@@ -1,12 +1,30 @@
+interface Option {
+  leading?: boolean
+  trailing?: boolean
+}
+
 export function debounce<Params extends unknown[]>(
   func: (...args: Params) => unknown,
   timeout: number,
+  option?: Option,
 ): (...args: Params) => void {
   let timer: ReturnType<typeof setTimeout>
+  let leadingCall = option?.leading ?? false
+  const trailing = option?.trailing ?? true
+
   return (...args: Params) => {
+    if (!timer && leadingCall) {
+      func(...args)
+    }
+
     clearTimeout(timer)
     timer = setTimeout(() => {
-      func(...args)
+      if (trailing || !leadingCall) {
+        func(...args)
+      }
+      if (leadingCall) {
+        leadingCall = false
+      }
     }, timeout)
   }
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

debounce에 `leading`, `trailing` 옵션을 추가했습니다.

## 변경 내역

- as-is: `trailing` 으로 동작
- to-be: 세 번째 인자로 `{ leading: boolean, trailing: boolean }` 옵션을 명시하여 debounce 실행 시점을 컨트롤 할 수 있습니다. 기본 옵션은 `{ leading: false, trailing: true }`입니다.
