### PR TITLE
[Chat] chat container에 css props을 적용할 수 있도록 수정합니다.

### DIFF
--- a/packages/chat/src/chat/chat-container.tsx
+++ b/packages/chat/src/chat/chat-container.tsx
@@ -1,5 +1,6 @@
 import { ElementType, PropsWithChildren, useState } from 'react'
 import dynamic from 'next/dynamic'
+import { CSSProp } from 'styled-components'
 
 import {
   ImagePayload,
@@ -20,6 +21,10 @@ export interface ChatContainerProps extends ChatContextValue {
    * Chat list와 보내기 Input 창을 감싸는 컨테이너로, 커스텀 스타일 등 적용 가능
    */
   container: ElementType
+  /**
+   * ChatContainer가 동적으로 변화하는 스타일일 경우 사용합니다.
+   */
+  containerCss: CSSProp
   /**
    * input 창, 보내기 버튼 등을 포함하는 컴포넌트
    */
@@ -44,6 +49,7 @@ const defaultOnImageBubbleClick = (imageInfos: MetaDataInterface[]) => {
 export const ChatContainer = ({
   container: Container,
   inputElement: Input,
+  containerCss,
   children,
 
   textBubbleFontSize,
@@ -53,7 +59,6 @@ export const ChatContainer = ({
   onRichBubbleButtonBeforeRouting,
   onImageBubbleClick = defaultOnImageBubbleClick,
   onTextBubbleClick,
-  ...props
 }: PropsWithChildren<ChatContainerProps>) => {
   const [postMessage, setPostMessage] = useState<PostMessageActionType | null>(
     null,
@@ -73,7 +78,7 @@ export const ChatContainer = ({
       }}
     >
       <ScrollProvider>
-        <Container {...props}>{children}</Container>
+        <Container css={containerCss}>{children}</Container>
         {Input && postMessage ? <Input postMessage={postMessage} /> : null}
       </ScrollProvider>
     </ChatContext.Provider>

--- a/packages/chat/src/chat/chat-container.tsx
+++ b/packages/chat/src/chat/chat-container.tsx
@@ -78,7 +78,7 @@ export const ChatContainer = ({
       }}
     >
       <ScrollProvider>
-        <Container css={containerCss}>{children}</Container>
+        <Container css={containerCss ?? {}}>{children}</Container>
         {Input && postMessage ? <Input postMessage={postMessage} /> : null}
       </ScrollProvider>
     </ChatContext.Provider>

--- a/packages/chat/src/chat/chat-container.tsx
+++ b/packages/chat/src/chat/chat-container.tsx
@@ -24,7 +24,7 @@ export interface ChatContainerProps extends ChatContextValue {
   /**
    * ChatContainer가 동적으로 변화하는 스타일일 경우 사용합니다.
    */
-  containerCss: CSSProp
+  containerCss?: CSSProp
   /**
    * input 창, 보내기 버튼 등을 포함하는 컴포넌트
    */

--- a/packages/chat/src/chat/chat-container.tsx
+++ b/packages/chat/src/chat/chat-container.tsx
@@ -21,9 +21,7 @@ export interface ChatContainerProps extends ChatContextValue {
    * Chat list와 보내기 Input 창을 감싸는 컨테이너로, 커스텀 스타일 등 적용 가능
    */
   container: ElementType
-  containerProps?: {
-    css?: CSSProp
-  }
+  css?: CSSProp
   /**
    * input 창, 보내기 버튼 등을 포함하는 컴포넌트
    */
@@ -47,7 +45,7 @@ const defaultOnImageBubbleClick = (imageInfos: MetaDataInterface[]) => {
  */
 export const ChatContainer = ({
   container: Container,
-  containerProps,
+  css,
   inputElement: Input,
   children,
 
@@ -77,7 +75,7 @@ export const ChatContainer = ({
       }}
     >
       <ScrollProvider>
-        <Container {...containerProps}>{children}</Container>
+        <Container css={css}>{children}</Container>
         {Input && postMessage ? <Input postMessage={postMessage} /> : null}
       </ScrollProvider>
     </ChatContext.Provider>

--- a/packages/chat/src/chat/chat-container.tsx
+++ b/packages/chat/src/chat/chat-container.tsx
@@ -1,6 +1,5 @@
-import { ElementType, PropsWithChildren, useState } from 'react'
+import { ComponentType, PropsWithChildren, useState } from 'react'
 import dynamic from 'next/dynamic'
-import { CSSProp } from 'styled-components'
 
 import {
   ImagePayload,
@@ -20,15 +19,11 @@ export interface ChatContainerProps extends ChatContextValue {
   /**
    * Chat list와 보내기 Input 창을 감싸는 컨테이너로, 커스텀 스타일 등 적용 가능
    */
-  container: ElementType
-  /**
-   * ChatContainer가 동적으로 변화하는 스타일일 경우 사용합니다.
-   */
-  containerCss?: CSSProp
+  container: ComponentType<PropsWithChildren>
   /**
    * input 창, 보내기 버튼 등을 포함하는 컴포넌트
    */
-  inputElement?: ElementType
+  inputElement?: ComponentType<{ postMessage: PostMessageActionType }>
   /**
    * 메시지를 전송하는 api를 래핑하는 함수
    */
@@ -49,7 +44,6 @@ const defaultOnImageBubbleClick = (imageInfos: MetaDataInterface[]) => {
 export const ChatContainer = ({
   container: Container,
   inputElement: Input,
-  containerCss,
   children,
 
   textBubbleFontSize,
@@ -78,7 +72,7 @@ export const ChatContainer = ({
       }}
     >
       <ScrollProvider>
-        <Container css={containerCss ?? {}}>{children}</Container>
+        <Container>{children}</Container>
         {Input && postMessage ? <Input postMessage={postMessage} /> : null}
       </ScrollProvider>
     </ChatContext.Provider>

--- a/packages/chat/src/chat/chat-container.tsx
+++ b/packages/chat/src/chat/chat-container.tsx
@@ -1,6 +1,5 @@
 import { ElementType, PropsWithChildren, useState } from 'react'
 import dynamic from 'next/dynamic'
-import { CSSProp } from 'styled-components'
 
 import {
   ImagePayload,
@@ -21,7 +20,6 @@ export interface ChatContainerProps extends ChatContextValue {
    * Chat list와 보내기 Input 창을 감싸는 컨테이너로, 커스텀 스타일 등 적용 가능
    */
   container: ElementType
-  css?: CSSProp
   /**
    * input 창, 보내기 버튼 등을 포함하는 컴포넌트
    */
@@ -45,7 +43,6 @@ const defaultOnImageBubbleClick = (imageInfos: MetaDataInterface[]) => {
  */
 export const ChatContainer = ({
   container: Container,
-  css,
   inputElement: Input,
   children,
 
@@ -56,6 +53,7 @@ export const ChatContainer = ({
   onRichBubbleButtonBeforeRouting,
   onImageBubbleClick = defaultOnImageBubbleClick,
   onTextBubbleClick,
+  ...props
 }: PropsWithChildren<ChatContainerProps>) => {
   const [postMessage, setPostMessage] = useState<PostMessageActionType | null>(
     null,
@@ -75,7 +73,7 @@ export const ChatContainer = ({
       }}
     >
       <ScrollProvider>
-        <Container css={css}>{children}</Container>
+        <Container {...props}>{children}</Container>
         {Input && postMessage ? <Input postMessage={postMessage} /> : null}
       </ScrollProvider>
     </ChatContext.Provider>

--- a/packages/chat/src/chat/chat-container.tsx
+++ b/packages/chat/src/chat/chat-container.tsx
@@ -1,5 +1,6 @@
-import React, { ElementType, PropsWithChildren, useState } from 'react'
+import { ElementType, PropsWithChildren, useState } from 'react'
 import dynamic from 'next/dynamic'
+import { CSSProp } from 'styled-components'
 
 import {
   ImagePayload,
@@ -20,6 +21,9 @@ export interface ChatContainerProps extends ChatContextValue {
    * Chat list와 보내기 Input 창을 감싸는 컨테이너로, 커스텀 스타일 등 적용 가능
    */
   container: ElementType
+  containerProps: {
+    css: CSSProp
+  }
   /**
    * input 창, 보내기 버튼 등을 포함하는 컴포넌트
    */
@@ -43,6 +47,7 @@ const defaultOnImageBubbleClick = (imageInfos: MetaDataInterface[]) => {
  */
 export const ChatContainer = ({
   container: Container,
+  containerProps,
   inputElement: Input,
   children,
 
@@ -72,7 +77,7 @@ export const ChatContainer = ({
       }}
     >
       <ScrollProvider>
-        <Container>{children}</Container>
+        <Container {...containerProps}>{children}</Container>
         {Input && postMessage ? <Input postMessage={postMessage} /> : null}
       </ScrollProvider>
     </ChatContext.Provider>

--- a/packages/chat/src/chat/chat-container.tsx
+++ b/packages/chat/src/chat/chat-container.tsx
@@ -21,8 +21,8 @@ export interface ChatContainerProps extends ChatContextValue {
    * Chat list와 보내기 Input 창을 감싸는 컨테이너로, 커스텀 스타일 등 적용 가능
    */
   container: ElementType
-  containerProps: {
-    css: CSSProp
+  containerProps?: {
+    css?: CSSProp
   }
   /**
    * input 창, 보내기 버튼 등을 포함하는 컴포넌트


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
기존엔 동적으로 ChatContainer의 스타일을 설정하기 어렵습니다. ChatContainer에 containerProps를 추가하여 동적으로 스타일을 수정할 수 있도록 변경합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
