### PR TITLE
egjs flicking.css import 이슈

### DIFF
--- a/packages/ad-banners/src/flicking.css
+++ b/packages/ad-banners/src/flicking.css
@@ -1,0 +1,44 @@
+.flicking-viewport {
+  position: relative;
+  overflow: hidden;
+}
+
+.flicking-viewport.vertical {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.flicking-viewport.vertical > .flicking-camera {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.flicking-viewport.flicking-hidden > .flicking-camera > * {
+  visibility: hidden;
+}
+
+.flicking-camera {
+  width: 100%;
+  height: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  z-index: 1;
+  will-change: transform;
+}
+
+.flicking-camera > * {
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}

--- a/packages/ad-banners/src/horizontal-list-view.tsx
+++ b/packages/ad-banners/src/horizontal-list-view.tsx
@@ -8,7 +8,7 @@ import { Banner } from './typing'
 import HorizontalEntity from './horizontal-entity'
 import ListSection from './list-section'
 
-// import '@egjs/react-flicking/dist/flicking.css'
+import './flicking.css'
 
 interface HorizontalListViewProps {
   banners: Banner[]

--- a/packages/ad-banners/src/horizontal-list-view.tsx
+++ b/packages/ad-banners/src/horizontal-list-view.tsx
@@ -8,7 +8,7 @@ import { Banner } from './typing'
 import HorizontalEntity from './horizontal-entity'
 import ListSection from './list-section'
 
-import '@egjs/react-flicking/dist/flicking.css'
+// import '@egjs/react-flicking/dist/flicking.css'
 
 interface HorizontalListViewProps {
   banners: Banner[]

--- a/packages/carousel/src/carousel.tsx
+++ b/packages/carousel/src/carousel.tsx
@@ -12,7 +12,7 @@ import Flicking, { FlickingProps, FlickingOptions } from '@egjs/react-flicking'
 
 import CarouselItem from './carousel-item'
 
-// import '@egjs/react-flicking/dist/flicking.css'
+import './flicking.css'
 
 interface CarouselBaseProps {
   margin?: MarginPadding

--- a/packages/carousel/src/carousel.tsx
+++ b/packages/carousel/src/carousel.tsx
@@ -12,7 +12,7 @@ import Flicking, { FlickingProps, FlickingOptions } from '@egjs/react-flicking'
 
 import CarouselItem from './carousel-item'
 
-import '@egjs/react-flicking/dist/flicking.css'
+// import '@egjs/react-flicking/dist/flicking.css'
 
 interface CarouselBaseProps {
   margin?: MarginPadding

--- a/packages/carousel/src/carousel.tsx
+++ b/packages/carousel/src/carousel.tsx
@@ -8,11 +8,7 @@ import {
   marginMixin,
   formatMarginPadding,
 } from '@titicaca/core-elements'
-import Flicking, {
-  FlickingProps,
-  FlickingOptions,
-  MOVE_TYPE,
-} from '@egjs/react-flicking'
+import Flicking, { FlickingProps, FlickingOptions } from '@egjs/react-flicking'
 
 import CarouselItem from './carousel-item'
 
@@ -85,7 +81,7 @@ const FLICK_ATTRIBUTES: Partial<FlickingProps & FlickingOptions> = {
   hanger: '50%',
   anchor: '50%',
   gap: 10,
-  moveType: [MOVE_TYPE.SNAP, { count: 1 }],
+  moveType: ['snap', { count: 1 }],
   collectStatistics: false,
   zIndex: 50,
   classPrefix: 'eg-flick',

--- a/packages/carousel/src/flicking.css
+++ b/packages/carousel/src/flicking.css
@@ -1,0 +1,44 @@
+.flicking-viewport {
+  position: relative;
+  overflow: hidden;
+}
+
+.flicking-viewport.vertical {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.flicking-viewport.vertical > .flicking-camera {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.flicking-viewport.flicking-hidden > .flicking-camera > * {
+  visibility: hidden;
+}
+
+.flicking-camera {
+  width: 100%;
+  height: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  z-index: 1;
+  will-change: transform;
+}
+
+.flicking-camera > * {
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}

--- a/packages/image-carousel/src/flicking.css
+++ b/packages/image-carousel/src/flicking.css
@@ -1,0 +1,44 @@
+.flicking-viewport {
+  position: relative;
+  overflow: hidden;
+}
+
+.flicking-viewport.vertical {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.flicking-viewport.vertical > .flicking-camera {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.flicking-viewport.flicking-hidden > .flicking-camera > * {
+  visibility: hidden;
+}
+
+.flicking-camera {
+  width: 100%;
+  height: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  z-index: 1;
+  will-change: transform;
+}
+
+.flicking-camera > * {
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}

--- a/packages/image-carousel/src/image-carousel.tsx
+++ b/packages/image-carousel/src/image-carousel.tsx
@@ -8,7 +8,7 @@ import { CarouselImageMeta, RendererParams } from './types'
 import { PageLabel } from './page-label'
 import Content from './content'
 
-// import '@egjs/react-flicking/dist/flicking.css'
+import './flicking.css'
 
 interface ImageCarouselProps extends Omit<CarouselProps, 'pageLabelRenderer'> {
   images: CarouselImageMeta[]

--- a/packages/image-carousel/src/image-carousel.tsx
+++ b/packages/image-carousel/src/image-carousel.tsx
@@ -8,7 +8,7 @@ import { CarouselImageMeta, RendererParams } from './types'
 import { PageLabel } from './page-label'
 import Content from './content'
 
-import '@egjs/react-flicking/dist/flicking.css'
+// import '@egjs/react-flicking/dist/flicking.css'
 
 interface ImageCarouselProps extends Omit<CarouselProps, 'pageLabelRenderer'> {
   images: CarouselImageMeta[]


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

WIP

Next.js 에서 node_modules 의 css 를 import 할 수 없음

<img width="781" alt="스크린샷 2023-07-06 오전 11 06 30" src="https://github.com/titicacadev/triple-frontend/assets/37819666/71988381-6bf0-42fc-875a-82f3f74db2ab">

Try1.
next.config.js 의 transpilePackages 로 모듈 컴파일해서 불러오기
-> build 시에 css 파싱에러 발생

Try2.
_app.tsx 에서 CDN link 불러오고 컴포넌트에서 css import 제거
-> css 제대로 적용 안됨, 가능하더라도 컴포넌트 단위에서 css 미적용 이슈 있음

Try3.
flicking.css 를 직접 복사해서 컴포넌트내에서 참조
-> 버전 바뀔때마다 매번 추가해줄 수 없음.. 다른 방법 필요

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
