### PR TITLE
라벨 부착 자동화 GHA 실행 조건을 수정합니다.

### DIFF
--- a/.github/workflows/add-label.yaml
+++ b/.github/workflows/add-label.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   label-pr:
-    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.user.login != 'triple-bot' && !startsWith(github.event.pull_request.head.ref, 'release/') }}
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.user.login != 'triple-bot' && !contains(github.event.pull_request.labels.*.name, 'release') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION


<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

릴리즈 PR에 대해선 라벨을 자동으로 붙이지 않도록 하기 위해 기존에는 브랜치 이름이 `release/` 로 시작하는지를 검사했으나, PR에 `release` 라벨이 붙어있는지를 검사하는 방식으로 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
