### PR TITLE
Chat에 disableUnreadCount props를 추가합니다.

### DIFF
--- a/packages/chat/src/chat-bubble/chat-bubble.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble.tsx
@@ -20,6 +20,7 @@ interface ChatBubbleProps {
   otherReadInfo?: OtherUnreadInterface[]
   displayTarget: UserType
   postMessageAction?: PostMessageActionType
+  disableUnreadCount?: boolean
 }
 
 const ChatBubble = ({
@@ -29,22 +30,24 @@ const ChatBubble = ({
   otherReadInfo,
   displayTarget: componentDisplayTarget,
   postMessageAction,
+  disableUnreadCount = false,
 }: ChatBubbleProps) => {
   const otherUserInfo = useMemo(
     () => others.find((other) => other.id === senderId),
     [senderId, others],
   )
 
-  const unreadCount = otherReadInfo
-    ? otherReadInfo.reduce(
-        (prev, info) =>
-          Number(info.lastSeenMessageId) < Number(message.id) &&
-          info.memberId !== message.senderId
-            ? prev + 1
-            : prev,
-        0,
-      )
-    : null
+  const unreadCount =
+    !disableUnreadCount && otherReadInfo
+      ? otherReadInfo.reduce(
+          (prev, info) =>
+            Number(info.lastSeenMessageId) < Number(message.id) &&
+            info.memberId !== message.senderId
+              ? prev + 1
+              : prev,
+          0,
+        )
+      : null
 
   const payload = useMemo(() => {
     if (!message.displayTarget || message.displayTarget === 'all') {

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -59,6 +59,7 @@ export interface ChatProps {
   showFailToast?: (message: string) => void
 
   updateChatData?: UpdateChatData
+  disableUnreadCount?: boolean
 }
 
 /**
@@ -78,6 +79,7 @@ export const Chat = ({
   notifyNewMessage,
   showFailToast,
   updateChatData,
+  disableUnreadCount = false,
   ...props
 }: ChatProps) => {
   const { chatRoomRef, bottomRef, setScrollY, scrollToBottom } =
@@ -221,7 +223,7 @@ export const Chat = ({
   }
 
   const handleChangeLastMessageId = async () => {
-    await updateUnread()
+    !disableUnreadCount && (await updateUnread())
     scrollToBottom()
 
     if (!isScrollReady.current) {
@@ -275,6 +277,7 @@ export const Chat = ({
                     postMessage ? postMessageAction : undefined
                   }
                   otherReadInfo={otherUnreadInfo}
+                  disableUnreadCount={disableUnreadCount}
                 />
               ) : null}
             </li>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
chat에 disableUnreadCount props를 추가합니다. 해당 props가 true라면
- 메세지 UI에서 메세지 읽음 숫자를 노출하지 않도록 합니다.
- 마지막 메세지 확인 시 last-message API 호출을 하지 않도록 합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

