### PR TITLE
view-utilities에 common, client export 경로를 추가하고 query 관련 유틸함수를 작성합니다.

### DIFF
--- a/packages/view-utilities/package.json
+++ b/packages/view-utilities/package.json
@@ -11,7 +11,6 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
-  "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "typesVersions": {
     "*": {

--- a/packages/view-utilities/package.json
+++ b/packages/view-utilities/package.json
@@ -20,6 +20,9 @@
       ],
       "common": [
         "lib/app-directory/common/index.d.ts"
+      ],
+      "client": [
+        "lib/app-directory/client/index.d.ts"
       ]
     }
   },
@@ -33,6 +36,11 @@
       "import": "./lib/app-directory/common/index.js",
       "require": "./lib/app-directory/common/index.js",
       "types": "./lib/app-directory/common/index.d.ts"
+    },
+    "./client": {
+      "import": "./lib/app-directory/client/index.js",
+      "require": "./lib/app-directory/client/index.js",
+      "types": "./lib/app-directory/client/index.d.ts"
     }
   },
   "files": [

--- a/packages/view-utilities/package.json
+++ b/packages/view-utilities/package.json
@@ -12,6 +12,29 @@
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "lib/index.d.ts"
+      ],
+      "common": [
+        "lib/app-directory/common/index.d.ts"
+      ]
+    }
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/index.js",
+      "require": "./lib/index.js",
+      "types": "./lib/index.d.ts"
+    },
+    "./common": {
+      "import": "./lib/app-directory/common/index.js",
+      "require": "./lib/app-directory/common/index.js",
+      "types": "./lib/app-directory/common/index.d.ts"
+    }
+  },
   "files": [
     "lib"
   ],

--- a/packages/view-utilities/src/app-directory/client/convert-search-params-to-query.ts
+++ b/packages/view-utilities/src/app-directory/client/convert-search-params-to-query.ts
@@ -1,0 +1,10 @@
+import { ReadonlyURLSearchParams } from 'next/navigation'
+
+export function convertSearchParamsToQuery(
+  searchParams: ReadonlyURLSearchParams,
+) {
+  return Array.from(searchParams.entries()).reduce(
+    (query, [key, value]) => ({ ...query, [key]: value }),
+    {},
+  )
+}

--- a/packages/view-utilities/src/app-directory/client/index.ts
+++ b/packages/view-utilities/src/app-directory/client/index.ts
@@ -1,0 +1,1 @@
+export * from './convert-search-params-to-query'

--- a/packages/view-utilities/src/app-directory/common/index.ts
+++ b/packages/view-utilities/src/app-directory/common/index.ts
@@ -1,0 +1,4 @@
+export * from '../../url'
+export * from '../../generate-deep-link/make-deep-link-generator'
+export * from '../../strict-query'
+export * from '../../normalize-query-keys'


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- view-utilities에 common, client export 경로를 추가합니다. (fetcher에서 사용하는 view-utilities에서 client 모듈이 혼용되는 것을 방지합니다.)
- [app 디렉토리에서 query를 가져오는 방식이 변경됨](https://nextjs.org/docs/app/api-reference/functions/use-search-params)에 따라 next의 searchParams를 기존 query 형태로 변환하는 유틸 함수를 작성했습니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
