### PR TITLE
현지에서 길묻기 팝업 글씨 크기 조정

### DIFF
--- a/packages/directions-finder/src/ask-to-the-local.tsx
+++ b/packages/directions-finder/src/ask-to-the-local.tsx
@@ -70,10 +70,10 @@ export default function AskToTheLocal({
           marginTop: 20,
         }}
       >
-        <Text maxLines={2} textStyle="M4" color="blue">
+        <Text maxLines={2} color="blue" size={36}>
           {localName}
         </Text>
-        <Text textStyle="M" margin={{ top: 10 }}>
+        <Text margin={{ top: 10 }} size={28} css={{ lineHeight: '38px' }}>
           {localAddress}
         </Text>
         <HR1 compact css={{ marginTop: 20, marginBottom: 20 }} />


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- 현지에서 길묻기 팝업의 글씨 크기를 조정합니다. 
  - [제보 스레드](https://interpark.slack.com/archives/C05GCN0AYSZ/p1689126314989689), [피그마 기획안](https://www.figma.com/file/26eycUno2av7hjsRoFnRDR/20230712_poi-%EB%82%B4-%EA%B8%B8%EC%B0%BE%EA%B8%B0_%ED%8F%B0%ED%8A%B8-%ED%81%AC%EA%B8%B0-%EB%B3%80%EA%B2%BD?node-id=1%3A301&mode=dev)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

|as-is|to-be|
|--|--|
|<img width="286" alt="스크린샷 2023-07-19 오후 4 01 35" src="https://github.com/titicacadev/triple-frontend/assets/37494848/0301dbc5-f3a5-4b1c-892a-3bcbe663fba9">|<img width="288" alt="스크린샷 2023-07-19 오후 4 01 45" src="https://github.com/titicacadev/triple-frontend/assets/37494848/c5f0de56-f7a6-4889-b360-6bb30a37bd29">|
