### PR TITLE
[Chat] iOS 모바일에서 init 시점에 infinite scroll 로직 실행되는 오류 수정

### DIFF
--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -25,7 +25,7 @@ import { useChat } from './chat-context'
 import { useChatMessage } from './use-chat-message'
 import { getChatListHeight, useScrollContext } from './scroll-context'
 
-const MINIMUM_INITIAL_INTERSECTING_TIME = 3000
+const MINIMUM_INTERSECTING_TIME = 3000
 export const CHAT_CONTAINER_ID = 'chat-inner-container'
 
 export interface ChatProps {
@@ -234,26 +234,23 @@ export const Chat = ({
     if (isIntersecting) {
       const prevScrollY = getChatListHeight()
 
-      if (!(target as HTMLElement).dataset.viewStartedAt) {
-        ;(target as HTMLElement).dataset.viewStartedAt = time.toString()
-      } else {
-        const viewStartedAt = Number(
-          (target as HTMLElement).dataset.viewStartedAt,
-        )
-        if (
-          time - viewStartedAt >= MINIMUM_INITIAL_INTERSECTING_TIME &&
-          hasPrevMessage
-        ) {
-          const pastMessages = await fetchPastMessages()
+      const lastViewStartedAt = Number(
+        (target as HTMLElement).dataset.lastViewStartedAt || '',
+      )
+      if (
+        time - lastViewStartedAt >= MINIMUM_INTERSECTING_TIME &&
+        hasPrevMessage
+      ) {
+        const pastMessages = await fetchPastMessages()
 
-          await dispatch({
-            action: ChatActions.PAST,
-            messages: pastMessages,
-          })
-          setScrollY(prevScrollY)
-        }
+        await dispatch({
+          action: ChatActions.PAST,
+          messages: pastMessages,
+        })
+        setScrollY(prevScrollY)
       }
     }
+    ;(target as HTMLElement).dataset.lastViewStartedAt = time.toString()
   }
 
   return (

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -234,23 +234,26 @@ export const Chat = ({
     if (isIntersecting) {
       const prevScrollY = getChatListHeight()
 
-      const lastViewStartedAt = Number(
-        (target as HTMLElement).dataset.lastViewStartedAt || '',
-      )
-      if (
-        time - lastViewStartedAt >= MINIMUM_INTERSECTING_TIME &&
-        hasPrevMessage
-      ) {
-        const pastMessages = await fetchPastMessages()
+      if (!(target as HTMLElement).dataset.viewStartedAt) {
+        ;(target as HTMLElement).dataset.viewStartedAt = time.toString()
+      } else {
+        const viewStartedAt = Number(
+          (target as HTMLElement).dataset.viewStartedAt,
+        )
+        if (
+          time - viewStartedAt >= MINIMUM_INTERSECTING_TIME &&
+          hasPrevMessage
+        ) {
+          const pastMessages = await fetchPastMessages()
 
-        await dispatch({
-          action: ChatActions.PAST,
-          messages: pastMessages,
-        })
-        setScrollY(prevScrollY)
+          await dispatch({
+            action: ChatActions.PAST,
+            messages: pastMessages,
+          })
+          setScrollY(prevScrollY)
+        }
       }
     }
-    ;(target as HTMLElement).dataset.lastViewStartedAt = time.toString()
   }
 
   return (

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -25,7 +25,7 @@ import { useChat } from './chat-context'
 import { useChatMessage } from './use-chat-message'
 import { getChatListHeight, useScrollContext } from './scroll-context'
 
-const MINIMUM_INTERSECTING_TIME = 3000
+const MINIMUM_INITIAL_INTERSECTING_TIME = 3000
 export const CHAT_CONTAINER_ID = 'chat-inner-container'
 
 export interface ChatProps {
@@ -241,7 +241,7 @@ export const Chat = ({
           (target as HTMLElement).dataset.viewStartedAt,
         )
         if (
-          time - viewStartedAt >= MINIMUM_INTERSECTING_TIME &&
+          time - viewStartedAt >= MINIMUM_INITIAL_INTERSECTING_TIME &&
           hasPrevMessage
         ) {
           const pastMessages = await fetchPastMessages()


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

- iOS 모바일 사파리에서 `Chat`이 `Popup`과 함께 사용되었을 때 init 시점에  infinite scroll이 트리거 되어 bottom으로 이동하는 스크롤과, top으로 이동하는 스크롤이 중첩되는 현상을 수정합니다. 
  - iOS 모바일 사파리에서 Intersecting이 팝업 오픈 transform이 모두 완료된 이후 true로 변경되어(iOS 모바일 사파리에서는 Intersecting 상태가 transform에 영향을 받는 것으로 예상됨, [관련 이슈](https://github.com/w3c/IntersectionObserver/issues/484)) init 시점에 bottom으로 이동하는 스크롤과, top으로 이동하는 스크롤이 중첩되어 스크롤이 부자연스러운 오류가 발생합니다. 

## 변경 내역

- IntersectionObserver의 time은 [도큐먼트가 생성된 시점으로 부터의 시간](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry/time)이므로, 채팅 메시지 infinite scroll을 위한 time 비교는 Intersecting 변경 시점으로 수정합니다. [[참고](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API/Timing_element_visibility)]
  - MINIMUM_INTERSECTING_TIME 3s 변경 필요한지 논의 필요.

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
