### PR TITLE
[resource-list-element] 광고 표기 위치와 디자인을 수정합니다.

### DIFF
--- a/packages/resource-list-element/src/extended-resource-list-element.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.tsx
@@ -98,9 +98,31 @@ function ExtendedResourceListElement<R extends ResourceMeta>({
     <ResourceListItem onClick={onClick} {...props}>
       <FlexBox flex justifyContent="space-between">
         <ContentContainer>
-          <Text bold maxLines={2} size="large">
-            {name}
-          </Text>
+          <FlexBox
+            flex
+            alignItems="flex-start"
+            justifyContent="space-between"
+            gap="7px"
+          >
+            <Text bold maxLines={2} size="large">
+              {name}
+            </Text>
+
+            {isAdvertisement ? (
+              <Text
+                size={9}
+                color="gray400"
+                css={{
+                  minWidth: '26px',
+                  border: '1px solid var(--color-gray200)',
+                  borderRadius: '4px',
+                  padding: '2px 3px',
+                }}
+              >
+                {t(['gwanggo', '광고'])}
+              </Text>
+            ) : null}
+          </FlexBox>
 
           <Text
             alpha={0.7}
@@ -136,18 +158,6 @@ function ExtendedResourceListElement<R extends ResourceMeta>({
                 margin: '3px 0 0',
               }}
             >
-              {isAdvertisement ? (
-                <Label
-                  emphasized
-                  size="tiny"
-                  promo
-                  color="white"
-                  margin={{ right: 5 }}
-                  verticalAlign="middle"
-                >
-                  {t(['gwanggo', '광고'])}
-                </Label>
-              ) : null}
               {distance || distance === 0 ? (
                 <Text inline color="blue" size="small" alpha={1}>
                   {`${distance}${distanceSuffix} `}

--- a/packages/resource-list-element/src/extended-resource-list-element.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.tsx
@@ -55,10 +55,6 @@ const ResourceListItem = styled(List.Item)`
   cursor: pointer;
 `
 
-const ContentContainer = styled.div`
-  width: calc(100% - 110px);
-`
-
 const LabelContainer = styled.div`
   position: absolute;
   bottom: 20px;
@@ -96,8 +92,8 @@ function ExtendedResourceListElement<R extends ResourceMeta>({
 
   return (
     <ResourceListItem onClick={onClick} {...props}>
-      <FlexBox flex justifyContent="space-between">
-        <ContentContainer>
+      <FlexBox flex justifyContent="space-between" gap="16px">
+        <Container css={{ width: '100%' }}>
           <FlexBox
             flex
             alignItems="flex-start"
@@ -114,10 +110,10 @@ function ExtendedResourceListElement<R extends ResourceMeta>({
                 lineHeight="12px"
                 color="gray400"
                 css={{
-                  minWidth: '26px',
+                  minWidth: '24px',
                   border: '1px solid var(--color-gray200)',
                   borderRadius: '4px',
-                  padding: '2px 3px 3px',
+                  padding: '1px 2px',
                 }}
               >
                 {t(['gwanggo', '광고'])}
@@ -171,7 +167,7 @@ function ExtendedResourceListElement<R extends ResourceMeta>({
               ) : null}
             </Container>
           ) : null}
-        </ContentContainer>
+        </Container>
 
         <Container position="relative">
           <Container clearing>

--- a/packages/resource-list-element/src/extended-resource-list-element.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.tsx
@@ -110,13 +110,14 @@ function ExtendedResourceListElement<R extends ResourceMeta>({
 
             {isAdvertisement ? (
               <Text
-                size={9}
+                size={10}
+                lineHeight="12px"
                 color="gray400"
                 css={{
                   minWidth: '26px',
                   border: '1px solid var(--color-gray200)',
                   borderRadius: '4px',
-                  padding: '2px 3px',
+                  padding: '2px 3px 3px',
                 }}
               >
                 {t(['gwanggo', '광고'])}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

호텔 목록에 광고 또는 협찬이 들어오는 호텔을 목록 최상단에 노출해야하는 상황입니다.

기존의 광고 표기 위치와 디자인이 달라서 이를 수정합니다.

[관련 피그마](https://www.figma.com/file/aicFCSpR2wN5q6evH9edRw/20230704_%EC%88%99%EC%86%8C%2FTNA-%EC%83%81%EC%84%B8%ED%8E%98%EC%9D%B4%EC%A7%80-%EC%83%81%EB%8B%A8-%ED%98%9C%ED%83%9D-%EC%98%81%EC%97%AD-%EA%B0%9C%EC%84%A0?node-id=464%3A91627&mode=dev)

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 논의 내용

호텔웹에 별도로 추가하는 것보다 기존에 있던 props를 이용하는 것이 효율적이라고 판단되어 이와 같이 작업했습니다.

공통 코드를 수정하다보니, 다른 곳에도 영향이 있을 수 있어서 [스레드](https://interpark.slack.com/archives/C05FJFC4HGS/p1692938760318459)에서 로우와 논의 후에 진행했습니다.

## 스크린샷 & URL

AS-IS

![image](https://github.com/titicacadev/triple-frontend/assets/38130934/b704c61c-66ef-435a-88bd-03aaecb8ccee)


TO-BE

![image](https://github.com/titicacadev/triple-frontend/assets/38130934/ad8c523b-655f-46c6-9645-ba4fcd4c0e0c)

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
