### PR TITLE
tds-ui, tds-widget 패키지 추가

### DIFF
--- a/packages/tds-theme/package.json
+++ b/packages/tds-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/tds-theme",
-  "version": "13.3.0",
+  "version": "13.4.0",
   "description": "TDS theme",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/tds-theme",

--- a/packages/tds-ui/package.json
+++ b/packages/tds-ui/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@titicaca/tds-ui",
+  "version": "13.4.0",
+  "description": "TDS ui",
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/tds-ui",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/titicacadev/triple-frontend.git"
+  },
+  "bugs": {
+    "url": "https://github.com/titicacadev/triple-frontend/issues"
+  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "publishConfig": {
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts"
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "build": "pnpm run build:cjs && pnpm run build:types",
+    "build:cjs": "swc src -d lib --config-file ../../.swcrc",
+    "build:types": "tsc -p tsconfig.build.json",
+    "lint:es": "eslint src",
+    "lint:es:fix": "eslint src --fix",
+    "lint:style": "stylelint 'src/**/*.{js,ts,tsx}'",
+    "lint:style:fix": "stylelint 'src/**/*.{js,ts,tsx}' --fix",
+    "lint:etc": "prettier src --check",
+    "lint:etc:fix": "prettier src --write"
+  },
+  "lint-staged": {
+    "*": [
+      "prettier --check"
+    ],
+    "*.{js,ts,tsx}": [
+      "eslint"
+    ]
+  },
+  "devDependencies": {
+    "react": "^18.2.0",
+    "styled-components": "^5.3.11"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "styled-components": "^5.3.9"
+  }
+}

--- a/packages/tds-ui/tsconfig.build.json
+++ b/packages/tds-ui/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
+    "outDir": "./lib"
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "lib",
+    "src/**/*.test.*",
+    "src/**/*.spec.*",
+    "src/**/*.stories.*"
+  ]
+}

--- a/packages/tds-ui/tsconfig.json
+++ b/packages/tds-ui/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["node_modules", "lib"]
+}

--- a/packages/tds-widget/package.json
+++ b/packages/tds-widget/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@titicaca/tds-widget",
+  "version": "13.4.0",
+  "description": "TDS widget",
+  "license": "MIT",
+  "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/tds-widget",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/titicacadev/triple-frontend.git"
+  },
+  "bugs": {
+    "url": "https://github.com/titicacadev/triple-frontend/issues"
+  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "publishConfig": {
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts"
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "build": "pnpm run build:cjs && pnpm run build:types",
+    "build:cjs": "swc src -d lib --config-file ../../.swcrc",
+    "build:types": "tsc -p tsconfig.build.json",
+    "lint:es": "eslint src",
+    "lint:es:fix": "eslint src --fix",
+    "lint:style": "stylelint 'src/**/*.{js,ts,tsx}'",
+    "lint:style:fix": "stylelint 'src/**/*.{js,ts,tsx}' --fix",
+    "lint:etc": "prettier src --check",
+    "lint:etc:fix": "prettier src --write"
+  },
+  "lint-staged": {
+    "*": [
+      "prettier --check"
+    ],
+    "*.{js,ts,tsx}": [
+      "eslint"
+    ]
+  },
+  "devDependencies": {
+    "react": "^18.2.0",
+    "styled-components": "^5.3.11"
+  },
+  "peerDependencies": {
+    "react": "^18.0",
+    "styled-components": "^5.3.9"
+  }
+}

--- a/packages/tds-widget/tsconfig.build.json
+++ b/packages/tds-widget/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
+    "outDir": "./lib"
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "lib",
+    "src/**/*.test.*",
+    "src/**/*.spec.*",
+    "src/**/*.stories.*"
+  ]
+}

--- a/packages/tds-widget/tsconfig.json
+++ b/packages/tds-widget/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1600,6 +1600,24 @@ importers:
         specifier: ^5.3.11
         version: 5.3.11(@babel/core@7.22.11)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
 
+  packages/tds-ui:
+    devDependencies:
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      styled-components:
+        specifier: ^5.3.11
+        version: 5.3.11(@babel/core@7.22.11)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+
+  packages/tds-widget:
+    devDependencies:
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      styled-components:
+        specifier: ^5.3.11
+        version: 5.3.11(@babel/core@7.22.11)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+
   packages/triple-document:
     dependencies:
       '@titicaca/color-palette':
@@ -1936,7 +1954,7 @@ packages:
       '@babel/generator': 7.22.10
       '@babel/parser': 7.22.13
       '@babel/runtime': 7.22.6
