### PR TITLE
[Chat] 채팅 리트라이 이벤트를 위한 props를 추가합니다.

### DIFF
--- a/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
@@ -24,11 +24,13 @@ function SentChatContainer({
   createdAt,
   unreadCount,
   onRetry,
+  onCancel,
   children,
 }: PropsWithChildren<{
   createdAt?: string
   unreadCount: number | null
   onRetry?: () => Promise<boolean> | undefined
+  onCancel?: () => void
 }>) {
   const [show, setShow] = useState<boolean>(true)
 
@@ -43,7 +45,12 @@ function SentChatContainer({
               }
             }}
           />
-          <DeleteButton onClick={() => setShow(false)} />
+          <DeleteButton
+            onClick={() => {
+              onCancel?.()
+              setShow(false)
+            }}
+          />
         </SendingFailureHandlerContainer>
       ) : (
         <BubbleInfo
@@ -109,6 +116,10 @@ export interface ChatBubbleUIProps {
    * 'sent' 타입일 때, 메시지 전송 실패할 경우 재시도하는 함수
    */
   onRetry?: () => Promise<boolean> | undefined
+  /**
+   * 'sent' 타입일 때, 메시지 전송 실패할 경우 재시도를 취소하는 함수
+   */
+  onCancel?: () => void
 }
 
 export function ChatBubbleUI({

--- a/packages/chat/src/chat-bubble/chat-bubble.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble.tsx
@@ -21,6 +21,8 @@ interface ChatBubbleProps {
   displayTarget: UserType
   postMessageAction?: PostMessageActionType
   disableUnreadCount?: boolean
+  onRetryButtonClick?: () => void
+  onRetryCancelButtonClick?: () => void
 }
 
 const ChatBubble = ({
@@ -30,6 +32,8 @@ const ChatBubble = ({
   otherReadInfo,
   displayTarget: componentDisplayTarget,
   postMessageAction,
+  onRetryButtonClick,
+  onRetryCancelButtonClick,
   disableUnreadCount = false,
 }: ChatBubbleProps) => {
   const otherUserInfo = useMemo(
@@ -64,13 +68,22 @@ const ChatBubble = ({
     message.payload,
   ])
 
-  const onRetry =
+  const couldRetry =
     !message.createdAt &&
     message.payload.type !== MessageType.RICH &&
-    postMessageAction
-      ? () =>
-          postMessageAction(message.payload as TextPayload | ImagePayload, true)
-      : undefined
+    !!postMessageAction
+
+  const onRetry = () => {
+    onRetryButtonClick?.()
+    return postMessageAction?.(
+      message.payload as TextPayload | ImagePayload,
+      true,
+    )
+  }
+
+  const onCancel = () => {
+    onRetryCancelButtonClick?.()
+  }
 
   return (
     <ChatBubbleUI
@@ -82,7 +95,8 @@ const ChatBubble = ({
       unreadCount={unreadCount}
       createdAt={createdAt}
       payload={payload}
-      onRetry={onRetry}
+      onRetry={couldRetry ? onRetry : undefined}
+      onCancel={onCancel}
     />
   )
 }

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -57,6 +57,8 @@ export interface ChatProps {
   room: RoomInterface
   notifyNewMessage?: (lastMessage: MessageInterface) => void
   showFailToast?: (message: string) => void
+  onRetryButtonClick?: () => void
+  onRetryCancelButtonClick?: () => void
 
   updateChatData?: UpdateChatData
   disableUnreadCount?: boolean
@@ -78,6 +80,8 @@ export const Chat = ({
   getUnreadRoom,
   notifyNewMessage,
   showFailToast,
+  onRetryButtonClick,
+  onRetryCancelButtonClick,
   updateChatData,
   disableUnreadCount = false,
   ...props
@@ -277,6 +281,8 @@ export const Chat = ({
                     postMessage ? postMessageAction : undefined
                   }
                   otherReadInfo={otherUnreadInfo}
+                  onRetryButtonClick={onRetryButtonClick}
+                  onRetryCancelButtonClick={onRetryCancelButtonClick}
                   disableUnreadCount={disableUnreadCount}
                 />
               ) : null}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[Chat] 채팅 리트라이 이벤트를 위한 props를 추가합니다.
- 리트라이 버튼 클릭
- 리트라이 취소 버튼 클릭
<img width="367" alt="스크린샷 2023-09-14 오전 10 19 28" src="https://github.com/titicacadev/triple-frontend/assets/37494848/9d16fb99-24a8-4178-b848-fe9bd727e7c4">

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

