### PR TITLE
tsconfig emit 관련 설정을 tsconfig.build.json 으로 이동

### DIFF
--- a/packages/ab-experiments/tsconfig.build.json
+++ b/packages/ab-experiments/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/action-sheet/tsconfig.build.json
+++ b/packages/action-sheet/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/ad-banners/tsconfig.build.json
+++ b/packages/ad-banners/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/app-banner/tsconfig.build.json
+++ b/packages/app-banner/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/app-installation-cta/tsconfig.build.json
+++ b/packages/app-installation-cta/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/author/tsconfig.build.json
+++ b/packages/author/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/booking-completion/tsconfig.build.json
+++ b/packages/booking-completion/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/carousel/tsconfig.build.json
+++ b/packages/carousel/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/chat/tsconfig.build.json
+++ b/packages/chat/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/color-palette/tsconfig.build.json
+++ b/packages/color-palette/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/constants/tsconfig.build.json
+++ b/packages/constants/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/content-sharing/tsconfig.build.json
+++ b/packages/content-sharing/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/core-elements/tsconfig.build.json
+++ b/packages/core-elements/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/date-picker/tsconfig.build.json
+++ b/packages/date-picker/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/directions-finder/tsconfig.build.json
+++ b/packages/directions-finder/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/drawer-button/tsconfig.build.json
+++ b/packages/drawer-button/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/fetcher/tsconfig.build.json
+++ b/packages/fetcher/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/footer/tsconfig.build.json
+++ b/packages/footer/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/form/tsconfig.build.json
+++ b/packages/form/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/hub-form/tsconfig.build.json
+++ b/packages/hub-form/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/i18n/tsconfig.build.json
+++ b/packages/i18n/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/icons/tsconfig.build.json
+++ b/packages/icons/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/image-carousel/tsconfig.build.json
+++ b/packages/image-carousel/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/intersection-observer/tsconfig.build.json
+++ b/packages/intersection-observer/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/listing-filter/tsconfig.build.json
+++ b/packages/listing-filter/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/location-properties/tsconfig.build.json
+++ b/packages/location-properties/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/map/tsconfig.build.json
+++ b/packages/map/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/meta-tags/tsconfig.build.json
+++ b/packages/meta-tags/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/modals/tsconfig.build.json
+++ b/packages/modals/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/nearby-pois/tsconfig.build.json
+++ b/packages/nearby-pois/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/poi-detail/tsconfig.build.json
+++ b/packages/poi-detail/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/poi-list-elements/tsconfig.build.json
+++ b/packages/poi-list-elements/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/popup/tsconfig.build.json
+++ b/packages/popup/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/pricing/tsconfig.build.json
+++ b/packages/pricing/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/public-header/tsconfig.build.json
+++ b/packages/public-header/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/react-contexts/tsconfig.build.json
+++ b/packages/react-contexts/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/react-hooks/tsconfig.build.json
+++ b/packages/react-hooks/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/react-triple-client-interfaces/tsconfig.build.json
+++ b/packages/react-triple-client-interfaces/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/recommended-contents/tsconfig.build.json
+++ b/packages/recommended-contents/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/replies/tsconfig.build.json
+++ b/packages/replies/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/resource-list-element/tsconfig.build.json
+++ b/packages/resource-list-element/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/review/tsconfig.build.json
+++ b/packages/review/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/router/tsconfig.build.json
+++ b/packages/router/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/scrap-button/tsconfig.build.json
+++ b/packages/scrap-button/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/scroll-spy/tsconfig.build.json
+++ b/packages/scroll-spy/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/scroll-to-element/tsconfig.build.json
+++ b/packages/scroll-to-element/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/search/tsconfig.build.json
+++ b/packages/search/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/slider/tsconfig.build.json
+++ b/packages/slider/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/social-reviews/tsconfig.build.json
+++ b/packages/social-reviews/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/standard-action-handler/tsconfig.build.json
+++ b/packages/standard-action-handler/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/static-map/tsconfig.build.json
+++ b/packages/static-map/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/static-page-contents/tsconfig.build.json
+++ b/packages/static-page-contents/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/style-box/tsconfig.build.json
+++ b/packages/style-box/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/triple-document/tsconfig.build.json
+++ b/packages/triple-document/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/triple-email-document/tsconfig.build.json
+++ b/packages/triple-email-document/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/triple-fallback-action/tsconfig.build.json
+++ b/packages/triple-fallback-action/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/triple-header/tsconfig.build.json
+++ b/packages/triple-header/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/triple-media/tsconfig.build.json
+++ b/packages/triple-media/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/type-definitions/tsconfig.build.json
+++ b/packages/type-definitions/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/ui-flow/tsconfig.build.json
+++ b/packages/ui-flow/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/user-verification/tsconfig.build.json
+++ b/packages/user-verification/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/view-utilities/tsconfig.build.json
+++ b/packages/view-utilities/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/packages/web-storage/tsconfig.build.json
+++ b/packages/web-storage/tsconfig.build.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "./lib"
   },
   "include": ["src/**/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,17 +2,13 @@
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2015"],
     "module": "ESNext",
+    "moduleResolution": "Node",
     "target": "ES2015",
 
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "declaration": true,
-    "declarationMap": true,
-    "emitDeclarationOnly": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react-jsx",
-    "moduleResolution": "node",
-    "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

tsconfig emit 관련 설정을 tsconfig.build.json 으로 이동

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

stories 파일에서 이런 타입 에러가 발생하고 있습니다:

```
The inferred type of 'default' cannot be named without a reference to '.pnpm/@storybook+types@7.4.0/node_modules/@storybook/types'. This is likely not portable. A type annotation is necessary.
```

stories 파일을 빌드해서 d.ts 파일을 emit 하려고 할 때 스토리북이 해당 패키지의 직접 의존성이 아니라서 에러가 발생하는 것 같습니다. 그런데 stories 파일은 d.ts로 컴파일하지 않으므로 `root/tsconfig.json`에서 emit 관련된 `declaration`, `emitDeclarationOnly`, `noEmitOnError`를 `<package>/tsconfig.build.json` 으로 옮깁니다.

`declarationMap`을 제거합니다. 이 옵션은 d.ts.map 파일을 만드는데, vscode 같은 개발 환경에서 d.ts 파일에서 원본 ts[x] 파일의 reference를 찾을 수 있게 해주는 역할을 합니다. 그런데 개발하면서 그닥 쓸모가 있는 기능은 아닌 것 같습니다. d.ts.map 파일을 만들지 않게 해서 배포되는 패키지의 사이즈를 줄입니다.