-      '@babel/traverse': 7.22.11
+      '@babel/traverse': 7.22.11(supports-color@5.5.0)
       '@babel/types': 7.22.11
       babel-preset-fbjs: 3.4.0(@babel/core@7.22.11)
       chalk: 4.1.2
@@ -2005,7 +2023,7 @@ packages:
       '@babel/helpers': 7.22.11
       '@babel/parser': 7.22.13
       '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.11
+      '@babel/traverse': 7.22.11(supports-color@5.5.0)
       '@babel/types': 7.22.11
       convert-source-map: 1.9.0
       debug: 4.3.4(supports-color@5.5.0)
@@ -2157,7 +2175,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.5
       '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.11
+      '@babel/traverse': 7.22.11(supports-color@5.5.0)
       '@babel/types': 7.22.11
     transitivePeerDependencies:
       - supports-color
@@ -2222,7 +2240,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.11
+      '@babel/traverse': 7.22.11(supports-color@5.5.0)
       '@babel/types': 7.22.11
     transitivePeerDependencies:
       - supports-color
@@ -2274,7 +2292,7 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.22.5
       '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.11
+      '@babel/traverse': 7.22.11(supports-color@5.5.0)
       '@babel/types': 7.22.11
     transitivePeerDependencies:
       - supports-color
@@ -2285,7 +2303,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.11
+      '@babel/traverse': 7.22.11(supports-color@5.5.0)
       '@babel/types': 7.22.11
     transitivePeerDependencies:
       - supports-color
@@ -3461,7 +3479,7 @@ packages:
       '@babel/parser': 7.22.13
       '@babel/types': 7.22.11
 
-  /@babel/traverse@7.22.11:
+  /@babel/traverse@7.22.11(supports-color@5.5.0):
     resolution: {integrity: sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
@@ -4841,7 +4859,7 @@ packages:
     dependencies:
       '@babel/parser': 7.22.13
       '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.22.11)
-      '@babel/traverse': 7.22.11
+      '@babel/traverse': 7.22.11(supports-color@5.5.0)
       '@babel/types': 7.22.11
       '@graphql-tools/utils': 10.0.3(graphql@16.8.0)
       graphql: 16.8.0
@@ -7891,7 +7909,7 @@ packages:
     dependencies:
       '@babel/generator': 7.22.10
       '@babel/parser': 7.22.13
-      '@babel/traverse': 7.22.11
+      '@babel/traverse': 7.22.11(supports-color@5.5.0)
       '@babel/types': 7.22.11
       '@storybook/csf': 0.1.1
       '@storybook/types': 7.4.0
@@ -12783,7 +12801,7 @@ packages:
     resolution: {integrity: sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==}
     engines: {node: '>=8.3.0'}
     dependencies:
-      '@babel/traverse': 7.22.11
+      '@babel/traverse': 7.22.11(supports-color@5.5.0)
       '@babel/types': 7.22.11
       c8: 7.14.0
     transitivePeerDependencies:

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -61,7 +61,9 @@
       ],
       "@titicaca/static-map": ["./packages/static-map/src"],
       "@titicaca/static-page-contents": ["./packages/static-page-contents/src"],
-      "@titicaca/triple-tds": ["./packages/tds-theme/src"],
+      "@titicaca/tds-theme": ["./packages/tds-theme/src"],
+      "@titicaca/tds-ui": ["./packages/tds-ui/src"],
+      "@titicaca/tds-widget": ["./packages/tds-widget/src"],
       "@titicaca/triple-document": ["./packages/triple-document/src"],
       "@titicaca/triple-email-document": [
         "./packages/triple-email-document/src"


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

https://github.com/titicacadev/triple-frontend/issues/2130

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- tds-ui, tds-widget 패키지를 추가합니다. 빈 패키지만 만들고 코드는 다른 pr에서 옮길 예정입니다.
- 현재 패키지는 feature와 layer의 구분없이 나뉘는데, 이제는 layer 단위로만 구분해보려고 합니다. 과도하게 많고 관계가 복잡한 패키지 개수를 줄이려고 합니다.
- tds-ui는 TDS의 presentational ui를 모은 패키지입니다.
	- core-elements, action-sheet, modals, popup 등이 해당되고 이것들을 하나로 합칠 예정입니다.
- tds-widget은 여러개의 tds-ui를 조합한 컴포넌트 패턴입니다.
	- query fetch, mutation을 할 수 있습니다.
	- i18n 적용된 텍스트를 내장합니다.
	- next를 peer dependency로 사용합니다. (app router, page router 둘 다 호환을 위해서 중간 패키지를 별도로 만들어야 할 수도...)
	- native app과 통신합니다. (app interface)