### PR TITLE
triple-document 쿠폰 개선

### DIFF
--- a/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
+++ b/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
@@ -95,11 +95,15 @@ async function downloadCoupon(slugId: string) {
 
 export function CouponDownloadButton({
   slugId,
+  textColor,
+  backgroundColor,
   verificationType,
   enabledAt,
   onClick,
 }: {
   slugId: string
+  textColor?: string
+  backgroundColor?: string
   verificationType?: VerificationType
   enabledAt?: string
   onClick?: () => void
@@ -188,6 +192,7 @@ export function CouponDownloadButton({
   return (
     <>
       <BaseCouponDownloadButton
+        css={{ color: textColor, backgroundColor }}
         disabled={buttonDisabled}
         onClick={handleCouponDownloadButtonClick}
       >
@@ -255,11 +260,15 @@ async function downloadCoupons(coupons: CouponData[]) {
 
 export function CouponGroupDownloadButton({
   groupId,
+  textColor,
+  backgroundColor,
   verificationType,
   enabledAt,
   onClick,
 }: {
   groupId: string
+  textColor?: string
+  backgroundColor?: string
   verificationType?: VerificationType
   enabledAt?: string
   onClick?: () => void
@@ -356,6 +365,7 @@ export function CouponGroupDownloadButton({
   return (
     <>
       <BaseCouponDownloadButton
+        css={{ color: textColor, backgroundColor }}
         disabled={buttonDisabled}
         onClick={handleCouponDownloadButtonClick}
       >

--- a/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
+++ b/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
@@ -40,6 +40,11 @@ const BaseCouponDownloadButton = styled(Button)`
 
 const MAX_COUPONS_PER_USER_ERROR_CODE = 'MAX_COUPONS_PER_USER'
 
+export const DEFAULT_BUTTON_COLOR = {
+  background: '#368fff',
+  text: '#ffffff',
+}
+
 function useDownloadTimePassed(time: string | undefined) {
   const calculator = useCallback(() => {
     return (
@@ -95,8 +100,8 @@ async function downloadCoupon(slugId: string) {
 
 export function CouponDownloadButton({
   slugId,
-  textColor,
-  backgroundColor,
+  textColor = DEFAULT_BUTTON_COLOR.text,
+  backgroundColor = DEFAULT_BUTTON_COLOR.background,
   verificationType,
   enabledAt,
   onClick,
@@ -260,8 +265,8 @@ async function downloadCoupons(coupons: CouponData[]) {
 
 export function CouponGroupDownloadButton({
   groupId,
-  textColor,
-  backgroundColor,
+  textColor = DEFAULT_BUTTON_COLOR.text,
+  backgroundColor = DEFAULT_BUTTON_COLOR.background,
   verificationType,
   enabledAt,
   onClick,

--- a/packages/triple-document/src/elements/coupon/index.tsx
+++ b/packages/triple-document/src/elements/coupon/index.tsx
@@ -9,7 +9,14 @@ import { CouponModal } from './modals'
 import {
   CouponDownloadButton,
   CouponGroupDownloadButton,
+  DEFAULT_BUTTON_COLOR,
 } from './coupon-download-buttons'
+
+const DEFAULT_COLOR = {
+  buttonText: DEFAULT_BUTTON_COLOR.text,
+  buttonBackground: DEFAULT_BUTTON_COLOR.background,
+  description: '#3a3a3a80',
+}
 
 export default function Coupon({
   value: {
@@ -18,11 +25,7 @@ export default function Coupon({
     verificationType,
     couponType = 'single',
     enabledAt,
-    color = {
-      buttonBackground: '#368fff',
-      buttonText: '#ffffff',
-      description: '#3a3a3a80',
-    },
+    color = DEFAULT_COLOR,
   },
 }: {
   value: {
@@ -87,7 +90,7 @@ export default function Coupon({
 
       {description ? (
         <Text
-          css={{ color: color.description }}
+          css={{ color: color.description || DEFAULT_COLOR.description }}
           margin={{ top: 13 }}
           lineHeight={1.46}
           size="tiny"

--- a/packages/triple-document/src/elements/coupon/index.tsx
+++ b/packages/triple-document/src/elements/coupon/index.tsx
@@ -18,6 +18,11 @@ export default function Coupon({
     verificationType,
     couponType = 'single',
     enabledAt,
+    color = {
+      buttonBackground: '#368fff',
+      buttonText: '#ffffff',
+      description: '#3a3a3a80',
+    },
   },
 }: {
   value: {
@@ -26,6 +31,12 @@ export default function Coupon({
     verificationType?: VerificationType
     couponType?: 'single' | 'group'
     enabledAt?: string
+    color?: {
+      background?: string
+      buttonText?: string
+      buttonBackground?: string
+      description?: string
+    }
   }
 }) {
   const trackEventWithMetadata = useEventTrackerWithMetadata()
@@ -50,7 +61,8 @@ export default function Coupon({
   return (
     <Container
       css={{
-        margin: '44px 30px 42px',
+        padding: '44px 30px 42px',
+        backgroundColor: color.background,
       }}
     >
       {couponType === 'single' ? (
@@ -59,6 +71,8 @@ export default function Coupon({
           slugId={identifier}
           enabledAt={enabledAt}
           onClick={handleCouponClick}
+          textColor={color.buttonText}
+          backgroundColor={color.buttonBackground}
         />
       ) : (
         <CouponGroupDownloadButton
@@ -66,13 +80,14 @@ export default function Coupon({
           groupId={identifier}
           enabledAt={enabledAt}
           onClick={handleCouponClick}
+          textColor={color.buttonText}
+          backgroundColor={color.buttonBackground}
         />
       )}
 
       {description ? (
         <Text
-          color="gray"
-          alpha={0.5}
+          css={{ color: color.description }}
           margin={{ top: 13 }}
           lineHeight={1.46}
           size="tiny"

--- a/packages/triple-document/src/index.ts
+++ b/packages/triple-document/src/index.ts
@@ -7,7 +7,7 @@ export { generateCoupon } from './elements/tna/helpers'
 export { Slot } from './elements/tna/slot'
 export { PricePolicyCouponInfo } from './elements/tna/price-policy-coupon-info'
 
-export { DeepLinkProvider, useDeepLink } from './prop-context/deep-link'
+export { useDeepLink } from './prop-context/deep-link'
 export { useImageClickHandler } from './prop-context/image-click-handler'
 export { useImageSource } from './prop-context/image-source'
 export { useLinkClickHandler } from './prop-context/link-click-handler'

--- a/packages/triple-document/src/index.ts
+++ b/packages/triple-document/src/index.ts
@@ -7,7 +7,7 @@ export { generateCoupon } from './elements/tna/helpers'
 export { Slot } from './elements/tna/slot'
 export { PricePolicyCouponInfo } from './elements/tna/price-policy-coupon-info'
 
-export { useDeepLink } from './prop-context/deep-link'
+export { DeepLinkProvider, useDeepLink } from './prop-context/deep-link'
 export { useImageClickHandler } from './prop-context/image-click-handler'
 export { useImageSource } from './prop-context/image-source'
 export { useLinkClickHandler } from './prop-context/link-click-handler'

--- a/packages/triple-document/src/triple-document.stories.tsx
+++ b/packages/triple-document/src/triple-document.stories.tsx
@@ -1,8 +1,10 @@
+import { rest } from 'msw'
 import { useEffect } from 'react'
-import { Meta } from '@storybook/react'
+import { Meta, StoryObj } from '@storybook/react'
 import { useScrollToAnchor } from '@titicaca/react-hooks'
 import { Container } from '@titicaca/core-elements'
 
+import { DeepLinkProvider } from './prop-context/deep-link'
 import MOCK_REGIONS from './mocks/triple-document.regions.json'
 import MOCK_EMBEDDED from './mocks/triple-document.embedded.json'
 import MOCK_ITINERARY from './mocks/triple-document.itinerary.json'
@@ -20,25 +22,27 @@ const {
   embedded: Embedded,
   anchor: Anchor,
   itinerary: Itinerary,
+  coupon: Coupon,
 } = ELEMENTS
 
 export default {
   title: 'triple-document / TripleDocument',
 } as Meta
 
-export function Sample() {
-  return (
+export const Sample: StoryObj<typeof TripleDocument> = {
+  name: '샘플',
+  render: () => (
     <Container centered css={{ maxWidth: 768 }}>
       <TripleDocument>
         {SAMPLE as TripleElementData<string, unknown>[]}
       </TripleDocument>
     </Container>
-  )
+  ),
 }
-Sample.storyName = '샘플'
 
-export function TextExample() {
-  return (
+export const TextExample: StoryObj<typeof Text> = {
+  name: '텍스트',
+  render: () => (
     <>
       <Text value={{ text: '텍스트: medium 16 80%' }} />
       <Text
@@ -48,89 +52,138 @@ export function TextExample() {
       />
       <Text bold value={{ text: '강조 텍스트: bold 16 100%' }} alpha={1} />
     </>
-  )
-}
-TextExample.storyName = '텍스트'
-
-export function NoteExample() {
-  return (
-    <Note
-      value={{
-        body: '목적지로 바로 가지 않고, 중간 지점에서 잠시 머무는 단기 체류를 뜻한다. 보통 경유 시간인 3-4시간 정도가 아니라 24시간 이상을 뜻하기 때문에 관광과 숙박이 가능한 것이 특징. 일부 항공사는 스탑오버시 무료 관광을 제공하니 참고할것!',
-        title: '잠깐! 스탑오버(Stopover)란?',
-      }}
-    />
-  )
-}
-NoteExample.storyName = '노트'
-
-export function VideoExample() {
-  return (
-    <Video
-      value={{
-        provider: 'youtube',
-        identifier: 'hYIe4VrfHoA',
-      }}
-    />
-  )
-}
-VideoExample.storyName = '비디오'
-
-export function TableExample() {
-  return (
-    <Table
-      value={{
-        table: {
-          type: 'horizontal',
-          head: [{ text: '취소 시점' }, { text: '취소 수수료' }],
-          body: [
-            [{ text: '구매 당일 (No-show 제외)' }, { text: '0원' }],
-            [{ text: '구매 익일 ~ 출발 61일 전' }, { text: '1,000원' }],
-            [{ text: '출발 60일 전 ~ 출발 31일 전' }, { text: '3,000원' }],
-            [{ text: '출발 30일 전 ~ 출발 8일 전' }, { text: '4,000원' }],
-            [{ text: '출발 7일 전 ~ 출발 2일 전' }, { text: '6,000원' }],
-            [{ text: '출발 1일 전 ~ 출발시간 전' }, { text: '12,000원' }],
-            [{ text: '출발시간 이후 (No-show)' }, { text: '15,000원' }],
-          ],
-        },
-      }}
-    />
-  )
-}
-TableExample.storyName = '표'
-
-export function Region() {
-  return <Regions value={{ regions: MOCK_REGIONS }} />
-}
-Region.storyName = '리전'
-
-export function EmbeddedExample() {
-  return <Embedded value={MOCK_EMBEDDED} />
-}
-EmbeddedExample.storyName = '임베딩'
-
-export function AnchorExample() {
-  useEffect(() => {
-    window.history.pushState(null, '', '#android')
-  }, [])
-
-  useScrollToAnchor({ delayTime: 0 })
-
-  return (
-    <div>
-      <div style={{ height: '200vh' }} />
-      <div>Android</div>
-      <Anchor value={{ href: 'android' }} />
-      <div style={{ height: '200vh' }} />
-      <div>ios</div>
-      <Anchor value={{ href: 'ios' }} />
-    </div>
-  )
-}
-AnchorExample.storyName = 'Anchor'
-
-export function DocumentItinerary() {
-  return <Itinerary value={MOCK_ITINERARY.article.source.body[1].value} />
+  ),
 }
 
-DocumentItinerary.storyName = '추천코스 기본'
+export const NoteExample: StoryObj<typeof Note> = {
+  name: '노트',
+  render: (args) => <Note value={args.value} />,
+  args: {
+    value: {
+      body: '목적지로 바로 가지 않고, 중간 지점에서 잠시 머무는 단기 체류를 뜻한다. 보통 경유 시간인 3-4시간 정도가 아니라 24시간 이상을 뜻하기 때문에 관광과 숙박이 가능한 것이 특징. 일부 항공사는 스탑오버시 무료 관광을 제공하니 참고할것!',
+      title: '잠깐! 스탑오버(Stopover)란?',
+    },
+  },
+}
+
+export const VideoExample: StoryObj<typeof Video> = {
+  name: '비디오',
+  render: (args) => <Video value={args.value} />,
+  args: {
+    value: {
+      provider: 'youtube',
+      identifier: 'hYIe4VrfHoA',
+    },
+  },
+}
+
+export const TableExample: StoryObj<typeof Table> = {
+  name: '표',
+  render: (args) => <Table value={args.value} />,
+  args: {
+    value: {
+      table: {
+        type: 'horizontal',
+        head: [{ text: '취소 시점' }, { text: '취소 수수료' }],
+        body: [
+          [{ text: '구매 당일 (No-show 제외)' }, { text: '0원' }],
+          [{ text: '구매 익일 ~ 출발 61일 전' }, { text: '1,000원' }],
+          [{ text: '출발 60일 전 ~ 출발 31일 전' }, { text: '3,000원' }],
+          [{ text: '출발 30일 전 ~ 출발 8일 전' }, { text: '4,000원' }],
+          [{ text: '출발 7일 전 ~ 출발 2일 전' }, { text: '6,000원' }],
+          [{ text: '출발 1일 전 ~ 출발시간 전' }, { text: '12,000원' }],
+          [{ text: '출발시간 이후 (No-show)' }, { text: '15,000원' }],
+        ],
+      },
+    },
+  },
+}
+
+export const RegionExample: StoryObj<typeof Regions> = {
+  name: '리전',
+  render: (args) => <Regions value={args.value} />,
+  args: {
+    value: MOCK_REGIONS,
+  },
+}
+
+export const EmbeddedExample: StoryObj<typeof Embedded> = {
+  name: '임베딩',
+  render: (args) => <Embedded value={args.value} />,
+  args: {
+    value: MOCK_EMBEDDED,
+  },
+}
+
+export const AnchorExample: StoryObj<typeof Anchor> = {
+  name: '앵커',
+  render: function Render() {
+    useEffect(() => {
+      window.history.pushState(null, '', '#android')
+    }, [])
+
+    useScrollToAnchor({ delayTime: 0 })
+
+    return (
+      <div>
+        <div style={{ height: '200vh' }} />
+        <div>Android</div>
+        <Anchor value={{ href: 'android' }} />
+        <div style={{ height: '200vh' }} />
+        <div>ios</div>
+        <Anchor value={{ href: 'ios' }} />
+      </div>
+    )
+  },
+}
+
+export const DocumentItinerary: StoryObj<typeof Itinerary> = {
+  name: '추천코스 기본',
+  render: (args) => <Itinerary value={args.value} />,
+  args: {
+    value: MOCK_ITINERARY.article.source.body[1].value,
+  },
+}
+
+export const CouponExample: StoryObj<typeof Coupon> = {
+  name: '쿠폰',
+  render: (args) => (
+    <DeepLinkProvider value="https://triple-dev.onelink.me">
+      <Coupon value={args.value} />
+    </DeepLinkProvider>
+  ),
+  args: {
+    value: {
+      identifier: 'TEST_IDENTIFIER',
+      description:
+        '쿠폰은 최초 1회만 지급되며, 이미 쿠폰을 받았다면  ‘쿠폰함’에서 확인 할 수 있습니다.',
+      enabledAt: '2023-07-03',
+      color: {
+        background: undefined,
+        buttonBackground: '#368fff',
+        buttonText: '#ffffff',
+        description: '#3a3a3a80',
+      },
+    },
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get('/api/benefit/coupons/:id', (req, res, ctx) => {
+          return res(
+            ctx.json({
+              downloaded: true,
+            }),
+          )
+        }),
+        rest.get('/api/users/smscert', (req, res, ctx) => {
+          return res(
+            ctx.json({
+              verified: true,
+            }),
+          )
+        }),
+      ],
+    },
+  },
+}

--- a/packages/triple-document/src/triple-document.stories.tsx
+++ b/packages/triple-document/src/triple-document.stories.tsx
@@ -103,7 +103,7 @@ export const RegionExample: StoryObj<typeof Regions> = {
   name: '리전',
   render: (args) => <Regions value={args.value} />,
   args: {
-    value: MOCK_REGIONS,
+    value: { regions: MOCK_REGIONS },
   },
 }
 


### PR DESCRIPTION
## PR 설명

쿠폰 엘리먼트의 구성요소 색상을 변경할 수 있는 옵션을 제공합니다.

## 변경 내역

- color 옵션이 주어지지 않으면 DEFAULT_COLOR 를 사용합니다.
- coupon 스토리를 추가합니다.
- triple-document 스토리를 CSF3 형식으로 변경합니다.

## 스크린샷

아티클 어드민 사용 예시

https://github.com/titicacadev/triple-frontend/assets/37819666/ece005f3-eae3-4eb2-a4dc-0cc98a11adb3

