### PR TITLE
쿠폰 색상 HEX fixation 을 지원합니다.

### DIFF
--- a/packages/triple-document/src/elements/coupon/index.tsx
+++ b/packages/triple-document/src/elements/coupon/index.tsx
@@ -11,6 +11,7 @@ import {
   CouponGroupDownloadButton,
   DEFAULT_BUTTON_COLOR,
 } from './coupon-download-buttons'
+import { safeParseHexColor } from './utils'
 
 const DEFAULT_COLOR = {
   buttonText: DEFAULT_BUTTON_COLOR.text,
@@ -65,7 +66,7 @@ export default function Coupon({
     <Container
       css={{
         padding: '44px 30px 42px',
-        backgroundColor: color.background,
+        backgroundColor: safeParseHexColor(color.background),
       }}
     >
       {couponType === 'single' ? (
@@ -74,8 +75,8 @@ export default function Coupon({
           slugId={identifier}
           enabledAt={enabledAt}
           onClick={handleCouponClick}
-          textColor={color.buttonText}
-          backgroundColor={color.buttonBackground}
+          textColor={safeParseHexColor(color.buttonText)}
+          backgroundColor={safeParseHexColor(color.buttonBackground)}
         />
       ) : (
         <CouponGroupDownloadButton
@@ -83,14 +84,18 @@ export default function Coupon({
           groupId={identifier}
           enabledAt={enabledAt}
           onClick={handleCouponClick}
-          textColor={color.buttonText}
-          backgroundColor={color.buttonBackground}
+          textColor={safeParseHexColor(color.buttonText)}
+          backgroundColor={safeParseHexColor(color.buttonBackground)}
         />
       )}
 
       {description ? (
         <Text
-          css={{ color: color.description || DEFAULT_COLOR.description }}
+          css={{
+            color: safeParseHexColor(
+              color.description || DEFAULT_COLOR.description,
+            ),
+          }}
           margin={{ top: 13 }}
           lineHeight={1.46}
           size="tiny"

--- a/packages/triple-document/src/elements/coupon/utils.test.ts
+++ b/packages/triple-document/src/elements/coupon/utils.test.ts
@@ -2,7 +2,7 @@ import { safeParseHexColor } from './utils'
 
 test('sRGB 스펙에 맞는 HEX 코드 색상을 올바르게 처리합니다.', () => {
   const threeValueExample = '#f09'
-  const fourValueExample = '#F09'
+  const fourValueExample = '#F009'
   const sixValueExample = '#ff0099'
   const eightValueExample = ' #ff009990'
 

--- a/packages/triple-document/src/elements/coupon/utils.test.ts
+++ b/packages/triple-document/src/elements/coupon/utils.test.ts
@@ -1,0 +1,28 @@
+import { safeParseHexColor } from './utils'
+
+test('sRGB 스펙에 맞는 HEX 코드 색상을 올바르게 처리합니다.', () => {
+  const threeValueExample = '#f09'
+  const fourValueExample = '#F09'
+  const sixValueExample = '#ff0099'
+  const eightValueExample = ' #ff009990'
+
+  expect(safeParseHexColor(threeValueExample)).toBe(threeValueExample)
+  expect(safeParseHexColor(fourValueExample)).toBe(fourValueExample)
+  expect(safeParseHexColor(sixValueExample)).toBe(sixValueExample)
+  expect(safeParseHexColor(eightValueExample)).toBe(eightValueExample)
+})
+
+test('# 이 포함된 HEX 코드라면 그대로 반환합니다.', () => {
+  const example = '#ffffff80'
+  expect(safeParseHexColor(example)).toBe(example)
+})
+
+test('# 를 제외하고 유효한 HEX 코드라면 #를 포함해서 반환합니다.', () => {
+  const example = 'ffffff80'
+  expect(safeParseHexColor(example)).toBe(`#${example}`)
+})
+
+test('유효한 HEX 코드가 아닐 경우 그대로 반환합니다.', () => {
+  const example = 'white'
+  expect(safeParseHexColor(example)).toBe(example)
+})

--- a/packages/triple-document/src/elements/coupon/utils.ts
+++ b/packages/triple-document/src/elements/coupon/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * @reference https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color
+ */
+export function safeParseHexColor(color?: string) {
+  if (!color) {
+    return
+  }
+
+  const HEX_ALPHA_PATTERN = /^#([A-F0-9]{3,4}|[A-F0-9]{6}|[A-F0-9]{8})$/i
+  const colorCode = color.startsWith('#') ? color : `#${color}`
+
+  return HEX_ALPHA_PATTERN.test(colorCode) ? colorCode : color
+}


### PR DESCRIPTION
## PR 설명

기획자분들이 HEX 색상코드를 입력하실 때 `#` 을 포함해서 입력하는게 익숙하지 않다고 하셔서 `#` 를 보정해주는 함수를 추가합니다.
