### PR TITLE
[LocationProperties] 액션시트에서 누락된 주소를 복원합니다.

### DIFF
--- a/packages/location-properties/src/location-properties.tsx
+++ b/packages/location-properties/src/location-properties.tsx
@@ -123,7 +123,9 @@ function LocationProperties({
         <ActionSheetItem
           buttonLabel={t(['bogsa', '복사'])}
           onClick={handleClick}
-        />
+        >
+          {value}
+        </ActionSheetItem>
       </ActionSheet>
     </>
   )


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
LocationProperties 액션시트에서 누락된 주소를 복원합니다. i18n 적용하면서 누락된 듯 합니다. ([제보 스레드](https://interpark.slack.com/archives/C05ERUV2603/p1694482363453889))
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
|as-is|to-be|
|---|---|
|![img_8552](https://github.com/titicacadev/triple-frontend/assets/37494848/ea81662c-ce77-44ae-9031-7350d0ed2cec)|![screenshot_20230913_090327__dev](https://github.com/titicacadev/triple-frontend/assets/37494848/219af45a-0c41-4bf7-a31b-6be2fc34603a)|
