### PR TITLE
현지에서 길묻기 ellipsis 옵션 삭제

### DIFF
--- a/packages/directions-finder/src/ask-to-the-local.tsx
+++ b/packages/directions-finder/src/ask-to-the-local.tsx
@@ -84,8 +84,7 @@ export default function AskToTheLocal({
           <Drawer active={open}>
             <DrawerContentContainer
               css={{
-                margin: '0 30px',
-                padding: '0 0 10px',
+                padding: '0 30px 10px',
                 background: 'var(--color-white)',
               }}
             >

--- a/packages/directions-finder/src/ask-to-the-local.tsx
+++ b/packages/directions-finder/src/ask-to-the-local.tsx
@@ -70,14 +70,14 @@ export default function AskToTheLocal({
           marginTop: 20,
         }}
       >
-        <Text maxLines={2} color="blue" size={36}>
+        <Text color="blue" size={36}>
           {localName}
         </Text>
         <Text margin={{ top: 10 }} size={28} css={{ lineHeight: '38px' }}>
           {localAddress}
         </Text>
         <HR1 compact css={{ marginTop: 20, marginBottom: 20 }} />
-        <Text textStyle="M" alpha={0.7}>
+        <Text textStyle="M" alpha={0.7} css={{ marginBottom: 150 }}>
           {primaryName}
         </Text>
         {phoneNumber ? (
@@ -86,6 +86,7 @@ export default function AskToTheLocal({
               css={{
                 margin: '0 30px',
                 padding: '0 0 10px',
+                background: 'var(--color-white)',
               }}
             >
               <CallButton fluid borderRadius={4} onClick={handleCall}>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- 현지에서 길묻기의 ellipsis 옵션을 삭제합니다. (말줄임 제거)
- 글자수가 많아질 경우 전화하기 버튼과 글자가 겹치는 것을 방지하기 위해 margin과 background를 추가했습니다.

|as-is|to-be|
|----|----|
|<img width="399" alt="스크린샷 2023-07-31 오후 4 08 34" src="https://github.com/titicacadev/triple-frontend/assets/37494848/268c69f0-5a60-415b-b195-9df4fa58fa7d">|<img width="399" src="https://github.com/titicacadev/triple-hotels-web/assets/37494848/e8da143b-ba54-4df5-804b-a40bc620dad9">|
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

