### PR TITLE
[Chat] message에 blinded 필드를 추가합니다.

### DIFF
--- a/packages/chat/src/bubbles/rich.tsx
+++ b/packages/chat/src/bubbles/rich.tsx
@@ -8,6 +8,7 @@ import {
   ButtonPayload,
   TextPayload,
   ImagePayload,
+  BackgroundColor,
 } from '../types'
 
 import { ImageBubble } from './image'
@@ -44,6 +45,7 @@ export function RichBubble({
   cloudinaryName,
   mediaUrlBase,
   onImageBubbleClick,
+  bubbleColor,
 }: {
   my: boolean
   items: (TextPayload | ImagePayload | ButtonPayload)[]
@@ -53,6 +55,7 @@ export function RichBubble({
   cloudinaryName: string
   mediaUrlBase: string
   onImageBubbleClick?: (imageInfos: MetaDataInterface[]) => void
+  bubbleColor?: { backgroundColor: BackgroundColor; text: string }
 }) {
   return (
     <TextBubble
@@ -60,6 +63,7 @@ export function RichBubble({
       size={textBubbleFontSize}
       maxWidthOffset={textBubbleMaxWidthOffset}
       margin={my ? { left: 8 } : undefined}
+      bubbleColor={bubbleColor}
     >
       {items.map((item, index) => {
         switch (item.type) {

--- a/packages/chat/src/bubbles/rich.tsx
+++ b/packages/chat/src/bubbles/rich.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled from 'styled-components'
 import { GlobalSizes } from '@titicaca/type-definitions'
 
@@ -8,8 +7,8 @@ import {
   ButtonPayload,
   TextPayload,
   ImagePayload,
-  BackgroundColor,
 } from '../types'
+import { BackgroundColor } from '../types/ui'
 
 import { ImageBubble } from './image'
 import { TextBubble } from './text'
@@ -55,7 +54,7 @@ export function RichBubble({
   cloudinaryName: string
   mediaUrlBase: string
   onImageBubbleClick?: (imageInfos: MetaDataInterface[]) => void
-  bubbleColor?: { backgroundColor: BackgroundColor; text: string }
+  bubbleColor?: { backgroundColor: BackgroundColor; textColor: string }
 }) {
   return (
     <TextBubble

--- a/packages/chat/src/bubbles/text.ts
+++ b/packages/chat/src/bubbles/text.ts
@@ -67,21 +67,19 @@ export const TextBubble = styled(Text).attrs({
     position: absolute;
     top: 5px;
     background-size: 10px 17px;
-    ${({ my, bubbleColor }) => css`
-      background-image: url('${getBackgroundImage(
+    background-image: url(${({ my, bubbleColor }) =>
+      `${getBackgroundImage(
         bubbleColor?.backgroundColor || getDefaultBackgroundColor(my),
-      )}');
-    `}
+      )}`});
   }
 
   ${({ maxWidthOffset }) => `max-width: calc(100% - ${maxWidthOffset}px);`}
-  ${({ my, bubbleColor }) =>
-    css`
-      background-color: ${BACKGROUND_COLORS[
+  background-color: ${({ my, bubbleColor }) =>
+    `${
+      BACKGROUND_COLORS[
         bubbleColor?.backgroundColor || getDefaultBackgroundColor(my)
-      ]};
-      color: ${bubbleColor?.textColor || 'var(--color-gray)'};
-    `}
+      ]
+    }`};
   ${({ my }) => css`
     ${TAIL_POSITION_STYLE_MAP[my ? 'right' : 'left']}
   `}

--- a/packages/chat/src/bubbles/text.ts
+++ b/packages/chat/src/bubbles/text.ts
@@ -1,9 +1,15 @@
 import styled, { css } from 'styled-components'
 import { Text } from '@titicaca/core-elements'
 
-const BACKGROUND_COLORS: { [key: string]: string } = {
+import { BackgroundColor } from '../types'
+
+const BACKGROUND_COLORS: {
+  [key in BackgroundColor]: string
+} = {
   blue: '#d7e9ff',
   gray: '#f5f5f5',
+  darkGray: '#F6F6F6',
+  mint: '#24CABD',
 }
 
 const TAIL_POSITION_STYLE_MAP: { [key: string]: ReturnType<typeof css> } = {
@@ -21,10 +27,12 @@ const TAIL_POSITION_STYLE_MAP: { [key: string]: ReturnType<typeof css> } = {
   `,
 }
 
-const getBackgroundImage = (my: boolean) => {
-  return `https://assets.triple.guide/images/img-speechbubble-${
-    my ? 'blue' : 'gray'
-  }@3x.png`
+const getBackgroundImage = (color: BackgroundColor) => {
+  return `https://assets.triple-dev.titicaca-corp.com/images/img-speechbubble-${color}@3x.png`
+}
+
+function getDefaultBackgroundColor(my: boolean) {
+  return my ? 'blue' : 'gray'
 }
 
 /**
@@ -37,6 +45,7 @@ export const TextBubble = styled(Text).attrs({
 })<{
   maxWidthOffset: number
   my: boolean
+  bubbleColor?: { backgroundColor: BackgroundColor; text: string }
 }>`
   border-radius: 10px;
   position: relative;
@@ -58,12 +67,22 @@ export const TextBubble = styled(Text).attrs({
     position: absolute;
     top: 5px;
     background-size: 10px 17px;
-    background-image: url(${({ my }) => getBackgroundImage(my)});
+    ${({ my, bubbleColor }) => css`
+      background-image: url(${getBackgroundImage(
+        bubbleColor?.backgroundColor || getDefaultBackgroundColor(my),
+      )});
+    `}
   }
 
   ${({ maxWidthOffset }) => `max-width: calc(100% - ${maxWidthOffset}px);`}
+  ${({ my, bubbleColor }) =>
+    css`
+      background-color: ${BACKGROUND_COLORS[
+        bubbleColor?.backgroundColor || getDefaultBackgroundColor(my)
+      ]};
+      color: ${bubbleColor?.text || 'gray'};
+    `}
   ${({ my }) => css`
-    background-color: ${BACKGROUND_COLORS[my ? 'blue' : 'gray']};
     ${TAIL_POSITION_STYLE_MAP[my ? 'right' : 'left']}
   `}
 `

--- a/packages/chat/src/bubbles/text.ts
+++ b/packages/chat/src/bubbles/text.ts
@@ -80,7 +80,7 @@ export const TextBubble = styled(Text).attrs({
       background-color: ${BACKGROUND_COLORS[
         bubbleColor?.backgroundColor || getDefaultBackgroundColor(my)
       ]};
-      color: ${bubbleColor?.text || 'gray'};
+      color: ${bubbleColor?.text || 'var(--color-gray)'};
     `}
   ${({ my }) => css`
     ${TAIL_POSITION_STYLE_MAP[my ? 'right' : 'left']}

--- a/packages/chat/src/bubbles/text.ts
+++ b/packages/chat/src/bubbles/text.ts
@@ -1,7 +1,7 @@
 import styled, { css } from 'styled-components'
 import { Text } from '@titicaca/core-elements'
 
-import { BackgroundColor } from '../types'
+import { BackgroundColor } from '../types/ui'
 
 const BACKGROUND_COLORS: {
   [key in BackgroundColor]: string
@@ -45,7 +45,7 @@ export const TextBubble = styled(Text).attrs({
 })<{
   maxWidthOffset: number
   my: boolean
-  bubbleColor?: { backgroundColor: BackgroundColor; text: string }
+  bubbleColor?: { backgroundColor: BackgroundColor; textColor: string }
 }>`
   border-radius: 10px;
   position: relative;
@@ -68,9 +68,9 @@ export const TextBubble = styled(Text).attrs({
     top: 5px;
     background-size: 10px 17px;
     ${({ my, bubbleColor }) => css`
-      background-image: url(${getBackgroundImage(
+      background-image: url('${getBackgroundImage(
         bubbleColor?.backgroundColor || getDefaultBackgroundColor(my),
-      )});
+      )}');
     `}
   }
 
@@ -80,7 +80,7 @@ export const TextBubble = styled(Text).attrs({
       background-color: ${BACKGROUND_COLORS[
         bubbleColor?.backgroundColor || getDefaultBackgroundColor(my)
       ]};
-      color: ${bubbleColor?.text || 'var(--color-gray)'};
+      color: ${bubbleColor?.textColor || 'var(--color-gray)'};
     `}
   ${({ my }) => css`
     ${TAIL_POSITION_STYLE_MAP[my ? 'right' : 'left']}

--- a/packages/chat/src/bubbles/text.ts
+++ b/packages/chat/src/bubbles/text.ts
@@ -83,4 +83,6 @@ export const TextBubble = styled(Text).attrs({
   ${({ my }) => css`
     ${TAIL_POSITION_STYLE_MAP[my ? 'right' : 'left']}
   `}
+  color: ${({ bubbleColor }) =>
+    `${bubbleColor?.textColor || 'var(--color-gray)'}`}
 `

--- a/packages/chat/src/chat-bubble/blinded.tsx
+++ b/packages/chat/src/chat-bubble/blinded.tsx
@@ -3,12 +3,12 @@ import styled from 'styled-components'
 
 import { useChat } from '../chat'
 import { TextBubble } from '../bubbles/text'
-import { BackgroundColor } from '../types'
+import { BackgroundColor } from '../types/ui'
 
 const ExclamationMarkIcon = styled.span<{ color?: 'gray' | 'white' }>`
-  background-image: url('https://assets.triple.guide/images/ico_exclamation_mark_${({
-    color = 'gray',
-  }) => color}.svg');
+  ${({ color = 'gray' }) =>
+    `background-image: url('https://assets.triple.guide/images/ico_exclamation_mark_${color}.svg');`}
+
   width: 16px;
   height: 16px;
 `
@@ -19,7 +19,7 @@ export default function BlindedBubble({
 }: {
   my: boolean
   blindedText?: string
-  bubbleColor?: { backgroundColor: BackgroundColor; text: string }
+  bubbleColor?: { backgroundColor: BackgroundColor; textColor: string }
 }) {
   const { textBubbleMaxWidthOffset } = useChat()
   return (

--- a/packages/chat/src/chat-bubble/blinded.tsx
+++ b/packages/chat/src/chat-bubble/blinded.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import { useChat } from '../chat'
 import { TextBubble } from '../bubbles/text'
+import { BackgroundColor } from '../types'
 
 const ExclamationMarkIcon = styled.span<{ color?: 'gray' | 'white' }>`
   background-image: url('https://assets.triple.guide/images/ico_exclamation_mark_${({
@@ -14,9 +15,11 @@ const ExclamationMarkIcon = styled.span<{ color?: 'gray' | 'white' }>`
 export default function BlindedBubble({
   my,
   blindedText,
+  bubbleColor,
 }: {
   my: boolean
   blindedText?: string
+  bubbleColor?: { backgroundColor: BackgroundColor; text: string }
 }) {
   const { textBubbleMaxWidthOffset } = useChat()
   return (
@@ -24,6 +27,7 @@ export default function BlindedBubble({
       maxWidthOffset={textBubbleMaxWidthOffset}
       my={my}
       margin={my ? { left: 8 } : undefined}
+      bubbleColor={bubbleColor}
     >
       <FlexBox flex alignItems="center" gap="4px">
         <ExclamationMarkIcon

--- a/packages/chat/src/chat-bubble/blinded.tsx
+++ b/packages/chat/src/chat-bubble/blinded.tsx
@@ -1,0 +1,37 @@
+import { FlexBox } from '@titicaca/core-elements'
+import styled from 'styled-components'
+
+import { useChat } from '../chat'
+import { TextBubble } from '../bubbles/text'
+
+const ExclamationMarkIcon = styled.span<{ color?: 'gray' | 'white' }>`
+  background-image: url('https://assets.triple.guide/images/ico_exclamation_mark_${({
+    color = 'gray',
+  }) => color}.svg');
+  width: 16px;
+  height: 16px;
+`
+export default function BlindedBubble({
+  my,
+  blindedText,
+}: {
+  my: boolean
+  blindedText?: string
+}) {
+  const { textBubbleMaxWidthOffset } = useChat()
+  return (
+    <TextBubble
+      maxWidthOffset={textBubbleMaxWidthOffset}
+      my={my}
+      margin={my ? { left: 8 } : undefined}
+    >
+      <FlexBox flex alignItems="center" gap="4px">
+        <ExclamationMarkIcon
+          color={my ? 'white' : 'gray'}
+          style={{ flex: '0 0 16px' }}
+        />
+        <span>{blindedText ?? '관리자에 의해 삭제되었습니다'}</span>
+      </FlexBox>
+    </TextBubble>
+  )
+}

--- a/packages/chat/src/chat-bubble/bubble-payload.tsx
+++ b/packages/chat/src/chat-bubble/bubble-payload.tsx
@@ -2,18 +2,13 @@ import { Autolinker } from 'autolinker'
 
 import { ImageBubble, RichBubble, TextBubble } from '../bubbles'
 import { useChat } from '../chat'
-import {
-  BackgroundColor,
-  ImagePayload,
-  MessageType,
-  RichPayload,
-  TextPayload,
-} from '../types'
+import { ImagePayload, MessageType, RichPayload, TextPayload } from '../types'
+import { BackgroundColor } from '../types/ui'
 
 interface BubblePayloadProps {
   payload: TextPayload | ImagePayload | RichPayload
   my: boolean
-  bubbleColor?: { backgroundColor: BackgroundColor; text: string }
+  bubbleColor?: { backgroundColor: BackgroundColor; textColor: string }
 }
 
 const BubblePayload = ({ payload, my, bubbleColor }: BubblePayloadProps) => {

--- a/packages/chat/src/chat-bubble/bubble-payload.tsx
+++ b/packages/chat/src/chat-bubble/bubble-payload.tsx
@@ -2,14 +2,21 @@ import { Autolinker } from 'autolinker'
 
 import { ImageBubble, RichBubble, TextBubble } from '../bubbles'
 import { useChat } from '../chat'
-import { ImagePayload, MessageType, RichPayload, TextPayload } from '../types'
+import {
+  BackgroundColor,
+  ImagePayload,
+  MessageType,
+  RichPayload,
+  TextPayload,
+} from '../types'
 
 interface BubblePayloadProps {
   payload: TextPayload | ImagePayload | RichPayload
   my: boolean
+  bubbleColor?: { backgroundColor: BackgroundColor; text: string }
 }
 
-const BubblePayload = ({ payload, my }: BubblePayloadProps) => {
+const BubblePayload = ({ payload, my, bubbleColor }: BubblePayloadProps) => {
   const {
     textBubbleFontSize,
     textBubbleMaxWidthOffset,
@@ -37,6 +44,7 @@ const BubblePayload = ({ payload, my }: BubblePayloadProps) => {
           size={textBubbleFontSize}
           maxWidthOffset={textBubbleMaxWidthOffset}
           margin={my ? { left: 8 } : undefined}
+          bubbleColor={bubbleColor}
         >
           <div
             onClick={onTextBubbleClick}
@@ -61,6 +69,7 @@ const BubblePayload = ({ payload, my }: BubblePayloadProps) => {
           cloudinaryName={cloudinaryName}
           mediaUrlBase={mediaUrlBase}
           onImageBubbleClick={onImageBubbleClick}
+          bubbleColor={bubbleColor}
         />
       )
     default:

--- a/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
@@ -1,7 +1,12 @@
 import React, { PropsWithChildren, useState } from 'react'
 import { Container } from '@titicaca/core-elements'
 
-import { TextPayload, ImagePayload, RichPayload } from '../types'
+import {
+  TextPayload,
+  ImagePayload,
+  RichPayload,
+  BackgroundColorInterface,
+} from '../types'
 
 import { BubbleInfo } from './bubble-info'
 import {
@@ -123,6 +128,24 @@ export interface ChatBubbleUIProps {
    * 'sent' 타입일 때, 메시지 전송 실패할 경우 재시도를 취소하는 함수
    */
   onCancel?: () => void
+  bubbleColor?: {
+    sent: { backgroundColor: BackgroundColorInterface['sent']; text: string }
+    received: {
+      backgroundColor: BackgroundColorInterface['received']
+      text: string
+    }
+  }
+}
+
+const DEFAULT_BUBBLE_COLOR: {
+  sent: { backgroundColor: BackgroundColorInterface['sent']; text: string }
+  received: {
+    backgroundColor: BackgroundColorInterface['received']
+    text: string
+  }
+} = {
+  sent: { backgroundColor: 'blue', text: 'var(--color-gray)' },
+  received: { backgroundColor: 'gray', text: 'var(--color-gray)' },
 }
 
 export function ChatBubbleUI({
@@ -135,6 +158,7 @@ export function ChatBubbleUI({
   blindedAt,
   blindedText,
   onRetry,
+  bubbleColor = DEFAULT_BUBBLE_COLOR,
 }: ChatBubbleUIProps) {
   switch (type) {
     case 'sent':
@@ -145,9 +169,17 @@ export function ChatBubbleUI({
           onRetry={onRetry}
         >
           {blindedAt ? (
-            <BlindedBubble my blindedText={blindedText} />
+            <BlindedBubble
+              my
+              blindedText={blindedText}
+              bubbleColor={bubbleColor?.sent}
+            />
           ) : (
-            <BubblePayload payload={payload} my />
+            <BubblePayload
+              payload={payload}
+              my
+              bubbleColor={bubbleColor?.sent}
+            />
           )}
         </SentChatContainer>
       )
@@ -160,9 +192,17 @@ export function ChatBubbleUI({
           profileName={profileName}
         >
           {blindedAt ? (
-            <BlindedBubble my={false} blindedText={blindedText} />
+            <BlindedBubble
+              my={false}
+              blindedText={blindedText}
+              bubbleColor={bubbleColor?.received}
+            />
           ) : (
-            <BubblePayload payload={payload} my={false} />
+            <BubblePayload
+              payload={payload}
+              my={false}
+              bubbleColor={bubbleColor?.received}
+            />
           )}
         </ReceivedChatContainer>
       )

--- a/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
@@ -12,6 +12,7 @@ import {
   ProfileName,
 } from './elements'
 import BubblePayload from './bubble-payload'
+import BlindedBubble from './blinded'
 
 const CHAT_CONTAINER_STYLES = {
   marginTop: 20,
@@ -112,6 +113,8 @@ export interface ChatBubbleUIProps {
   profileName?: string
   unreadCount: number | null
   createdAt?: string
+  blindedAt?: string
+  blindedText?: string
   /**
    * 'sent' 타입일 때, 메시지 전송 실패할 경우 재시도하는 함수
    */
@@ -129,6 +132,8 @@ export function ChatBubbleUI({
   createdAt,
   profileImageUrl,
   profileName,
+  blindedAt,
+  blindedText,
   onRetry,
 }: ChatBubbleUIProps) {
   switch (type) {
@@ -139,7 +144,11 @@ export function ChatBubbleUI({
           unreadCount={unreadCount}
           onRetry={onRetry}
         >
-          <BubblePayload payload={payload} my />
+          {blindedAt ? (
+            <BlindedBubble my blindedText={blindedText} />
+          ) : (
+            <BubblePayload payload={payload} my />
+          )}
         </SentChatContainer>
       )
     case 'received':
@@ -150,7 +159,11 @@ export function ChatBubbleUI({
           profileImageUrl={profileImageUrl}
           profileName={profileName}
         >
-          <BubblePayload payload={payload} my={false} />
+          {blindedAt ? (
+            <BlindedBubble my={false} blindedText={blindedText} />
+          ) : (
+            <BubblePayload payload={payload} my={false} />
+          )}
         </ReceivedChatContainer>
       )
     default:

--- a/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
@@ -1,12 +1,8 @@
 import React, { PropsWithChildren, useState } from 'react'
 import { Container } from '@titicaca/core-elements'
 
-import {
-  TextPayload,
-  ImagePayload,
-  RichPayload,
-  BackgroundColorInterface,
-} from '../types'
+import { TextPayload, ImagePayload, RichPayload } from '../types'
+import { BubbleColor, ChatBubbleColor } from '../types/ui'
 
 import { BubbleInfo } from './bubble-info'
 import {
@@ -128,24 +124,15 @@ export interface ChatBubbleUIProps {
    * 'sent' 타입일 때, 메시지 전송 실패할 경우 재시도를 취소하는 함수
    */
   onCancel?: () => void
-  bubbleColor?: {
-    sent: { backgroundColor: BackgroundColorInterface['sent']; text: string }
-    received: {
-      backgroundColor: BackgroundColorInterface['received']
-      text: string
-    }
-  }
+  bubbleColor?: ChatBubbleColor
 }
 
 const DEFAULT_BUBBLE_COLOR: {
-  sent: { backgroundColor: BackgroundColorInterface['sent']; text: string }
-  received: {
-    backgroundColor: BackgroundColorInterface['received']
-    text: string
-  }
+  sent: BubbleColor<'sent'>
+  received: BubbleColor<'received'>
 } = {
-  sent: { backgroundColor: 'blue', text: 'var(--color-gray)' },
-  received: { backgroundColor: 'gray', text: 'var(--color-gray)' },
+  sent: { backgroundColor: 'blue', textColor: 'var(--color-gray)' },
+  received: { backgroundColor: 'gray', textColor: 'var(--color-gray)' },
 }
 
 export function ChatBubbleUI({

--- a/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren, useState } from 'react'
 import { Container } from '@titicaca/core-elements'
 
 import { TextPayload, ImagePayload, RichPayload } from '../types'
-import { BubbleColor, ChatBubbleColor } from '../types/ui'
+import { ChatBubbleColor } from '../types/ui'
 
 import { BubbleInfo } from './bubble-info'
 import {
@@ -127,14 +127,6 @@ export interface ChatBubbleUIProps {
   bubbleColor?: ChatBubbleColor
 }
 
-const DEFAULT_BUBBLE_COLOR: {
-  sent: BubbleColor<'sent'>
-  received: BubbleColor<'received'>
-} = {
-  sent: { backgroundColor: 'blue', textColor: 'var(--color-gray)' },
-  received: { backgroundColor: 'gray', textColor: 'var(--color-gray)' },
-}
-
 export function ChatBubbleUI({
   type,
   payload,
@@ -145,10 +137,11 @@ export function ChatBubbleUI({
   blindedAt,
   blindedText,
   onRetry,
-  bubbleColor = DEFAULT_BUBBLE_COLOR,
+  bubbleColor,
 }: ChatBubbleUIProps) {
   switch (type) {
-    case 'sent':
+    case 'sent': {
+      const sentBubbleColor = bubbleColor?.sent
       return (
         <SentChatContainer
           createdAt={createdAt}
@@ -159,18 +152,36 @@ export function ChatBubbleUI({
             <BlindedBubble
               my
               blindedText={blindedText}
-              bubbleColor={bubbleColor?.sent}
+              bubbleColor={
+                sentBubbleColor
+                  ? {
+                      ...sentBubbleColor,
+                      textColor:
+                        sentBubbleColor.textColor.blinded ||
+                        sentBubbleColor.textColor.normal,
+                    }
+                  : undefined
+              }
             />
           ) : (
             <BubblePayload
               payload={payload}
               my
-              bubbleColor={bubbleColor?.sent}
+              bubbleColor={
+                sentBubbleColor
+                  ? {
+                      ...sentBubbleColor,
+                      textColor: sentBubbleColor.textColor.normal,
+                    }
+                  : undefined
+              }
             />
           )}
         </SentChatContainer>
       )
-    case 'received':
+    }
+    case 'received': {
+      const receivedBubbleColor = bubbleColor?.received
       return (
         <ReceivedChatContainer
           unreadCount={unreadCount}
@@ -182,17 +193,34 @@ export function ChatBubbleUI({
             <BlindedBubble
               my={false}
               blindedText={blindedText}
-              bubbleColor={bubbleColor?.received}
+              bubbleColor={
+                receivedBubbleColor
+                  ? {
+                      ...receivedBubbleColor,
+                      textColor:
+                        receivedBubbleColor.textColor.blinded ||
+                        receivedBubbleColor.textColor.normal,
+                    }
+                  : undefined
+              }
             />
           ) : (
             <BubblePayload
               payload={payload}
               my={false}
-              bubbleColor={bubbleColor?.received}
+              bubbleColor={
+                receivedBubbleColor
+                  ? {
+                      ...receivedBubbleColor,
+                      textColor: receivedBubbleColor.textColor.normal,
+                    }
+                  : undefined
+              }
             />
           )}
         </ReceivedChatContainer>
       )
+    }
     default:
       return null
   }

--- a/packages/chat/src/chat-bubble/chat-bubble.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble.tsx
@@ -1,6 +1,7 @@
-import React, { memo, useMemo } from 'react'
+import { memo, useMemo } from 'react'
 
 import {
+  BackgroundColorInterface,
   ImagePayload,
   MessageInterface,
   MessageType,
@@ -24,6 +25,13 @@ interface ChatBubbleProps {
   onRetryButtonClick?: () => void
   onRetryCancelButtonClick?: () => void
   blindedText?: string
+  bubbleColor?: {
+    sent: { backgroundColor: BackgroundColorInterface['sent']; text: string }
+    received: {
+      backgroundColor: BackgroundColorInterface['received']
+      text: string
+    }
+  }
 }
 
 const ChatBubble = ({
@@ -37,6 +45,7 @@ const ChatBubble = ({
   onRetryCancelButtonClick,
   disableUnreadCount = false,
   blindedText,
+  bubbleColor,
 }: ChatBubbleProps) => {
   const otherUserInfo = useMemo(
     () => others.find((other) => other.id === senderId),
@@ -101,6 +110,7 @@ const ChatBubble = ({
       onCancel={onCancel}
       blindedAt={message.blindedAt}
       blindedText={blindedText}
+      bubbleColor={bubbleColor}
     />
   )
 }

--- a/packages/chat/src/chat-bubble/chat-bubble.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble.tsx
@@ -1,7 +1,6 @@
 import { memo, useMemo } from 'react'
 
 import {
-  BackgroundColorInterface,
   ImagePayload,
   MessageInterface,
   MessageType,
@@ -12,6 +11,7 @@ import {
   UserType,
 } from '../types'
 import { getProfileImageUrl } from '../utils'
+import { ChatBubbleColor } from '../types/ui'
 
 import { ChatBubbleUI } from './chat-bubble-ui'
 
@@ -25,13 +25,7 @@ interface ChatBubbleProps {
   onRetryButtonClick?: () => void
   onRetryCancelButtonClick?: () => void
   blindedText?: string
-  bubbleColor?: {
-    sent: { backgroundColor: BackgroundColorInterface['sent']; text: string }
-    received: {
-      backgroundColor: BackgroundColorInterface['received']
-      text: string
-    }
-  }
+  bubbleColor?: ChatBubbleColor
 }
 
 const ChatBubble = ({

--- a/packages/chat/src/chat-bubble/chat-bubble.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble.tsx
@@ -56,12 +56,6 @@ const ChatBubble = ({
       : null
 
   const payload = useMemo(() => {
-    if (message.blinded) {
-      return {
-        type: MessageType.TEXT,
-        message: blindedText || '관리자에 의해 삭제된 메세지입니다.',
-      } as TextPayload
-    }
     if (!message.displayTarget || message.displayTarget === 'all') {
       return message.payload
     }
@@ -105,6 +99,8 @@ const ChatBubble = ({
       payload={payload}
       onRetry={couldRetry ? onRetry : undefined}
       onCancel={onCancel}
+      blindedAt={message.blindedAt}
+      blindedText={blindedText}
     />
   )
 }

--- a/packages/chat/src/chat-bubble/chat-bubble.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble.tsx
@@ -23,6 +23,7 @@ interface ChatBubbleProps {
   disableUnreadCount?: boolean
   onRetryButtonClick?: () => void
   onRetryCancelButtonClick?: () => void
+  blindedText?: string
 }
 
 const ChatBubble = ({
@@ -35,6 +36,7 @@ const ChatBubble = ({
   onRetryButtonClick,
   onRetryCancelButtonClick,
   disableUnreadCount = false,
+  blindedText,
 }: ChatBubbleProps) => {
   const otherUserInfo = useMemo(
     () => others.find((other) => other.id === senderId),
@@ -54,6 +56,12 @@ const ChatBubble = ({
       : null
 
   const payload = useMemo(() => {
+    if (message.blinded) {
+      return {
+        type: MessageType.TEXT,
+        message: blindedText || '관리자에 의해 삭제된 메세지입니다.',
+      } as TextPayload
+    }
     if (!message.displayTarget || message.displayTarget === 'all') {
       return message.payload
     }

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -7,7 +7,6 @@ import { closeKeyboard } from '@titicaca/triple-web-to-native-interfaces'
 import { Container } from '@titicaca/core-elements'
 
 import {
-  BackgroundColorInterface,
   HasUnreadOfRoomInterface,
   ImagePayload,
   MessageInterface,
@@ -20,6 +19,7 @@ import {
 } from '../types'
 import ChatBubble from '../chat-bubble'
 import { HiddenElement } from '../chat-bubble/elements'
+import { ChatBubbleColor } from '../types/ui'
 
 import { ChatActions, ChatReducer, initialChatState } from './reducer'
 import { useChat } from './chat-context'
@@ -58,13 +58,7 @@ export interface ChatProps {
   updateChatData?: UpdateChatData
   disableUnreadCount?: boolean
   blindedText?: string
-  bubbleColor?: {
-    sent: { backgroundColor: BackgroundColorInterface['sent']; text: string }
-    received: {
-      backgroundColor: BackgroundColorInterface['received']
-      text: string
-    }
-  }
+  bubbleColor?: ChatBubbleColor
 }
 
 /**

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -1,18 +1,13 @@
 import { IncomingMessage } from 'http'
 
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useReducer,
-  useRef,
-} from 'react'
+import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import { StaticIntersectionObserver as IntersectionObserver } from '@titicaca/intersection-observer'
 import { useUserAgentContext } from '@titicaca/react-contexts'
 import { closeKeyboard } from '@titicaca/triple-web-to-native-interfaces'
 import { Container } from '@titicaca/core-elements'
 
 import {
+  BackgroundColorInterface,
   HasUnreadOfRoomInterface,
   ImagePayload,
   MessageInterface,
@@ -63,6 +58,13 @@ export interface ChatProps {
   updateChatData?: UpdateChatData
   disableUnreadCount?: boolean
   blindedText?: string
+  bubbleColor?: {
+    sent: { backgroundColor: BackgroundColorInterface['sent']; text: string }
+    received: {
+      backgroundColor: BackgroundColorInterface['received']
+      text: string
+    }
+  }
 }
 
 /**
@@ -86,6 +88,7 @@ export const Chat = ({
   updateChatData,
   disableUnreadCount = false,
   blindedText,
+  bubbleColor,
   ...props
 }: ChatProps) => {
   const { chatRoomRef, bottomRef, setScrollY, scrollToBottom } =
@@ -287,6 +290,7 @@ export const Chat = ({
                   onRetryCancelButtonClick={onRetryCancelButtonClick}
                   disableUnreadCount={disableUnreadCount}
                   blindedText={blindedText}
+                  bubbleColor={bubbleColor}
                 />
               ) : null}
             </li>

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -62,6 +62,7 @@ export interface ChatProps {
 
   updateChatData?: UpdateChatData
   disableUnreadCount?: boolean
+  blindedText?: string
 }
 
 /**
@@ -84,6 +85,7 @@ export const Chat = ({
   onRetryCancelButtonClick,
   updateChatData,
   disableUnreadCount = false,
+  blindedText,
   ...props
 }: ChatProps) => {
   const { chatRoomRef, bottomRef, setScrollY, scrollToBottom } =
@@ -284,6 +286,7 @@ export const Chat = ({
                   onRetryButtonClick={onRetryButtonClick}
                   onRetryCancelButtonClick={onRetryCancelButtonClick}
                   disableUnreadCount={disableUnreadCount}
+                  blindedText={blindedText}
                 />
               ) : null}
             </li>

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -208,10 +208,3 @@ export interface MetaDataInterface {
   width: number
   height: number
 }
-
-export type BackgroundColor = 'mint' | 'blue' | 'gray' | 'darkGray'
-
-export interface BackgroundColorInterface {
-  sent: Extract<BackgroundColor, 'mint' | 'blue'>
-  received: Extract<BackgroundColor, 'gray' | 'darkGray'>
-}

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -69,7 +69,7 @@ export interface MessageInterface {
   createdAt?: string
   displayTarget?: UserType[] | DisplayTargetAll
   alternative?: TextPayload | ImagePayload | RichPayload
-  blinded?: boolean
+  blindedAt?: string
 }
 
 export interface UserInterface {

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -69,6 +69,7 @@ export interface MessageInterface {
   createdAt?: string
   displayTarget?: UserType[] | DisplayTargetAll
   alternative?: TextPayload | ImagePayload | RichPayload
+  blinded?: boolean
 }
 
 export interface UserInterface {

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -208,3 +208,10 @@ export interface MetaDataInterface {
   width: number
   height: number
 }
+
+export type BackgroundColor = 'mint' | 'blue' | 'gray' | 'darkGray'
+
+export interface BackgroundColorInterface {
+  sent: Extract<BackgroundColor, 'mint' | 'blue'>
+  received: Extract<BackgroundColor, 'gray' | 'darkGray'>
+}

--- a/packages/chat/src/types/ui.ts
+++ b/packages/chat/src/types/ui.ts
@@ -7,14 +7,11 @@ export interface BackgroundColorInterface {
 
 export interface BubbleColor<T extends 'sent' | 'received'> {
   backgroundColor: BackgroundColorInterface[T]
-  textColor: string
+  textColor: {
+    normal: string
+    blinded?: string
+  }
 }
-
-// type BubbleColor<T extends 'sent' | 'received' | undefined = undefined> = {
-//   textColor: string
-// } & (T extends undefined
-//   ? { backgroundColor: BackgroundColor }
-//   : { backgroundColor: BackgroundColorInterface[T] })
 
 export interface ChatBubbleColor {
   sent: BubbleColor<'sent'>

--- a/packages/chat/src/types/ui.ts
+++ b/packages/chat/src/types/ui.ts
@@ -1,0 +1,22 @@
+export type BackgroundColor = 'mint' | 'blue' | 'gray' | 'darkGray'
+
+export interface BackgroundColorInterface {
+  sent: Extract<BackgroundColor, 'mint' | 'blue'>
+  received: Extract<BackgroundColor, 'gray' | 'darkGray'>
+}
+
+export interface BubbleColor<T extends 'sent' | 'received'> {
+  backgroundColor: BackgroundColorInterface[T]
+  textColor: string
+}
+
+// type BubbleColor<T extends 'sent' | 'received' | undefined = undefined> = {
+//   textColor: string
+// } & (T extends undefined
+//   ? { backgroundColor: BackgroundColor }
+//   : { backgroundColor: BackgroundColorInterface[T] })
+
+export interface ChatBubbleColor {
+  sent: BubbleColor<'sent'>
+  received: BubbleColor<'received'>
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

관리자에 의해 blind된 메세지를 위해 `blinded` 필드를 추가합니다. `Chat` 컴포넌트의 prop으로 `blindedText`를 설정해 넘겨주게 되면 해당 텍스트를 노출하고, `blindedText`가 설정되지 않았을 경우에는 기본 텍스트인 `관리자에 의해 삭제된 메세지입니다.`를 노출합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- `MessageInterface`에 `blinded` 추가
- `Chat` 컴포넌트 prop에 `blindedText` 추가
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

message의 blind가 true일 때
- `blindedText` 설정 시
![image](https://github.com/titicacadev/triple-frontend/assets/43779313/4c955849-5d63-48f7-9b8e-fd4fd7cc8e35)

- `blindedText` 미설정 시
![image](https://github.com/titicacadev/triple-frontend/assets/43779313/a371ad50-162c-49c4-ad09-d26606310172)

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
