### PR TITLE
[Chat] RoomMetadata의 타입을 변경합니다.

### DIFF
--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -56,7 +56,7 @@ export interface RoomInterface {
   members: UserInterface[]
   isDirect: boolean
   createdAt: string
-  metadata: RoomMetadata
+  metadata?: RoomMetadata
 }
 
 export type DisplayTargetAll = 'all'

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -43,7 +43,7 @@ export interface RoomListResultWithPagingInterface
 export interface RoomMetadata {
   name: string
   memberCounts: number
-  faqId?: string
+  articleId?: string
 }
 
 export interface RoomInterface {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
RoomMetadata의 타입을 변경합니다.
- 채팅 공지사항을 faq가 아닌 article로 관리함에 따라 RoomMetadata의 faqId가 articleId로 변경되었습니다.
- RoomMetadata는 room의 type이 event일 때만 존재하므로 옵셔널 값으로 변경합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
