### PR TITLE
focus trap 테스트가 랜덤하게 실패하는 현상 수정

### DIFF
--- a/packages/action-sheet/src/action-sheet.test.tsx
+++ b/packages/action-sheet/src/action-sheet.test.tsx
@@ -66,6 +66,8 @@ test('focus trap을 사용합니다.', async () => {
     </ActionSheet>,
   )
 
+  await waitFor(() => expect(screen.getByRole('dialog')).toHaveFocus())
+
   await user.tab()
 
   await waitFor(() => expect(screen.getByText('Button 1')).toHaveFocus())

--- a/packages/modals/src/modal/modal.test.tsx
+++ b/packages/modals/src/modal/modal.test.tsx
@@ -93,6 +93,8 @@ test('focus trap을 사용합니다.', async () => {
     </Modal>,
   )
 
+  await waitFor(() => expect(screen.getByRole('dialog')).toHaveFocus())
+
   await user.tab()
 
   await waitFor(() => expect(screen.getByText('Button 1')).toHaveFocus())

--- a/packages/popup/src/popup.test.tsx
+++ b/packages/popup/src/popup.test.tsx
@@ -46,6 +46,8 @@ test('focus trap을 사용합니다.', async () => {
     </Popup>,
   )
 
+  await waitFor(() => expect(screen.getByRole('dialog')).toHaveFocus())
+
   await user.tab()
 
   await waitFor(() => expect(screen.getByText('Button 1')).toHaveFocus())


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

focus trap 테스트가 랜덤하게 실패하는 현상 수정

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- floating 컴포넌트에서 initial focus가 설정되는 것은 비동기적인 동작이라서 focus trap 테스트가 랜덤하게 실패하고 있는 것 같습니다.
- role=dialog DOM이 initial focus로 설정되길 기다리도록 waitFor을 추가합니다.