### PR TITLE
/api/users/me의 타입을 최신화합니다.

### DIFF
--- a/packages/react-contexts/src/session-context/browser.tsx
+++ b/packages/react-contexts/src/session-context/browser.tsx
@@ -14,7 +14,7 @@ import { generateUrl } from '@titicaca/view-utilities'
 import qs from 'qs'
 import Cookies from 'universal-cookie'
 
-import { User, UserProvider, useUserState } from './user'
+import { GET_USER_REQUEST_URL, User, UserProvider, useUserState } from './user'
 import {
   SessionControllerContext,
   SessionAvailabilityContext,
@@ -90,7 +90,7 @@ InBrowserSessionContextProvider.getInitialProps = async function ({
             refresh: () => post('/api/users/web-session/token'),
           })
 
-    const response = await finalFetcher<User>('/api/users/me')
+    const response = await finalFetcher<User>(GET_USER_REQUEST_URL)
 
     if (response === 'NEED_LOGIN') {
       return undefined

--- a/packages/react-contexts/src/session-context/user.ts
+++ b/packages/react-contexts/src/session-context/user.ts
@@ -1,7 +1,26 @@
 import { createContext, useCallback, useContext, useState } from 'react'
 
 export interface User {
+  name: string
+  provider: Provider
+  country: string
+  lang: string
+  unregister: boolean | null
+  photo: string
+  mileage: Mileage
   uid: string
+}
+
+type Provider = 'TRIPLE' | 'NAVER' | 'KAKAO' | 'FACEBOOK' | 'APPLE'
+
+interface Mileage {
+  badges: {
+    icon: {
+      imageUrl: string
+    }
+  }[]
+  level: number
+  point: number
 }
 
 export const GET_USER_REQUEST_URL = '/api/users/me'


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- `/api/users/me` API 응답 type을 최신화합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 추후 작업
- User타입을 type-definitions 패키지로 옮겨 공통화 관리