### PR TITLE
[TFC-52] 트리플 헤더 블링크 이슈

### DIFF
--- a/packages/triple-header/package.json
+++ b/packages/triple-header/package.json
@@ -44,7 +44,7 @@
     "@titicaca/router": "workspace:*",
     "@titicaca/standard-action-handler": "workspace:*",
     "@titicaca/type-definitions": "workspace:*",
-    "framer-motion": "^10.16.12"
+    "framer-motion": "^10.16.9"
   },
   "devDependencies": {
     "@titicaca/i18n": "workspace:*",

--- a/packages/triple-header/package.json
+++ b/packages/triple-header/package.json
@@ -44,7 +44,7 @@
     "@titicaca/router": "workspace:*",
     "@titicaca/standard-action-handler": "workspace:*",
     "@titicaca/type-definitions": "workspace:*",
-    "framer-motion": "^7.10.3"
+    "framer-motion": "^10.16.5"
   },
   "devDependencies": {
     "@titicaca/i18n": "workspace:*",

--- a/packages/triple-header/package.json
+++ b/packages/triple-header/package.json
@@ -44,7 +44,7 @@
     "@titicaca/router": "workspace:*",
     "@titicaca/standard-action-handler": "workspace:*",
     "@titicaca/type-definitions": "workspace:*",
-    "framer-motion": "^10.16.5"
+    "framer-motion": "^10.16.12"
   },
   "devDependencies": {
     "@titicaca/i18n": "workspace:*",

--- a/packages/triple-header/src/frame/effects/common.ts
+++ b/packages/triple-header/src/frame/effects/common.ts
@@ -16,7 +16,8 @@ const COMMON_TRANSITION = {
 export function generateTransition<T>(
   initialOptions: T & InitialEffectOptions,
 ) {
-  const { infinity, repeatType, ...options } = initialOptions
+  const { infinity, repeatType, index, totalFramesCount, ...options } =
+    initialOptions
 
   const transition = {
     ...COMMON_TRANSITION,
@@ -25,6 +26,8 @@ export function generateTransition<T>(
     ...(repeatType && {
       repeatType,
     }),
+    ...(index && { delay: 3 * index }),
+    ...(totalFramesCount && { repeatDelay: 3 * (totalFramesCount - 1) }),
   }
 
   return transition

--- a/packages/triple-header/src/frame/effects/common.ts
+++ b/packages/triple-header/src/frame/effects/common.ts
@@ -15,13 +15,13 @@ const COMMON_TRANSITION = {
 
 export function generateTransition(
   initialOptions: InitialEffectOptions & { duration?: number },
+  index: number,
+  totalFramesCount: number,
 ) {
   const {
     infinity,
     repeatType,
     duration = COMMON_TRANSITION.duration,
-    index,
-    totalFramesCount,
     ...options
   } = initialOptions
 

--- a/packages/triple-header/src/frame/effects/common.ts
+++ b/packages/triple-header/src/frame/effects/common.ts
@@ -13,11 +13,17 @@ const COMMON_TRANSITION = {
   duration: 3,
 }
 
-export function generateTransition<T>(
-  initialOptions: T & InitialEffectOptions,
+export function generateTransition(
+  initialOptions: InitialEffectOptions & { duration?: number },
 ) {
-  const { infinity, repeatType, index, totalFramesCount, ...options } =
-    initialOptions
+  const {
+    infinity,
+    repeatType,
+    duration = COMMON_TRANSITION.duration,
+    index,
+    totalFramesCount,
+    ...options
+  } = initialOptions
 
   const transition = {
     ...COMMON_TRANSITION,
@@ -26,8 +32,10 @@ export function generateTransition<T>(
     ...(repeatType && {
       repeatType,
     }),
-    ...(index && { delay: 3 * index }),
-    ...(totalFramesCount && { repeatDelay: 3 * (totalFramesCount - 1) }),
+    ...(index && { delay: COMMON_TRANSITION.duration * index }),
+    ...(totalFramesCount && {
+      repeatDelay: COMMON_TRANSITION.duration * totalFramesCount - duration,
+    }),
   }
 
   return transition

--- a/packages/triple-header/src/frame/effects/common.ts
+++ b/packages/triple-header/src/frame/effects/common.ts
@@ -13,8 +13,8 @@ const COMMON_TRANSITION = {
   duration: 3,
 }
 
-export function generateTransition(
-  initialOptions: InitialEffectOptions & { duration?: number },
+export function generateTransition<T>(
+  initialOptions: T & InitialEffectOptions & { duration?: number },
   index: number,
   totalFramesCount: number,
 ) {
@@ -27,6 +27,7 @@ export function generateTransition(
 
   const transition = {
     ...COMMON_TRANSITION,
+    duration,
     ...options,
     ...(infinity && { repeat: Infinity }),
     ...(repeatType && {

--- a/packages/triple-header/src/frame/effects/common.ts
+++ b/packages/triple-header/src/frame/effects/common.ts
@@ -16,7 +16,7 @@ const COMMON_TRANSITION = {
 export function generateTransition<T>(
   initialOptions: T & InitialEffectOptions & { duration?: number },
   index: number,
-  totalFramesCount: number,
+  frameCount: number,
 ) {
   const {
     infinity,
@@ -34,8 +34,8 @@ export function generateTransition<T>(
       repeatType,
     }),
     ...(index && { delay: COMMON_TRANSITION.duration * index }),
-    ...(totalFramesCount && {
-      repeatDelay: COMMON_TRANSITION.duration * totalFramesCount - duration,
+    ...(frameCount && {
+      repeatDelay: COMMON_TRANSITION.duration * frameCount - duration,
     }),
   }
 

--- a/packages/triple-header/src/frame/effects/flying.tsx
+++ b/packages/triple-header/src/frame/effects/flying.tsx
@@ -12,13 +12,10 @@ type ExtendedEffectOptions = InitialEffectOptions & {
 export type FlyingEffect = { type: 'flying' } & FlyingProps
 
 interface FlyingProps {
-  options?: ExtendedEffectOptions
+  options: ExtendedEffectOptions
 }
 
-export function Flying({
-  children,
-  options = {},
-}: PropsWithChildren<FlyingProps>) {
+export function Flying({ children, options }: PropsWithChildren<FlyingProps>) {
   const transition = generateTransition({ ...options, duration: 0.3 })
 
   return (

--- a/packages/triple-header/src/frame/effects/flying.tsx
+++ b/packages/triple-header/src/frame/effects/flying.tsx
@@ -9,14 +9,28 @@ type ExtendedEffectOptions = InitialEffectOptions & {
   degree?: number
 }
 
-export type FlyingEffect = { type: 'flying' } & FlyingProps
+export type FlyingEffect = { type: 'flying' } & Omit<
+  FlyingProps,
+  'index' | 'totalFramesCount'
+>
 
 interface FlyingProps {
-  options: ExtendedEffectOptions
+  options?: ExtendedEffectOptions
+  index: number
+  totalFramesCount: number
 }
 
-export function Flying({ children, options }: PropsWithChildren<FlyingProps>) {
-  const transition = generateTransition({ ...options, duration: 0.3 })
+export function Flying({
+  children,
+  options = {},
+  index,
+  totalFramesCount,
+}: PropsWithChildren<FlyingProps>) {
+  const transition = generateTransition(
+    { ...options, duration: 0.3 },
+    index,
+    totalFramesCount,
+  )
 
   return (
     <MotionContainer

--- a/packages/triple-header/src/frame/effects/flying.tsx
+++ b/packages/triple-header/src/frame/effects/flying.tsx
@@ -11,25 +11,25 @@ type ExtendedEffectOptions = InitialEffectOptions & {
 
 export type FlyingEffect = { type: 'flying' } & Omit<
   FlyingProps,
-  'index' | 'totalFramesCount'
+  'index' | 'frameCount'
 >
 
 interface FlyingProps {
   options?: ExtendedEffectOptions
   index: number
-  totalFramesCount: number
+  frameCount: number
 }
 
 export function Flying({
   children,
   options = {},
   index,
-  totalFramesCount,
+  frameCount,
 }: PropsWithChildren<FlyingProps>) {
   const transition = generateTransition(
     { ...options, duration: 0.3 },
     index,
-    totalFramesCount,
+    frameCount,
   )
 
   return (

--- a/packages/triple-header/src/frame/effects/rotate.tsx
+++ b/packages/triple-header/src/frame/effects/rotate.tsx
@@ -11,22 +11,22 @@ type ExtendedEffectOptions = InitialEffectOptions & {
 
 export type RotateEffect = { type: 'rotate' } & Omit<
   RotateProps,
-  'index' | 'totalFramesCount'
+  'index' | 'frameCount'
 >
 
 interface RotateProps {
   options?: ExtendedEffectOptions
   index: number
-  totalFramesCount: number
+  frameCount: number
 }
 
 export function Rotate({
   children,
   options = {},
   index,
-  totalFramesCount,
+  frameCount,
 }: PropsWithChildren<RotateProps>) {
-  const transition = generateTransition(options, index, totalFramesCount)
+  const transition = generateTransition(options, index, frameCount)
 
   return (
     <MotionContainer

--- a/packages/triple-header/src/frame/effects/rotate.tsx
+++ b/packages/triple-header/src/frame/effects/rotate.tsx
@@ -9,14 +9,24 @@ type ExtendedEffectOptions = InitialEffectOptions & {
   degree?: number
 }
 
-export type RotateEffect = { type: 'rotate' } & RotateProps
+export type RotateEffect = { type: 'rotate' } & Omit<
+  RotateProps,
+  'index' | 'totalFramesCount'
+>
 
 interface RotateProps {
-  options: ExtendedEffectOptions
+  options?: ExtendedEffectOptions
+  index: number
+  totalFramesCount: number
 }
 
-export function Rotate({ children, options }: PropsWithChildren<RotateProps>) {
-  const transition = generateTransition(options)
+export function Rotate({
+  children,
+  options = {},
+  index,
+  totalFramesCount,
+}: PropsWithChildren<RotateProps>) {
+  const transition = generateTransition(options, index, totalFramesCount)
 
   return (
     <MotionContainer

--- a/packages/triple-header/src/frame/effects/rotate.tsx
+++ b/packages/triple-header/src/frame/effects/rotate.tsx
@@ -12,13 +12,10 @@ type ExtendedEffectOptions = InitialEffectOptions & {
 export type RotateEffect = { type: 'rotate' } & RotateProps
 
 interface RotateProps {
-  options?: ExtendedEffectOptions
+  options: ExtendedEffectOptions
 }
 
-export function Rotate({
-  children,
-  options = {},
-}: PropsWithChildren<RotateProps>) {
+export function Rotate({ children, options }: PropsWithChildren<RotateProps>) {
   const transition = generateTransition(options)
 
   return (

--- a/packages/triple-header/src/frame/effects/types.ts
+++ b/packages/triple-header/src/frame/effects/types.ts
@@ -3,6 +3,4 @@ type RepeatType = 'loop' | 'reverse' | 'mirror'
 export interface InitialEffectOptions {
   infinity?: boolean
   repeatType?: RepeatType
-  index: number
-  totalFramesCount: number
 }

--- a/packages/triple-header/src/frame/effects/types.ts
+++ b/packages/triple-header/src/frame/effects/types.ts
@@ -3,4 +3,6 @@ type RepeatType = 'loop' | 'reverse' | 'mirror'
 export interface InitialEffectOptions {
   infinity?: boolean
   repeatType?: RepeatType
+  index?: number
+  totalFramesCount?: number
 }

--- a/packages/triple-header/src/frame/effects/types.ts
+++ b/packages/triple-header/src/frame/effects/types.ts
@@ -3,6 +3,6 @@ type RepeatType = 'loop' | 'reverse' | 'mirror'
 export interface InitialEffectOptions {
   infinity?: boolean
   repeatType?: RepeatType
-  index?: number
-  totalFramesCount?: number
+  index: number
+  totalFramesCount: number
 }

--- a/packages/triple-header/src/frame/effects/zoom.tsx
+++ b/packages/triple-header/src/frame/effects/zoom.tsx
@@ -7,22 +7,22 @@ import { generateTransition, stringifyTransition } from './common'
 
 export type ZoomEffect = { type: 'zoom' } & Omit<
   ZoomProps,
-  'index' | 'totalFramesCount'
+  'index' | 'frameCount'
 >
 
 interface ZoomProps {
   options?: InitialEffectOptions
   index: number
-  totalFramesCount: number
+  frameCount: number
 }
 
 export function Zoom({
   children,
   options = {},
   index,
-  totalFramesCount,
+  frameCount,
 }: PropsWithChildren<ZoomProps>) {
-  const transition = generateTransition(options, index, totalFramesCount)
+  const transition = generateTransition(options, index, frameCount)
 
   return (
     <MotionContainer

--- a/packages/triple-header/src/frame/effects/zoom.tsx
+++ b/packages/triple-header/src/frame/effects/zoom.tsx
@@ -5,14 +5,24 @@ import { MotionContainer } from '../../motion-container'
 import { InitialEffectOptions } from './types'
 import { generateTransition, stringifyTransition } from './common'
 
-export type ZoomEffect = { type: 'zoom' } & ZoomProps
+export type ZoomEffect = { type: 'zoom' } & Omit<
+  ZoomProps,
+  'index' | 'totalFramesCount'
+>
 
 interface ZoomProps {
-  options: InitialEffectOptions
+  options?: InitialEffectOptions
+  index: number
+  totalFramesCount: number
 }
 
-export function Zoom({ children, options }: PropsWithChildren<ZoomProps>) {
-  const transition = generateTransition(options)
+export function Zoom({
+  children,
+  options = {},
+  index,
+  totalFramesCount,
+}: PropsWithChildren<ZoomProps>) {
+  const transition = generateTransition(options, index, totalFramesCount)
 
   return (
     <MotionContainer

--- a/packages/triple-header/src/frame/effects/zoom.tsx
+++ b/packages/triple-header/src/frame/effects/zoom.tsx
@@ -8,10 +8,10 @@ import { generateTransition, stringifyTransition } from './common'
 export type ZoomEffect = { type: 'zoom' } & ZoomProps
 
 interface ZoomProps {
-  options?: InitialEffectOptions
+  options: InitialEffectOptions
 }
 
-export function Zoom({ children, options = {} }: PropsWithChildren<ZoomProps>) {
+export function Zoom({ children, options }: PropsWithChildren<ZoomProps>) {
   const transition = generateTransition(options)
 
   return (

--- a/packages/triple-header/src/frame/frame.tsx
+++ b/packages/triple-header/src/frame/frame.tsx
@@ -45,7 +45,9 @@ export function Frame({
   totalFramesCount: number
   onLinkClick?: LinkEventHandler
 }) {
-  const FrameElement = FRAMES[type] as ComponentType<Omit<FrameData, 'type'>>
+  const FrameElement = FRAMES[type] as ComponentType<
+    Omit<FrameData, 'type'> & { index: number; totalFramesCount: number }
+  >
 
   const widthRatio = calculateFrameRatio(width)
   const heightRatio = calculateFrameRatio(height)

--- a/packages/triple-header/src/frame/frame.tsx
+++ b/packages/triple-header/src/frame/frame.tsx
@@ -34,11 +34,15 @@ const FrameContainer = styled(Container)<{
 
 export function Frame({
   frame: { type, width, height, value, effect },
+  index,
   calculateFrameRatio,
+  totalFramesCount,
   onLinkClick,
 }: {
   frame: FrameData
+  index: number
   calculateFrameRatio: (length?: number) => number
+  totalFramesCount: number
   onLinkClick?: LinkEventHandler
 }) {
   const FrameElement = FRAMES[type] as ComponentType<Omit<FrameData, 'type'>>
@@ -83,6 +87,8 @@ export function Frame({
       <FrameElement
         value={value}
         effect={effect}
+        index={index}
+        totalFramesCount={totalFramesCount}
         onLinkClick={linkClickHandler}
       />
     </FrameContainer>

--- a/packages/triple-header/src/frame/frame.tsx
+++ b/packages/triple-header/src/frame/frame.tsx
@@ -36,17 +36,17 @@ export function Frame({
   frame: { type, width, height, value, effect },
   index,
   calculateFrameRatio,
-  totalFramesCount,
+  frameCount,
   onLinkClick,
 }: {
   frame: FrameData
   index: number
   calculateFrameRatio: (length?: number) => number
-  totalFramesCount: number
+  frameCount: number
   onLinkClick?: LinkEventHandler
 }) {
   const FrameElement = FRAMES[type] as ComponentType<
-    Omit<FrameData, 'type'> & { index: number; totalFramesCount: number }
+    Omit<FrameData, 'type'> & { index: number; frameCount: number }
   >
 
   const widthRatio = calculateFrameRatio(width)
@@ -90,7 +90,7 @@ export function Frame({
         value={value}
         effect={effect}
         index={index}
-        totalFramesCount={totalFramesCount}
+        frameCount={frameCount}
         onLinkClick={linkClickHandler}
       />
     </FrameContainer>

--- a/packages/triple-header/src/frame/image.tsx
+++ b/packages/triple-header/src/frame/image.tsx
@@ -40,7 +40,11 @@ export function ImageFrame({
   const EffectElement = effect ? EFFECTS[effect.type] : MotionContainer
 
   return Object.keys(image).length > 0 ? (
-    <EffectElement options={{ ...effect?.options, index, totalFramesCount }}>
+    <EffectElement
+      options={effect?.options}
+      index={index}
+      totalFramesCount={totalFramesCount}
+    >
       <Image
         src={image.sizes.full.url}
         onClick={(e) => generateLinkClickHandler(onLinkClick)(e, image.link)}

--- a/packages/triple-header/src/frame/image.tsx
+++ b/packages/triple-header/src/frame/image.tsx
@@ -16,6 +16,8 @@ interface ImageFrameProps {
   width?: number
   height?: number
   effect?: Effect
+  index: number
+  totalFramesCount: number
   onLinkClick?: LinkEventHandler
 }
 
@@ -28,12 +30,14 @@ const Image = styled.img`
 export function ImageFrame({
   value: { image },
   effect,
+  index,
+  totalFramesCount,
   onLinkClick,
 }: ImageFrameProps) {
   const EffectElement = effect ? EFFECTS[effect.type] : MotionContainer
 
   return Object.keys(image).length > 0 ? (
-    <EffectElement options={effect?.options}>
+    <EffectElement options={{ ...effect?.options, index, totalFramesCount }}>
       <Image
         src={image.sizes.full.url}
         onClick={(e) => generateLinkClickHandler(onLinkClick)(e, image.link)}

--- a/packages/triple-header/src/frame/image.tsx
+++ b/packages/triple-header/src/frame/image.tsx
@@ -9,7 +9,7 @@ import { generateLinkClickHandler } from './common'
 
 export type ImageFrame = { type: 'image' } & Omit<
   ImageFrameProps,
-  'index' | 'totalFramesCount'
+  'index' | 'frameCount'
 >
 
 interface ImageFrameProps {
@@ -20,7 +20,7 @@ interface ImageFrameProps {
   height?: number
   effect?: Effect
   index: number
-  totalFramesCount: number
+  frameCount: number
   onLinkClick?: LinkEventHandler
 }
 
@@ -34,7 +34,7 @@ export function ImageFrame({
   value: { image },
   effect,
   index,
-  totalFramesCount,
+  frameCount,
   onLinkClick,
 }: ImageFrameProps) {
   const EffectElement = effect ? EFFECTS[effect.type] : MotionContainer
@@ -43,7 +43,7 @@ export function ImageFrame({
     <EffectElement
       options={effect?.options}
       index={index}
-      totalFramesCount={totalFramesCount}
+      frameCount={frameCount}
     >
       <Image
         src={image.sizes.full.url}

--- a/packages/triple-header/src/frame/image.tsx
+++ b/packages/triple-header/src/frame/image.tsx
@@ -7,7 +7,10 @@ import { LinkEventHandler } from '../types'
 import { EFFECTS, Effect } from './effects'
 import { generateLinkClickHandler } from './common'
 
-export type ImageFrame = { type: 'image' } & ImageFrameProps
+export type ImageFrame = { type: 'image' } & Omit<
+  ImageFrameProps,
+  'index' | 'totalFramesCount'
+>
 
 interface ImageFrameProps {
   value: {

--- a/packages/triple-header/src/frame/text.tsx
+++ b/packages/triple-header/src/frame/text.tsx
@@ -6,7 +6,11 @@ import { Link, LinkEventHandler } from '../types'
 import { generateLinkClickHandler } from './common'
 import { EFFECTS, Effect } from './effects'
 
-export type TextFrame = { type: 'text' } & TextFrameProps
+export type TextFrame = { type: 'text' } & Omit<
+  TextFrameProps,
+  'index' | 'totalFramesCount'
+>
+
 interface TextFrameProps {
   value: {
     text: {

--- a/packages/triple-header/src/frame/text.tsx
+++ b/packages/triple-header/src/frame/text.tsx
@@ -36,7 +36,11 @@ export function TextFrame({
   const EffectElement = effect ? EFFECTS[effect.type] : MotionContainer
 
   return (
-    <EffectElement options={{ ...effect?.options, index, totalFramesCount }}>
+    <EffectElement
+      options={effect?.options}
+      index={index}
+      totalFramesCount={totalFramesCount}
+    >
       <Text
         onClick={(e) => generateLinkClickHandler(onLinkClick)(e, text.link)}
       >

--- a/packages/triple-header/src/frame/text.tsx
+++ b/packages/triple-header/src/frame/text.tsx
@@ -17,18 +17,22 @@ interface TextFrameProps {
   width?: number
   height?: number
   effect?: Effect
+  index: number
+  totalFramesCount: number
   onLinkClick?: LinkEventHandler
 }
 
 export function TextFrame({
   value: { text },
   effect,
+  index,
+  totalFramesCount,
   onLinkClick,
 }: TextFrameProps) {
   const EffectElement = effect ? EFFECTS[effect.type] : MotionContainer
 
   return (
-    <EffectElement options={effect?.options}>
+    <EffectElement options={{ ...effect?.options, index, totalFramesCount }}>
       <Text
         onClick={(e) => generateLinkClickHandler(onLinkClick)(e, text.link)}
       >

--- a/packages/triple-header/src/frame/text.tsx
+++ b/packages/triple-header/src/frame/text.tsx
@@ -8,7 +8,7 @@ import { EFFECTS, Effect } from './effects'
 
 export type TextFrame = { type: 'text' } & Omit<
   TextFrameProps,
-  'index' | 'totalFramesCount'
+  'index' | 'frameCount'
 >
 
 interface TextFrameProps {
@@ -22,7 +22,7 @@ interface TextFrameProps {
   height?: number
   effect?: Effect
   index: number
-  totalFramesCount: number
+  frameCount: number
   onLinkClick?: LinkEventHandler
 }
 
@@ -30,7 +30,7 @@ export function TextFrame({
   value: { text },
   effect,
   index,
-  totalFramesCount,
+  frameCount,
   onLinkClick,
 }: TextFrameProps) {
   const EffectElement = effect ? EFFECTS[effect.type] : MotionContainer
@@ -39,7 +39,7 @@ export function TextFrame({
     <EffectElement
       options={effect?.options}
       index={index}
-      totalFramesCount={totalFramesCount}
+      frameCount={frameCount}
     >
       <Text
         onClick={(e) => generateLinkClickHandler(onLinkClick)(e, text.link)}

--- a/packages/triple-header/src/layer/layer.tsx
+++ b/packages/triple-header/src/layer/layer.tsx
@@ -48,7 +48,9 @@ export function Layer({
             <Frame
               key={index}
               frame={frame}
+              index={index}
               calculateFrameRatio={calculateFrameRatio}
+              totalFramesCount={frames.length}
             />
           )
         })}

--- a/packages/triple-header/src/layer/layer.tsx
+++ b/packages/triple-header/src/layer/layer.tsx
@@ -50,7 +50,7 @@ export function Layer({
               frame={frame}
               index={index}
               calculateFrameRatio={calculateFrameRatio}
-              totalFramesCount={frames.length}
+              frameCount={frames.length}
             />
           )
         })}

--- a/packages/triple-header/src/layer/transitions/fade-in-out.tsx
+++ b/packages/triple-header/src/layer/transitions/fade-in-out.tsx
@@ -1,40 +1,29 @@
-import { useEffect, useState, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { MotionContainer } from '../../motion-container'
 
 const variants = {
-  fadeIn: {
-    opacity: [0, 1],
-    transition: { duration: 1.5 },
-  },
-  fadeOut: { opacity: 0, transition: { duration: 1 } },
+  fadeInOut: ({ index, length }: { index: number; length: number }) => ({
+    opacity: [0, 1, 1, 0],
+    transition: {
+      repeat: Infinity,
+      duration: 4,
+      times: [0, 0.375, 0.75, 1],
+      delay: 3 * index,
+      repeatDelay: 3 * length - 4,
+    },
+  }),
 }
 
 export function FadeInOut({ children }: { children: ReactNode[] }) {
-  const [visibleFrameIndex, setVisibleFrameIndex] = useState(0)
-
-  useEffect(() => {
-    const timer = setInterval(
-      () =>
-        setVisibleFrameIndex((prevVisibleFrameIndex) => {
-          return prevVisibleFrameIndex === children.length - 1
-            ? 0
-            : prevVisibleFrameIndex + 1
-        }),
-      3000,
-    )
-
-    return () => clearInterval(timer)
-  }, [children, visibleFrameIndex])
-
   return (
     <>
       {children.map((slide, index) => (
         <MotionContainer
           key={index}
-          initial="fadeOut"
+          custom={{ index, length: children.length }}
+          animate="fadeInOut"
           variants={variants}
-          animate={index === visibleFrameIndex ? 'fadeIn' : 'fadeOut'}
         >
           {slide}
         </MotionContainer>

--- a/packages/triple-header/src/layer/transitions/fade-in-out.tsx
+++ b/packages/triple-header/src/layer/transitions/fade-in-out.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useState, ReactNode } from 'react'
-import { AnimatePresence } from 'framer-motion'
 
 import { MotionContainer } from '../../motion-container'
 
 const variants = {
-  active: () => ({
+  fadeIn: {
     opacity: [0, 1],
     transition: { duration: 1.5 },
-  }),
-  exit: () => ({ opacity: 0, transition: { duration: 1 } }),
+  },
+  fadeOut: { opacity: 0, transition: { duration: 1 } },
 }
 
 export function FadeInOut({ children }: { children: ReactNode[] }) {
@@ -29,15 +28,17 @@ export function FadeInOut({ children }: { children: ReactNode[] }) {
   }, [children, visibleFrameIndex])
 
   return (
-    <AnimatePresence>
-      <MotionContainer
-        key={visibleFrameIndex}
-        variants={variants}
-        animate="active"
-        exit="exit"
-      >
-        {children[visibleFrameIndex]}
-      </MotionContainer>
-    </AnimatePresence>
+    <>
+      {children.map((slide, index) => (
+        <MotionContainer
+          key={index}
+          initial="fadeOut"
+          variants={variants}
+          animate={index === visibleFrameIndex ? 'fadeIn' : 'fadeOut'}
+        >
+          {slide}
+        </MotionContainer>
+      ))}
+    </>
   )
 }

--- a/packages/triple-header/src/layer/transitions/slide.tsx
+++ b/packages/triple-header/src/layer/transitions/slide.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, ReactNode } from 'react'
-import { AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 
 export function Slide({ children }: { children: ReactNode[] }) {
   const [visibleFrameIndex, setVisibleFrameIndex] = useState(0)
@@ -18,5 +18,11 @@ export function Slide({ children }: { children: ReactNode[] }) {
     return () => clearInterval(timer)
   }, [children, visibleFrameIndex])
 
-  return <AnimatePresence>{children[visibleFrameIndex]}</AnimatePresence>
+  return (
+    <AnimatePresence>
+      <motion.div key={visibleFrameIndex}>
+        {children[visibleFrameIndex]}
+      </motion.div>
+    </AnimatePresence>
+  )
 }

--- a/packages/triple-header/src/layer/transitions/slide.tsx
+++ b/packages/triple-header/src/layer/transitions/slide.tsx
@@ -1,41 +1,33 @@
-import { useEffect, useState, ReactNode } from 'react'
-import styled from 'styled-components'
-import { Container } from '@titicaca/core-elements'
+import { ReactNode } from 'react'
 
-const SlideContainer = styled(Container)<{ isVisible: boolean }>`
-  position: absolute;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
-`
+import { MotionContainer } from '../../motion-container'
+
+const variants = {
+  slide: ({ index, length }: { index: number; length: number }) => ({
+    opacity: [0, 1, 1, 0],
+    transition: {
+      repeat: Infinity,
+      duration: 3,
+      times: [0, 0, 1, 1],
+      delay: 3 * index,
+      repeatDelay: 3 * length - 3,
+    },
+  }),
+}
 
 export function Slide({ children }: { children: ReactNode[] }) {
-  const [visibleFrameIndex, setVisibleFrameIndex] = useState(0)
-
-  useEffect(() => {
-    const timer = setInterval(
-      () =>
-        setVisibleFrameIndex((prevVisibleFrameIndex) => {
-          return prevVisibleFrameIndex === children.length - 1
-            ? 0
-            : prevVisibleFrameIndex + 1
-        }),
-      3000,
-    )
-
-    return () => clearInterval(timer)
-  }, [children, visibleFrameIndex])
-
   return (
     <>
-      {children.map((slide, index) => {
-        return (
-          <SlideContainer key={index} isVisible={index === visibleFrameIndex}>
-            {slide}
-          </SlideContainer>
-        )
-      })}
+      {children.map((slide, index) => (
+        <MotionContainer
+          key={index}
+          animate="slide"
+          custom={{ index, length: children.length }}
+          variants={variants}
+        >
+          {slide}
+        </MotionContainer>
+      ))}
     </>
   )
 }

--- a/packages/triple-header/src/layer/transitions/slide.tsx
+++ b/packages/triple-header/src/layer/transitions/slide.tsx
@@ -18,9 +18,5 @@ export function Slide({ children }: { children: ReactNode[] }) {
     return () => clearInterval(timer)
   }, [children, visibleFrameIndex])
 
-  return (
-    <AnimatePresence initial exitBeforeEnter>
-      {children[visibleFrameIndex]}
-    </AnimatePresence>
-  )
+  return <AnimatePresence>{children[visibleFrameIndex]}</AnimatePresence>
 }

--- a/packages/triple-header/src/layer/transitions/slide.tsx
+++ b/packages/triple-header/src/layer/transitions/slide.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useState, ReactNode } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
+import styled from 'styled-components'
+import { Container } from '@titicaca/core-elements'
+
+const SlideContainer = styled(Container)<{ isVisible: boolean }>`
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
+`
 
 export function Slide({ children }: { children: ReactNode[] }) {
   const [visibleFrameIndex, setVisibleFrameIndex] = useState(0)
@@ -19,10 +28,14 @@ export function Slide({ children }: { children: ReactNode[] }) {
   }, [children, visibleFrameIndex])
 
   return (
-    <AnimatePresence>
-      <motion.div key={visibleFrameIndex} animate={{}}>
-        {children[visibleFrameIndex]}
-      </motion.div>
-    </AnimatePresence>
+    <>
+      {children.map((slide, index) => {
+        return (
+          <SlideContainer key={index} isVisible={index === visibleFrameIndex}>
+            {slide}
+          </SlideContainer>
+        )
+      })}
+    </>
   )
 }

--- a/packages/triple-header/src/layer/transitions/slide.tsx
+++ b/packages/triple-header/src/layer/transitions/slide.tsx
@@ -20,7 +20,7 @@ export function Slide({ children }: { children: ReactNode[] }) {
 
   return (
     <AnimatePresence>
-      <motion.div key={visibleFrameIndex}>
+      <motion.div key={visibleFrameIndex} animate={{}}>
         {children[visibleFrameIndex]}
       </motion.div>
     </AnimatePresence>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1757,7 +1757,7 @@ importers:
         specifier: workspace:*
         version: link:../type-definitions
       framer-motion:
-        specifier: ^10.16.12
+        specifier: ^10.16.9
         version: 10.16.12(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@titicaca/i18n':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1757,8 +1757,8 @@ importers:
         specifier: workspace:*
         version: link:../type-definitions
       framer-motion:
-        specifier: ^7.10.3
-        version: 7.10.3(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^10.16.5
+        version: 10.16.5(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@titicaca/i18n':
         specifier: workspace:*
@@ -5429,53 +5429,6 @@ packages:
       got: 11.8.6
       os-filter-obj: 2.0.0
     dev: true
-
-  /@motionone/animation@10.15.1:
-    resolution: {integrity: sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==}
-    dependencies:
-      '@motionone/easing': 10.15.1
-      '@motionone/types': 10.15.1
-      '@motionone/utils': 10.15.1
-      tslib: 2.6.2
-    dev: false
-
-  /@motionone/dom@10.16.2:
-    resolution: {integrity: sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==}
-    dependencies:
-      '@motionone/animation': 10.15.1
-      '@motionone/generators': 10.15.1
-      '@motionone/types': 10.15.1
-      '@motionone/utils': 10.15.1
-      hey-listen: 1.0.8
-      tslib: 2.6.2
-    dev: false
-
-  /@motionone/easing@10.15.1:
-    resolution: {integrity: sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==}
-    dependencies:
-      '@motionone/utils': 10.15.1
-      tslib: 2.6.2
-    dev: false
-
-  /@motionone/generators@10.15.1:
-    resolution: {integrity: sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==}
-    dependencies:
-      '@motionone/types': 10.15.1
-      '@motionone/utils': 10.15.1
-      tslib: 2.6.2
-    dev: false
-
-  /@motionone/types@10.15.1:
-    resolution: {integrity: sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA==}
-    dev: false
-
-  /@motionone/utils@10.15.1:
-    resolution: {integrity: sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==}
-    dependencies:
-      '@motionone/types': 10.15.1
-      hey-listen: 1.0.8
-      tslib: 2.6.2
-    dev: false
 
   /@mswjs/cookies@0.2.2:
     resolution: {integrity: sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==}
@@ -13384,17 +13337,20 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /framer-motion@7.10.3(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-k2ccYeZNSpPg//HTaqrU+4pRq9f9ZpaaN7rr0+Rx5zA4wZLbk547wtDzge2db1sB+1mnJ6r59P4xb+aEIi/W+w==}
+  /framer-motion@10.16.5(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-GEzVjOYP2MIpV9bT/GbhcsBNoImG3/2X3O/xVNWmktkv9MdJ7P/44zELm/7Fjb+O3v39SmKFnoDQB32giThzpg==}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
     dependencies:
-      '@motionone/dom': 10.16.2
-      hey-listen: 1.0.8
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      tslib: 2.4.0
+      tslib: 2.6.2
     optionalDependencies:
       '@emotion/is-prop-valid': 0.8.8
     dev: false
@@ -13985,10 +13941,6 @@ packages:
   /headers-polyfill@3.2.5:
     resolution: {integrity: sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==}
     dev: true
-
-  /hey-listen@1.0.8:
-    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
-    dev: false
 
   /hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
@@ -20762,10 +20714,6 @@ packages:
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
-
-  /tslib@2.4.0:
-    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-    dev: false
 
   /tslib@2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1757,8 +1757,8 @@ importers:
         specifier: workspace:*
         version: link:../type-definitions
       framer-motion:
-        specifier: ^10.16.5
-        version: 10.16.5(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^10.16.12
+        version: 10.16.12(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@titicaca/i18n':
         specifier: workspace:*
@@ -13337,8 +13337,8 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /framer-motion@10.16.5(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-GEzVjOYP2MIpV9bT/GbhcsBNoImG3/2X3O/xVNWmktkv9MdJ7P/44zELm/7Fjb+O3v39SmKFnoDQB32giThzpg==}
+  /framer-motion@10.16.12(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-w7Yzx0OzQ5Uh6uNkxaX+4TuAPuOKz3haSbjmHpdrqDpGuCJCpq6YP9Dy7JJWdZ6mJjndrg3Ao3vUwDajKNikCA==}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

리뷰를 위해 트리플 헤더 기능에 대해 간략하게 설명드리면, 트리플 헤더는 크게 레이어와 프레임이라는 개념을 사용합니다.
레이어는 z 축을 기반으로 액자형식으로 여러 이미지를 겹칠 수 있도록 하고, 각 레이어는 한 개 또는 여러 개의 프레임을 사용할 수 있습니다.

트리플 헤더에서 사용하는 애니메이션은 크게 두 종류로 구분할 수 있는데 요약하면 다음과 같습니다.
1. 프레임이 여러 개인 경우 프레임 간의 전환 시 발생하는 애니메이션 - 기본 전환, 페이드 인 아웃 등
2. 각 프레임이 노출되는 경우 발생하는 애니메이션 - 확대하기, 회전하기, 날라오기 등

이번 PR은 프레임이 여러 개인 경우 기본 전환 시, 프레임 전환 간 깜빡임 현상이 해결합니다. 그리고 추가적으로 다음 문제들을 해결합니다.
- 기본 전환, 페이드인아웃 전환 시, 프레임 효과를 한 번만 실행으로 설정해도 계속 실행되었던 문제를 해결합니다.
  - 프레임이 여러 개인 경우, 각 프레임이 노출될 때 발생하는 애니메이션의 옵션을 한 번만 실행으로 설정 시, 한 번만 실행됩니다.
- 프레임 날라오기 효과를 계속 실행으로 설정 시, 다른 프레임 효과와 동일한 시간 텀을 가지고 실행하도록 합니다.
  - 기존에는 0.3초마다 실행되고 있습니다.

## 변경 내역

- 기존에는 프레임 간 기본 전환 시 렌더링 할 프레임을 매번 변경하여, 각 프레임이 새롭게 렌더링 되었을 때 애니메이션을 실행하는 방식이었습니다. 모든 프레임을 렌더링하고 opacity로 노출할 프레임을 조절하고, index와 총 프레임 개수를 이용해서 `delay`, `repeatDelay`를 조절하는 방식으로 변경합니다.
- 이렇게 구현하니 화면을 계속해서 보고 있을 때는 잘 동작하는데, 백그라운드에서 실행시키다 앱으로 돌아오는 경우 1번 애니메이션(프레임이 여러 개인 경우 프레임 간의 전환 시 발생하는 애니메이션)과 2번 애니메이션(각 프레임이 노출되는 경우 발생하는 애니메이션) 싱크가 맞지 않습니다. 1번 애니메이션 동작 방식을 setInterval에서 2번 애니메이션과 동일하게 framer-motion의 옵션을 사용해서 조절하는 방식으로 변경합니다.   
- **reference** - [framer-motion 공식문서](https://www.framer.com/motion/transition/)

## 스크린샷 & URL

https://github.com/titicacadev/triple-frontend/assets/61184798/35598404-4943-43ca-921f-cae74e80badd



