### PR TITLE
[Chat] 전송 실패 메시지 처리 방식 변경

### DIFF
--- a/packages/chat/src/chat-bubble/chat-bubble.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble.tsx
@@ -22,8 +22,8 @@ interface ChatBubbleProps {
   displayTarget: UserType
   postMessageAction?: PostMessageActionType
   disableUnreadCount?: boolean
-  onRetryButtonClick?: () => void
-  onRetryCancelButtonClick?: () => void
+  onRetryButtonClick?: (message: MessageInterface) => void
+  onRetryCancelButtonClick?: (message: MessageInterface) => void
   blindedText?: string
   bubbleColor?: ChatBubbleColor
 }
@@ -79,7 +79,7 @@ const ChatBubble = ({
     !!postMessageAction
 
   const onRetry = () => {
-    onRetryButtonClick?.()
+    onRetryButtonClick?.(message)
     return postMessageAction?.(
       message.payload as TextPayload | ImagePayload,
       true,
@@ -87,7 +87,7 @@ const ChatBubble = ({
   }
 
   const onCancel = () => {
-    onRetryCancelButtonClick?.()
+    onRetryCancelButtonClick?.(message)
   }
 
   return (

--- a/packages/chat/src/chat/chat-container.tsx
+++ b/packages/chat/src/chat/chat-container.tsx
@@ -17,7 +17,7 @@ const ScrollProvider = dynamic(() => import('./scroll-context'), {
 
 export interface ChatContainerProps extends ChatContextValue {
   /**
-   * Chat list와 보내기 Input 창을 감싸는 컨테이너로, 커스텀 스타일 등 적용 가능
+   * Chat list를 감싸는 컨테이너로, 커스텀 스타일 등 적용 가능
    */
   container: ElementType
   /**

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -92,6 +92,7 @@ export const Chat = ({
   const [
     {
       messages,
+      failedMessages,
       hasPrevMessage,
       otherUnreadInfo,
       lastMessageId,
@@ -202,7 +203,6 @@ export const Chat = ({
       dispatch({
         action: ChatActions.POST,
         messages: newMessages,
-        payload,
       })
 
       const lastMessage = newMessages[newMessages.length - 1]
@@ -211,7 +211,7 @@ export const Chat = ({
       dispatch({
         action: ChatActions.FAILED_TO_POST,
         message: {
-          id: NaN,
+          id: new Date().getTime(),
           roomId: room.id,
           senderId: userInfo.me.id,
           payload,
@@ -262,34 +262,73 @@ export const Chat = ({
     }
   }
 
+  function removeFromFailedMessages(message: MessageInterface) {
+    dispatch({
+      action: ChatActions.REMOVE_FROM_FAILED,
+      message,
+    })
+  }
+
+  function onRetry(message: MessageInterface) {
+    removeFromFailedMessages(message)
+    onRetryButtonClick?.()
+  }
+
+  function onRetryCancel(message: MessageInterface) {
+    removeFromFailedMessages(message)
+    onRetryButtonClick?.()
+  }
+
   return (
     <>
       <IntersectionObserver onChange={onChangeScroll}>
         <HiddenElement />
       </IntersectionObserver>
       <Container ref={chatRoomRef} id={CHAT_CONTAINER_ID} {...props}>
-        <ul>
-          {messages.map((message: MessageInterface, index) => (
-            <li key={index}>
-              {userInfo ? (
-                <ChatBubble
-                  displayTarget={displayTarget}
-                  message={message}
-                  userInfo={userInfo}
-                  postMessageAction={
-                    postMessage ? postMessageAction : undefined
-                  }
-                  otherReadInfo={otherUnreadInfo}
-                  onRetryButtonClick={onRetryButtonClick}
-                  onRetryCancelButtonClick={onRetryCancelButtonClick}
-                  disableUnreadCount={disableUnreadCount}
-                  blindedText={blindedText}
-                  bubbleColor={bubbleColor}
-                />
-              ) : null}
-            </li>
-          ))}
-        </ul>
+        {userInfo ? (
+          <>
+            <ul id="messages_list">
+              {messages.map((message: MessageInterface) => (
+                <li key={message.id}>
+                  <ChatBubble
+                    displayTarget={displayTarget}
+                    message={message}
+                    userInfo={userInfo}
+                    postMessageAction={
+                      postMessage ? postMessageAction : undefined
+                    }
+                    otherReadInfo={otherUnreadInfo}
+                    onRetryButtonClick={onRetry}
+                    onRetryCancelButtonClick={onRetryCancel}
+                    disableUnreadCount={disableUnreadCount}
+                    blindedText={blindedText}
+                    bubbleColor={bubbleColor}
+                  />
+                </li>
+              ))}
+            </ul>
+            <ul id="failed_messages_list">
+              {failedMessages.map((message: MessageInterface) => (
+                <li key={message.id}>
+                  <ChatBubble
+                    displayTarget={displayTarget}
+                    message={message}
+                    userInfo={userInfo}
+                    postMessageAction={
+                      postMessage ? postMessageAction : undefined
+                    }
+                    otherReadInfo={otherUnreadInfo}
+                    onRetryButtonClick={onRetry}
+                    onRetryCancelButtonClick={onRetryCancel}
+                    disableUnreadCount={disableUnreadCount}
+                    blindedText={blindedText}
+                    bubbleColor={bubbleColor}
+                  />
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : null}
       </Container>
       <HiddenElement ref={bottomRef} />
     </>

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -56,7 +56,7 @@ export interface RoomInterface {
   members: UserInterface[]
   isDirect: boolean
   createdAt: string
-  metadata: RoomMetadata
+  metadata?: RoomMetadata
 }
 
 export type DisplayTargetAll = 'all'

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -43,7 +43,7 @@ export interface RoomListResultWithPagingInterface
 export interface RoomMetadata {
   name: string
   memberCounts: number
-  faqId?: string
+  articleId?: string
 }
 
 export interface RoomInterface {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

기존 코드에서 전송 실패한 메시지를 재전송할 때 정상 메시지들이 모두 없어지는 오류가 있었습니다. 현재는 reducer의 `messages` 내에서 정상 메시지들과 전송 실패 메시지들을 한 번에 다루고 있습니다. 전송 실패 메시지를 재전송 후 전송이 성공했을 때, 재전송에 성공한 메시지를 필터링하는 과정에서 조건이 잘못 걸려 이전 메시지들이 모두 사라지고 있었습니다. 

필터링 조건의 간소화와 가독성, 메시지들의 유지 보수의 간편화를 위해 reducer에 `failedMessages` 상태를 추가하고, `REMOVE_FROM_FAILED` 액션을 추가했습니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- `onRetry`, `onCancel` 적용
- `reducer`에 failed 메시지 관련 상태 및 액션 추가
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
