### PR TITLE
[v14] tds-ui import path 수정

### DIFF
--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -41,8 +41,8 @@
   },
   "dependencies": {
     "@react-google-maps/api": "^2.19.2",
-    "@titicaca/core-elements": "workspace:*",
     "@titicaca/router": "workspace:*",
+    "@titicaca/tds-ui": "workspace:*",
     "@titicaca/type-definitions": "workspace:*"
   },
   "devDependencies": {

--- a/packages/map/src/map.stories.tsx
+++ b/packages/map/src/map.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 
 import { MapView } from './map-view'
 import {

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -40,7 +40,6 @@
     ]
   },
   "dependencies": {
-    "@titicaca/core-elements": "workspace:*",
     "@titicaca/tds-ui": "workspace:*"
   },
   "devDependencies": {

--- a/packages/modals/src/transition-modal.stories.tsx
+++ b/packages/modals/src/transition-modal.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Button } from '@titicaca/core-elements'
+import { Button } from '@titicaca/tds-ui'
 
 import {
   TransitionModal,

--- a/packages/modals/src/transition-modal.tsx
+++ b/packages/modals/src/transition-modal.tsx
@@ -1,7 +1,7 @@
 import { ComponentType, FC, useMemo } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
-import { Text } from '@titicaca/core-elements'
+import { Text, Modal } from '@titicaca/tds-ui'
 import {
   useEventTrackingContext,
   useHistoryFunctions,
@@ -9,7 +9,6 @@ import {
 } from '@titicaca/react-contexts'
 import { DeepPartial } from 'utility-types'
 import { I18nCommonWebKeys } from '@titicaca/i18n'
-import { Modal } from '@titicaca/tds-ui'
 
 type ShowTransitionModal = (type: TransitionType) => void
 

--- a/packages/static-map/package.json
+++ b/packages/static-map/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@titicaca/core-elements": "workspace:*"
+    "@titicaca/tds-ui": "workspace:*"
   },
   "devDependencies": {
     "@titicaca/type-definitions": "workspace:*",

--- a/packages/static-map/src/static-map.tsx
+++ b/packages/static-map/src/static-map.tsx
@@ -6,7 +6,7 @@ import {
   formatMarginPadding,
   MEDIA_FRAME_OPTIONS,
   marginMixin,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { FrameRatioAndSizes } from '@titicaca/type-definitions'
 
 export type PoiType = 'attraction' | 'restaurant' | 'hotel'

--- a/packages/tds-ui/package.json
+++ b/packages/tds-ui/package.json
@@ -40,12 +40,14 @@
     ]
   },
   "dependencies": {
+    "@egjs/flicking": "^3.9.3",
+    "@egjs/react-flicking": "^3.8.3",
     "@floating-ui/react": "^0.25.4",
     "@titicaca/content-utilities": "^8.12.0",
-    "@titicaca/core-elements": "workspace:*",
     "@titicaca/intersection-observer": "workspace:*",
     "@titicaca/triple-fallback-action": "workspace:*",
     "@titicaca/view-utilities": "workspace:*",
+    "react-compound-slider": "^3.4.0",
     "react-input-mask": "^2.0.4",
     "react-roving-tabindex": "^3.2.0"
   },

--- a/packages/tds-ui/src/components/action-sheet-select/action-sheet-select-button.tsx
+++ b/packages/tds-ui/src/components/action-sheet-select/action-sheet-select-button.tsx
@@ -1,13 +1,14 @@
 import styled from 'styled-components'
+import { HTMLAttributes, forwardRef } from 'react'
+import { useMergeRefs } from '@floating-ui/react'
+
 import {
   FormFieldError,
   FormFieldHelp,
   FormFieldLabel,
-  Text,
   useFormField,
-} from '@titicaca/tds-ui'
-import { HTMLAttributes, forwardRef } from 'react'
-import { useMergeRefs } from '@floating-ui/react'
+} from '../form-field'
+import { Text } from '../text'
 
 import { useActionSheetSelect } from './action-sheet-select-context'
 

--- a/packages/tds-ui/src/components/action-sheet-select/action-sheet-select-button.tsx
+++ b/packages/tds-ui/src/components/action-sheet-select/action-sheet-select-button.tsx
@@ -5,7 +5,7 @@ import {
   FormFieldLabel,
   Text,
   useFormField,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { HTMLAttributes, forwardRef } from 'react'
 import { useMergeRefs } from '@floating-ui/react'
 

--- a/packages/tds-ui/src/components/action-sheet-select/action-sheet-select-options.tsx
+++ b/packages/tds-ui/src/components/action-sheet-select/action-sheet-select-options.tsx
@@ -3,7 +3,7 @@ import {
   FloatingList,
   FloatingPortal,
 } from '@floating-ui/react'
-import { FlexBox } from '@titicaca/core-elements'
+import { FlexBox } from '@titicaca/tds-ui'
 
 import { ActionSheetOverlay } from '../action-sheet/action-sheet-overlay'
 import {

--- a/packages/tds-ui/src/components/action-sheet-select/action-sheet-select-options.tsx
+++ b/packages/tds-ui/src/components/action-sheet-select/action-sheet-select-options.tsx
@@ -3,13 +3,13 @@ import {
   FloatingList,
   FloatingPortal,
 } from '@floating-ui/react'
-import { FlexBox } from '@titicaca/tds-ui'
 
 import { ActionSheetOverlay } from '../action-sheet/action-sheet-overlay'
 import {
   ActionSheetBody,
   ActionSheetBodyProps,
 } from '../action-sheet/action-sheet-body'
+import { FlexBox } from '../flex-box'
 
 import { useActionSheetSelect } from './action-sheet-select-context'
 

--- a/packages/tds-ui/src/components/action-sheet-select/action-sheet-select.tsx
+++ b/packages/tds-ui/src/components/action-sheet-select/action-sheet-select.tsx
@@ -8,9 +8,9 @@ import {
   useTransitionStatus,
 } from '@floating-ui/react'
 import { PropsWithChildren, useCallback, useId, useRef, useState } from 'react'
-import { FormField } from '@titicaca/tds-ui'
 
 import { TRANSITION_DURATION } from '../action-sheet/constants'
+import { FormField } from '../form-field'
 
 import { ActionSheetSelectContext } from './action-sheet-select-context'
 

--- a/packages/tds-ui/src/components/action-sheet-select/action-sheet-select.tsx
+++ b/packages/tds-ui/src/components/action-sheet-select/action-sheet-select.tsx
@@ -8,7 +8,7 @@ import {
   useTransitionStatus,
 } from '@floating-ui/react'
 import { PropsWithChildren, useCallback, useId, useRef, useState } from 'react'
-import { FormField } from '@titicaca/core-elements'
+import { FormField } from '@titicaca/tds-ui'
 
 import { TRANSITION_DURATION } from '../action-sheet/constants'
 

--- a/packages/tds-ui/src/components/action-sheet/action-sheet-body.tsx
+++ b/packages/tds-ui/src/components/action-sheet/action-sheet-body.tsx
@@ -1,8 +1,4 @@
-import {
-  Container,
-  MarginPadding,
-  safeAreaInsetMixin,
-} from '@titicaca/core-elements'
+import { Container, MarginPadding, safeAreaInsetMixin } from '@titicaca/tds-ui'
 import { PropsWithChildren, ReactNode, forwardRef } from 'react'
 import styled, { css } from 'styled-components'
 

--- a/packages/tds-ui/src/components/action-sheet/action-sheet-body.tsx
+++ b/packages/tds-ui/src/components/action-sheet/action-sheet-body.tsx
@@ -1,6 +1,9 @@
-import { Container, MarginPadding, safeAreaInsetMixin } from '@titicaca/tds-ui'
 import { PropsWithChildren, ReactNode, forwardRef } from 'react'
 import styled, { css } from 'styled-components'
+
+import { Container } from '../container'
+import { MarginPadding } from '../../commons'
+import { safeAreaInsetMixin } from '../../mixins'
 
 import { ActionSheetTitle } from './action-sheet-title'
 import { TRANSITION_DURATION } from './constants'

--- a/packages/tds-ui/src/components/action-sheet/action-sheet-title.tsx
+++ b/packages/tds-ui/src/components/action-sheet/action-sheet-title.tsx
@@ -1,5 +1,7 @@
 import { isValidElement, PropsWithChildren } from 'react'
-import { Container, Text } from '@titicaca/tds-ui'
+
+import { Container } from '../container'
+import { Text } from '../text'
 
 interface ActionSheetTitleProps extends PropsWithChildren {
   labelId: string

--- a/packages/tds-ui/src/components/action-sheet/action-sheet-title.tsx
+++ b/packages/tds-ui/src/components/action-sheet/action-sheet-title.tsx
@@ -1,5 +1,5 @@
 import { isValidElement, PropsWithChildren } from 'react'
-import { Container, Text } from '@titicaca/core-elements'
+import { Container, Text } from '@titicaca/tds-ui'
 
 interface ActionSheetTitleProps extends PropsWithChildren {
   labelId: string

--- a/packages/tds-ui/src/components/action-sheet/action-sheet.tsx
+++ b/packages/tds-ui/src/components/action-sheet/action-sheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId } from 'react'
-import { FlexBox } from '@titicaca/core-elements'
+import { FlexBox } from '@titicaca/tds-ui'
 import {
   FloatingFocusManager,
   FloatingPortal,

--- a/packages/tds-ui/src/components/action-sheet/action-sheet.tsx
+++ b/packages/tds-ui/src/components/action-sheet/action-sheet.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useId } from 'react'
-import { FlexBox } from '@titicaca/tds-ui'
 import {
   FloatingFocusManager,
   FloatingPortal,
@@ -9,6 +8,8 @@ import {
   useRole,
   useTransitionStatus,
 } from '@floating-ui/react'
+
+import { FlexBox } from '../flex-box'
 
 import { ActionSheetBody, ActionSheetBodyProps } from './action-sheet-body'
 import { ActionSheetContext } from './action-sheet-context'

--- a/packages/tds-ui/src/components/carousel/carousel-item.tsx
+++ b/packages/tds-ui/src/components/carousel/carousel-item.tsx
@@ -1,12 +1,8 @@
 import { MouseEventHandler, PropsWithChildren } from 'react'
 import styled from 'styled-components'
-import { GlobalSizes } from '@titicaca/type-definitions'
 import { StaticIntersectionObserver } from '@titicaca/intersection-observer'
 
-export type CarouselSizes = Exclude<
-  GlobalSizes,
-  'mini' | 'tiny' | 'huge' | 'massive'
->
+import { CarouselSizes } from '../../commons'
 
 const CAROUSEL_WIDTH_SIZES = {
   small: '140px',

--- a/packages/tds-ui/src/components/carousel/carousel.tsx
+++ b/packages/tds-ui/src/components/carousel/carousel.tsx
@@ -1,17 +1,15 @@
 import styled, { css } from 'styled-components'
 import { PropsWithChildren, useRef, useEffect, useState } from 'react'
 import { useUserAgentContext } from '@titicaca/react-contexts'
-import {
-  Container,
-  MarginPadding,
-  marginMixin,
-  formatMarginPadding,
-} from '@titicaca/tds-ui'
 import { FlickingOptions } from '@egjs/flicking'
 import Flicking from '@egjs/react-flicking'
 
-import CarouselItem from './carousel-item'
+import { MarginPadding } from '../../commons'
+import { formatMarginPadding, marginMixin } from '../../mixins'
+import { Container } from '../container'
+
 import ArrowIcon from './arrow-icon'
+import CarouselItem from './carousel-item'
 
 interface CarouselBaseProps {
   noFlicking?: boolean

--- a/packages/tds-ui/src/components/carousel/carousel.tsx
+++ b/packages/tds-ui/src/components/carousel/carousel.tsx
@@ -6,7 +6,7 @@ import {
   MarginPadding,
   marginMixin,
   formatMarginPadding,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { FlickingOptions } from '@egjs/flicking'
 import Flicking from '@egjs/react-flicking'
 

--- a/packages/tds-ui/src/components/carousel/index.ts
+++ b/packages/tds-ui/src/components/carousel/index.ts
@@ -1,2 +1,1 @@
 export { default as Carousel } from './carousel'
-export type { CarouselSizes } from './carousel-item'

--- a/packages/tds-ui/src/components/drawer-button/drawer-button.tsx
+++ b/packages/tds-ui/src/components/drawer-button/drawer-button.tsx
@@ -1,13 +1,9 @@
 import styled from 'styled-components'
-import {
-  Drawer,
-  Container,
-  Button,
-  safeAreaInsetMixin,
-  ButtonProps,
-  paddingMixin,
-  DrawerProps,
-} from '@titicaca/tds-ui'
+
+import { Drawer, DrawerProps } from '../drawer/drawer'
+import { Container } from '../container'
+import { Button, ButtonProps } from '../button'
+import { paddingMixin, safeAreaInsetMixin } from '../../mixins'
 
 const ButtonWithSafeAreaInset = styled(Button)`
   ${paddingMixin}

--- a/packages/tds-ui/src/components/drawer-button/drawer-button.tsx
+++ b/packages/tds-ui/src/components/drawer-button/drawer-button.tsx
@@ -7,7 +7,7 @@ import {
   ButtonProps,
   paddingMixin,
   DrawerProps,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 
 const ButtonWithSafeAreaInset = styled(Button)`
   ${paddingMixin}

--- a/packages/tds-ui/src/components/image/image.stories.mdx
+++ b/packages/tds-ui/src/components/image/image.stories.mdx
@@ -1,5 +1,7 @@
 import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
-import { Container, Image } from '@titicaca/tds-ui'
+
+import { Image } from './image'
+import { Container } from '../container'
 
 <Meta title="Core-Elements / Image" />
 

--- a/packages/tds-ui/src/components/image/image.stories.mdx
+++ b/packages/tds-ui/src/components/image/image.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Preview, Story } from '@storybook/addon-docs/blocks'
-import { Container, Image } from '@titicaca/core-elements'
+import { Container, Image } from '@titicaca/tds-ui'
 
 <Meta title="Core-Elements / Image" />
 

--- a/packages/tds-ui/src/components/list/list.stories.mdx
+++ b/packages/tds-ui/src/components/list/list.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
-import { List } from '@titicaca/core-elements'
+import { List } from '@titicaca/tds-ui'
 
 <Meta title="Core-Elements / List" />
 

--- a/packages/tds-ui/src/components/list/list.stories.mdx
+++ b/packages/tds-ui/src/components/list/list.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
-import { List } from '@titicaca/tds-ui'
+
+import { List } from './list'
 
 <Meta title="Core-Elements / List" />
 

--- a/packages/tds-ui/src/components/modal/modal-action.tsx
+++ b/packages/tds-ui/src/components/modal/modal-action.tsx
@@ -1,4 +1,4 @@
-import { GlobalColors } from '@titicaca/core-elements'
+import { GlobalColors } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 
 const ACTION_COLORS: Partial<Record<GlobalColors, string>> = {

--- a/packages/tds-ui/src/components/modal/modal-action.tsx
+++ b/packages/tds-ui/src/components/modal/modal-action.tsx
@@ -1,5 +1,6 @@
-import { GlobalColors } from '@titicaca/tds-ui'
 import styled from 'styled-components'
+
+import { GlobalColors } from '../../commons'
 
 const ACTION_COLORS: Partial<Record<GlobalColors, string>> = {
   gray: 'rgba(58, 58, 58, 0.5)',

--- a/packages/tds-ui/src/components/modal/modal-body.tsx
+++ b/packages/tds-ui/src/components/modal/modal-body.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import { css } from 'styled-components'
 
 export const ModalBody = ({ children, ...props }: PropsWithChildren) => {

--- a/packages/tds-ui/src/components/modal/modal-body.tsx
+++ b/packages/tds-ui/src/components/modal/modal-body.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from 'react'
-import { Container } from '@titicaca/tds-ui'
 import { css } from 'styled-components'
+
+import { Container } from '../container'
 
 export const ModalBody = ({ children, ...props }: PropsWithChildren) => {
   return (

--- a/packages/tds-ui/src/components/modal/modal-description.tsx
+++ b/packages/tds-ui/src/components/modal/modal-description.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren } from 'react'
-import { Text } from '@titicaca/tds-ui'
+
+import { Text } from '../text'
 
 import { useModal } from './modal-context'
 

--- a/packages/tds-ui/src/components/modal/modal-description.tsx
+++ b/packages/tds-ui/src/components/modal/modal-description.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 import { useModal } from './modal-context'
 

--- a/packages/tds-ui/src/components/modal/modal-title.tsx
+++ b/packages/tds-ui/src/components/modal/modal-title.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from 'react'
-import { Text } from '@titicaca/tds-ui'
 import styled from 'styled-components'
+
+import { Text } from '../text'
 
 import { useModal } from './modal-context'
 

--- a/packages/tds-ui/src/components/modal/modal-title.tsx
+++ b/packages/tds-ui/src/components/modal/modal-title.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 
 import { useModal } from './modal-context'

--- a/packages/tds-ui/src/components/modal/modal.tsx
+++ b/packages/tds-ui/src/components/modal/modal.tsx
@@ -9,7 +9,7 @@ import {
   useInteractions,
   useRole,
 } from '@floating-ui/react'
-import { Container, FlexBox } from '@titicaca/core-elements'
+import { Container, FlexBox } from '@titicaca/tds-ui'
 
 import { ModalAction } from './modal-action'
 import { ModalActions } from './modal-actions'

--- a/packages/tds-ui/src/components/modal/modal.tsx
+++ b/packages/tds-ui/src/components/modal/modal.tsx
@@ -9,7 +9,9 @@ import {
   useInteractions,
   useRole,
 } from '@floating-ui/react'
-import { Container, FlexBox } from '@titicaca/tds-ui'
+
+import { Container } from '../container'
+import { FlexBox } from '../flex-box'
 
 import { ModalAction } from './modal-action'
 import { ModalActions } from './modal-actions'

--- a/packages/tds-ui/src/components/popup/popup.tsx
+++ b/packages/tds-ui/src/components/popup/popup.tsx
@@ -1,6 +1,5 @@
 import { PropsWithChildren, useEffect } from 'react'
 import styled from 'styled-components'
-import { Navbar } from '@titicaca/tds-ui'
 import {
   FloatingFocusManager,
   FloatingOverlay,
@@ -11,6 +10,8 @@ import {
   useRole,
   useTransitionStatus,
 } from '@floating-ui/react'
+
+import { Navbar } from '../navbar'
 
 type NavbarIcon = 'close' | 'back'
 

--- a/packages/tds-ui/src/components/popup/popup.tsx
+++ b/packages/tds-ui/src/components/popup/popup.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, useEffect } from 'react'
 import styled from 'styled-components'
-import { Navbar } from '@titicaca/core-elements'
+import { Navbar } from '@titicaca/tds-ui'
 import {
   FloatingFocusManager,
   FloatingOverlay,

--- a/packages/tds-ui/src/components/segment/segment.stories.mdx
+++ b/packages/tds-ui/src/components/segment/segment.stories.mdx
@@ -1,5 +1,7 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
-import { Card, Container } from '@titicaca/tds-ui'
+
+import { Card } from '../card'
+import { Container } from '../container'
 
 <Meta title="Core-Elements / Card" component={Card} />
 

--- a/packages/tds-ui/src/components/segment/segment.stories.mdx
+++ b/packages/tds-ui/src/components/segment/segment.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
-import { Card, Container } from '@titicaca/core-elements'
+import { Card, Container } from '@titicaca/tds-ui'
 
 <Meta title="Core-Elements / Card" component={Card} />
 

--- a/packages/tds-ui/src/components/slider/slider-base.tsx
+++ b/packages/tds-ui/src/components/slider/slider-base.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react'
 import styled from 'styled-components'
 import { Rail, Slider as OriginalSlider, Handles } from 'react-compound-slider'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import { debounce } from '@titicaca/view-utilities'
 
 import Handle from './handle'

--- a/packages/tds-ui/src/components/slider/slider-base.tsx
+++ b/packages/tds-ui/src/components/slider/slider-base.tsx
@@ -8,8 +8,9 @@ import {
 } from 'react'
 import styled from 'styled-components'
 import { Rail, Slider as OriginalSlider, Handles } from 'react-compound-slider'
-import { Container } from '@titicaca/tds-ui'
 import { debounce } from '@titicaca/view-utilities'
+
+import { Container } from '../container'
 
 import Handle from './handle'
 import { ValueTransformer, SliderValue } from './types'

--- a/packages/tds-ui/src/components/text/text.stories.mdx
+++ b/packages/tds-ui/src/components/text/text.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 <Meta title="Core-Elements / Text" component={Text} />
 

--- a/packages/tds-ui/src/components/text/text.stories.mdx
+++ b/packages/tds-ui/src/components/text/text.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
-import { Text } from '@titicaca/tds-ui'
+
+import { Text } from './text'
 
 <Meta title="Core-Elements / Text" component={Text} />
 

--- a/packages/tds-ui/src/components/video/video.stories.mdx
+++ b/packages/tds-ui/src/components/video/video.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
-import { Video } from '@titicaca/tds-ui'
+
+import { Video } from './video'
 
 <Meta title="Core-Elements / Video" component={Video} />
 

--- a/packages/tds-ui/src/components/video/video.stories.mdx
+++ b/packages/tds-ui/src/components/video/video.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
-import { Video } from '@titicaca/core-elements'
+import { Video } from '@titicaca/tds-ui'
 
 <Meta title="Core-Elements / Video" component={Video} />
 

--- a/packages/tds-widget/src/ad-banner/content-details-banner.tsx
+++ b/packages/tds-widget/src/ad-banner/content-details-banner.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { MarginPadding } from '@titicaca/core-elements'
+import { MarginPadding } from '@titicaca/tds-ui'
 import {
   useDeviceContext,
   useEventTrackingContext,

--- a/packages/tds-widget/src/ad-banner/horizontal-list-view.tsx
+++ b/packages/tds-widget/src/ad-banner/horizontal-list-view.tsx
@@ -1,5 +1,5 @@
 import { FC, useRef, useEffect, useState } from 'react'
-import { formatMarginPadding, MarginPadding } from '@titicaca/core-elements'
+import { formatMarginPadding, MarginPadding } from '@titicaca/tds-ui'
 import { StaticIntersectionObserver as IntersectionObserver } from '@titicaca/intersection-observer'
 import { FlickingOptions } from '@egjs/flicking'
 import Flicking from '@egjs/react-flicking'

--- a/packages/tds-widget/src/ad-banner/list-section.ts
+++ b/packages/tds-widget/src/ad-banner/list-section.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Section } from '@titicaca/core-elements'
+import { Section } from '@titicaca/tds-ui'
 
 const ListSection = styled(Section)`
   @media (min-width: 600px) {

--- a/packages/tds-widget/src/ad-banner/list-top-banners.tsx
+++ b/packages/tds-widget/src/ad-banner/list-top-banners.tsx
@@ -1,5 +1,5 @@
 import { FC, useState, useEffect } from 'react'
-import { MarginPadding } from '@titicaca/core-elements'
+import { MarginPadding } from '@titicaca/tds-ui'
 import {
   useDeviceContext,
   useEventTrackingContext,

--- a/packages/tds-widget/src/ad-banner/vertical-entity.tsx
+++ b/packages/tds-widget/src/ad-banner/vertical-entity.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import styled from 'styled-components'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import { StaticIntersectionObserver as IntersectionObserver } from '@titicaca/intersection-observer'
 
 import { Banner } from './typing'

--- a/packages/tds-widget/src/ad-banner/vertical-list-view.tsx
+++ b/packages/tds-widget/src/ad-banner/vertical-list-view.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { css } from 'styled-components'
-import { formatMarginPadding, MarginPadding } from '@titicaca/core-elements'
+import { formatMarginPadding, MarginPadding } from '@titicaca/tds-ui'
 
 import VerticalEntity from './vertical-entity'
 import { Banner } from './typing'

--- a/packages/tds-widget/src/app-banner/app-banner.tsx
+++ b/packages/tds-widget/src/app-banner/app-banner.tsx
@@ -1,11 +1,7 @@
 import { SyntheticEvent } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
 import styled, { css } from 'styled-components'
-import {
-  Text,
-  layeringMixin,
-  LayeringMixinProps,
-} from '@titicaca/core-elements'
+import { Text, layeringMixin, LayeringMixinProps } from '@titicaca/tds-ui'
 
 const AppBannerFrame = styled.header<
   { fixed?: boolean; maxWidth?: number } & LayeringMixinProps

--- a/packages/tds-widget/src/app-installation-cta/app-installation-cta.tsx
+++ b/packages/tds-widget/src/app-installation-cta/app-installation-cta.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { LayeringMixinProps } from '@titicaca/core-elements'
+import { LayeringMixinProps } from '@titicaca/tds-ui'
 
 import { BottomFixedContainer } from './elements'
 import ImageBanner from './image-banner'

--- a/packages/tds-widget/src/app-installation-cta/article-card-cta/article-card-cta.tsx
+++ b/packages/tds-widget/src/app-installation-cta/article-card-cta/article-card-cta.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { Image } from '@titicaca/core-elements'
+import { Image } from '@titicaca/tds-ui'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { StaticIntersectionObserver } from '@titicaca/intersection-observer'
 import { InventoryItemMeta } from '@titicaca/type-definitions'

--- a/packages/tds-widget/src/app-installation-cta/chatbot-cta.tsx
+++ b/packages/tds-widget/src/app-installation-cta/chatbot-cta.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
-import { Text, LayeringMixinProps } from '@titicaca/core-elements'
+import { Text, LayeringMixinProps } from '@titicaca/tds-ui'
 import { CSSTransition } from 'react-transition-group'
 import { InventoryItemMeta } from '@titicaca/type-definitions'
 import { getWebStorage } from '@titicaca/web-storage'

--- a/packages/tds-widget/src/app-installation-cta/elements.tsx
+++ b/packages/tds-widget/src/app-installation-cta/elements.tsx
@@ -5,7 +5,7 @@ import {
   layeringMixin,
   LayeringMixinProps,
   safeAreaInsetMixin,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 
 export const Overlay = styled.div<LayeringMixinProps>`
   position: fixed;

--- a/packages/tds-widget/src/app-installation-cta/floating-button-cta.tsx
+++ b/packages/tds-widget/src/app-installation-cta/floating-button-cta.tsx
@@ -5,7 +5,7 @@ import {
   MarginPadding,
   LayeringMixinProps,
   Container,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { CSSTransition } from 'react-transition-group'
 import { getWebStorage } from '@titicaca/web-storage'
 

--- a/packages/tds-widget/src/author/author-intro.tsx
+++ b/packages/tds-widget/src/author/author-intro.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 const Html = styled.div`
   line-height: 1.43;

--- a/packages/tds-widget/src/author/author.tsx
+++ b/packages/tds-widget/src/author/author.tsx
@@ -1,4 +1,4 @@
-import { Container, Text, Image } from '@titicaca/core-elements'
+import { Container, Text, Image } from '@titicaca/tds-ui'
 import { ImageMeta } from '@titicaca/type-definitions'
 
 import AuthorIntro from './author-intro'

--- a/packages/tds-widget/src/booking-completion/index.tsx
+++ b/packages/tds-widget/src/booking-completion/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { Container, Text, Button, ButtonGroup } from '@titicaca/core-elements'
+import { Container, Text, Button, ButtonGroup } from '@titicaca/tds-ui'
 import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
 import { TranslatedProperty } from '@titicaca/type-definitions'

--- a/packages/tds-widget/src/chat/bubbles/text.ts
+++ b/packages/tds-widget/src/chat/bubbles/text.ts
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 const BACKGROUND_COLORS: { [key: string]: string } = {
   blue: '#d7e9ff',

--- a/packages/tds-widget/src/chat/chat-bubble/bubble-info.tsx
+++ b/packages/tds-widget/src/chat/chat-bubble/bubble-info.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import styled from 'styled-components'
-import { Container, Text } from '@titicaca/core-elements'
+import { Container, Text } from '@titicaca/tds-ui'
 
 const BubbleInfoContainer = styled(Container)`
   vertical-align: bottom;

--- a/packages/tds-widget/src/chat/chat-bubble/chat-bubble-ui.tsx
+++ b/packages/tds-widget/src/chat/chat-bubble/chat-bubble-ui.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren, useState } from 'react'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 
 import { TextPayload, ImagePayload, RichPayload } from '../types'
 

--- a/packages/tds-widget/src/chat/chat-bubble/elements.tsx
+++ b/packages/tds-widget/src/chat/chat-bubble/elements.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 export const HiddenElement = styled.div`
   height: 1px;

--- a/packages/tds-widget/src/chat/chat/chat-container.stories.tsx
+++ b/packages/tds-widget/src/chat/chat/chat-container.stories.tsx
@@ -1,5 +1,5 @@
 import type { StoryFn } from '@storybook/react'
-import { FlexBox } from '@titicaca/core-elements'
+import { FlexBox } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 
 import { MessageType, TextPayload } from '../types'

--- a/packages/tds-widget/src/chat/chat/chat.tsx
+++ b/packages/tds-widget/src/chat/chat/chat.tsx
@@ -10,7 +10,7 @@ import React, {
 import { StaticIntersectionObserver as IntersectionObserver } from '@titicaca/intersection-observer'
 import { useUserAgentContext } from '@titicaca/react-contexts'
 import { closeKeyboard } from '@titicaca/triple-web-to-native-interfaces'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 
 import {
   HasUnreadOfRoomInterface,

--- a/packages/tds-widget/src/content-sharing/content-sharing.tsx
+++ b/packages/tds-widget/src/content-sharing/content-sharing.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Container, Text } from '@titicaca/core-elements'
+import { Container, Text } from '@titicaca/tds-ui'
 
 const ShareIcon = styled.img`
   margin: 0 5px;

--- a/packages/tds-widget/src/directions-finder/ask-to-the-local.tsx
+++ b/packages/tds-widget/src/directions-finder/ask-to-the-local.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   safeAreaInsetMixin,
 } from '@titicaca/core-elements'
-import Popup from '@titicaca/popup'
+import { Popup } from '@titicaca/tds-ui'
 
 const DrawerContentContainer = styled(Container)`
   ${safeAreaInsetMixin}

--- a/packages/tds-widget/src/directions-finder/ask-to-the-local.tsx
+++ b/packages/tds-widget/src/directions-finder/ask-to-the-local.tsx
@@ -9,8 +9,8 @@ import {
   Section,
   Text,
   safeAreaInsetMixin,
-} from '@titicaca/core-elements'
-import { Popup } from '@titicaca/tds-ui'
+  Popup,
+} from '@titicaca/tds-ui'
 
 const DrawerContentContainer = styled(Container)`
   ${safeAreaInsetMixin}

--- a/packages/tds-widget/src/directions-finder/direction-buttons.tsx
+++ b/packages/tds-widget/src/directions-finder/direction-buttons.tsx
@@ -6,7 +6,7 @@ import {
   useUriHash,
 } from '@titicaca/react-contexts'
 import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
-import { Button, ButtonGroup } from '@titicaca/core-elements'
+import { Button, ButtonGroup } from '@titicaca/tds-ui'
 
 import AskToTheLocal from './ask-to-the-local'
 import { HASH_ASK_TO_LOCALS_POPUP } from './constants'

--- a/packages/tds-widget/src/footer/award-footer.tsx
+++ b/packages/tds-widget/src/footer/award-footer.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Container, FlexBox, Text } from '@titicaca/core-elements'
+import { Container, FlexBox, Text } from '@titicaca/tds-ui'
 import { Fragment, useState } from 'react'
 
 import { LinkGroup as LinkGroupBase } from './link-group'

--- a/packages/tds-widget/src/footer/company-info.tsx
+++ b/packages/tds-widget/src/footer/company-info.tsx
@@ -5,7 +5,7 @@ import {
   Text,
   FlexBox,
   AccordionTitle,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import {
   useEventTrackingContext,
   useSessionAvailability,

--- a/packages/tds-widget/src/footer/default-footer.tsx
+++ b/packages/tds-widget/src/footer/default-footer.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import styled from 'styled-components'
-import { Text, Container } from '@titicaca/core-elements'
+import { Text, Container } from '@titicaca/tds-ui'
 
 import { LinkGroup } from './link-group'
 import { CompanyInfo } from './company-info'

--- a/packages/tds-widget/src/footer/link-group.tsx
+++ b/packages/tds-widget/src/footer/link-group.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 
 const LinksContainer = styled(Container)`
   font-size: 11px;

--- a/packages/tds-widget/src/hub-form/cell.tsx
+++ b/packages/tds-widget/src/hub-form/cell.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, SyntheticEvent } from 'react'
 import styled, { css } from 'styled-components'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 type StyleType = 'SCHEDULE' | 'PEOPLE' | 'ORIGIN' | 'DESTINATION' | 'SEARCH'
 

--- a/packages/tds-widget/src/hub-form/cta.tsx
+++ b/packages/tds-widget/src/hub-form/cta.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren, SyntheticEvent } from 'react'
-import { Button } from '@titicaca/core-elements'
+import { Button } from '@titicaca/tds-ui'
 
 function Cta({
   available,

--- a/packages/tds-widget/src/hub-form/hub-form.tsx
+++ b/packages/tds-widget/src/hub-form/hub-form.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react'
 import styled from 'styled-components'
-import { CardFrame, CardProps } from '@titicaca/core-elements'
+import { CardFrame, CardProps } from '@titicaca/tds-ui'
 
 const HubFormFrame = styled(CardFrame)`
   > div:not(:last-child) {

--- a/packages/tds-widget/src/image-carousel/carousel.tsx
+++ b/packages/tds-widget/src/image-carousel/carousel.tsx
@@ -1,10 +1,6 @@
 import { FlickingEvent, FlickingOptions } from '@egjs/flicking'
 import Flicking, { FlickingProps } from '@egjs/react-flicking'
-import {
-  Container,
-  MarginPadding,
-  formatMarginPadding,
-} from '@titicaca/core-elements'
+import { Container, MarginPadding, formatMarginPadding } from '@titicaca/tds-ui'
 import { ReactNode, RefObject, useState } from 'react'
 import styled from 'styled-components'
 

--- a/packages/tds-widget/src/image-carousel/image-content.tsx
+++ b/packages/tds-widget/src/image-carousel/image-content.tsx
@@ -1,4 +1,4 @@
-import { Image } from '@titicaca/core-elements'
+import { Image } from '@titicaca/tds-ui'
 import { ImageSource } from '@titicaca/image-source'
 import { FrameRatioAndSizes, GlobalSizes } from '@titicaca/type-definitions'
 import { MouseEventHandler, ReactNode } from 'react'

--- a/packages/tds-widget/src/image-carousel/video-content.tsx
+++ b/packages/tds-widget/src/image-carousel/video-content.tsx
@@ -1,4 +1,4 @@
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import { FrameRatioAndSizes, GlobalSizes } from '@titicaca/type-definitions'
 import { MouseEventHandler, ReactNode, useEffect, useState } from 'react'
 import styled from 'styled-components'

--- a/packages/tds-widget/src/listing-filter/listing-filter.tsx
+++ b/packages/tds-widget/src/listing-filter/listing-filter.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components'
-import { MarginPadding, paddingMixin } from '@titicaca/core-elements'
+import { MarginPadding, paddingMixin } from '@titicaca/tds-ui'
 import { HTMLAttributes, ReactNode, PureComponent } from 'react'
 
 const FilterEntryBase = styled.div<{ active?: boolean; disabled?: boolean }>`

--- a/packages/tds-widget/src/location-properties/location-properties.tsx
+++ b/packages/tds-widget/src/location-properties/location-properties.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
-import { Segment, List } from '@titicaca/core-elements'
+import { Segment, List } from '@titicaca/tds-ui'
 import { ActionSheet, ActionSheetItem } from '@titicaca/tds-ui'
 import { useHistoryFunctions, useUriHash } from '@titicaca/react-contexts'
 import { TranslatedProperty } from '@titicaca/type-definitions'

--- a/packages/tds-widget/src/location-properties/location-properties.tsx
+++ b/packages/tds-widget/src/location-properties/location-properties.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
-import { Segment, List } from '@titicaca/tds-ui'
-import { ActionSheet, ActionSheetItem } from '@titicaca/tds-ui'
+import { Segment, List, ActionSheet, ActionSheetItem } from '@titicaca/tds-ui'
 import { useHistoryFunctions, useUriHash } from '@titicaca/react-contexts'
 import { TranslatedProperty } from '@titicaca/type-definitions'
 

--- a/packages/tds-widget/src/location-properties/location-properties.tsx
+++ b/packages/tds-widget/src/location-properties/location-properties.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
 import { Segment, List } from '@titicaca/core-elements'
-import { ActionSheet, ActionSheetItem } from '@titicaca/action-sheet'
+import { ActionSheet, ActionSheetItem } from '@titicaca/tds-ui'
 import { useHistoryFunctions, useUriHash } from '@titicaca/react-contexts'
 import { TranslatedProperty } from '@titicaca/type-definitions'
 

--- a/packages/tds-widget/src/location-properties/property-item.tsx
+++ b/packages/tds-widget/src/location-properties/property-item.tsx
@@ -6,7 +6,7 @@ import {
   FlexBox,
   LongClickableComponentProps,
   FlexBoxProps,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import {
   useEventTrackingContext,
   useHistoryFunctions,

--- a/packages/tds-widget/src/nearby-pois/nearby-pois.tsx
+++ b/packages/tds-widget/src/nearby-pois/nearby-pois.tsx
@@ -10,7 +10,7 @@ import {
   TabPanel,
   H1,
   Paragraph,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { PointGeoJson } from '@titicaca/type-definitions'
 

--- a/packages/tds-widget/src/nearby-pois/poi-entry.tsx
+++ b/packages/tds-widget/src/nearby-pois/poi-entry.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { List } from '@titicaca/core-elements'
+import { List } from '@titicaca/tds-ui'
 import { StaticIntersectionObserver as IntersectionObserver } from '@titicaca/intersection-observer'
 import { PoiListElement } from '@titicaca/poi-list-elements'
 import { useEventTrackingContext } from '@titicaca/react-contexts'

--- a/packages/tds-widget/src/poi-detail/actions.tsx
+++ b/packages/tds-widget/src/poi-detail/actions.tsx
@@ -7,7 +7,7 @@ import {
   MarginPadding,
   Tooltip,
   ButtonGroup,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { useEffect, useState } from 'react'
 import { getWebStorage } from '@titicaca/web-storage'
 

--- a/packages/tds-widget/src/poi-detail/area-names.tsx
+++ b/packages/tds-widget/src/poi-detail/area-names.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 import styled from 'styled-components'
-import { Container, Text } from '@titicaca/core-elements'
+import { Container, Text } from '@titicaca/tds-ui'
 
 const AreaContainer = styled(Container)`
   padding-left: 20px;

--- a/packages/tds-widget/src/poi-detail/copy-action-sheet-item.tsx
+++ b/packages/tds-widget/src/poi-detail/copy-action-sheet-item.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { ActionSheetItem } from '@titicaca/action-sheet'
+import { ActionSheetItem } from '@titicaca/tds-ui'
 import { useTranslation } from '@titicaca/next-i18next'
 
 export default function CopyActionSheetItem({

--- a/packages/tds-widget/src/poi-detail/copy-action-sheet.tsx
+++ b/packages/tds-widget/src/poi-detail/copy-action-sheet.tsx
@@ -1,4 +1,4 @@
-import { ActionSheet } from '@titicaca/action-sheet'
+import { ActionSheet } from '@titicaca/tds-ui'
 import { TranslatedProperty } from '@titicaca/type-definitions'
 
 import CopyActionSheetItem from './copy-action-sheet-item'

--- a/packages/tds-widget/src/poi-detail/detail-header-v2/index.tsx
+++ b/packages/tds-widget/src/poi-detail/detail-header-v2/index.tsx
@@ -9,7 +9,7 @@ import {
   Icon,
   Rating,
   TextTitle,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import {
   useEventTrackingContext,
   useHistoryFunctions,

--- a/packages/tds-widget/src/poi-detail/detail-header/business-hours-note.tsx
+++ b/packages/tds-widget/src/poi-detail/detail-header/business-hours-note.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
-import { Container, FlexBox, Text } from '@titicaca/core-elements'
+import { Container, FlexBox, Text } from '@titicaca/tds-ui'
 
 import { TimeIcon, RightArrowIcon } from './business-hours-icons'
 

--- a/packages/tds-widget/src/poi-detail/detail-header/index.tsx
+++ b/packages/tds-widget/src/poi-detail/detail-header/index.tsx
@@ -7,7 +7,7 @@ import {
   Rating,
   Icon,
   TextTitle,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import {
   useEventTrackingContext,
   useHistoryFunctions,

--- a/packages/tds-widget/src/poi-detail/image-carousel/carousel-section.tsx
+++ b/packages/tds-widget/src/poi-detail/image-carousel/carousel-section.tsx
@@ -1,4 +1,4 @@
-import { Section, Container } from '@titicaca/core-elements'
+import { Section, Container } from '@titicaca/tds-ui'
 
 import Carousel, { CarouselProps } from './carousel'
 import Placeholder from './placeholder'

--- a/packages/tds-widget/src/poi-detail/image-carousel/carousel.tsx
+++ b/packages/tds-widget/src/poi-detail/image-carousel/carousel.tsx
@@ -4,7 +4,7 @@ import ImageCarousel, {
   PageLabel,
   CarouselImageMeta,
 } from '@titicaca/image-carousel'
-import { Container, Responsive } from '@titicaca/core-elements'
+import { Container, Responsive } from '@titicaca/tds-ui'
 import { ImageSource } from '@titicaca/image-source'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'

--- a/packages/tds-widget/src/poi-detail/image-carousel/note.tsx
+++ b/packages/tds-widget/src/poi-detail/image-carousel/note.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@titicaca/next-i18next'
 import styled, { css } from 'styled-components'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 const NoteContainer = styled.div<{
   warning?: boolean

--- a/packages/tds-widget/src/poi-detail/image-carousel/placeholder.tsx
+++ b/packages/tds-widget/src/poi-detail/image-carousel/placeholder.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@titicaca/next-i18next'
 import styled, { css } from 'styled-components'
-import { Text, Responsive } from '@titicaca/core-elements'
+import { Text, Responsive } from '@titicaca/tds-ui'
 
 const ImagePlaceholderContainer = styled.div<{ large?: boolean }>`
   width: 100%;

--- a/packages/tds-widget/src/poi-detail/recommended-articles/article-entry.tsx
+++ b/packages/tds-widget/src/poi-detail/recommended-articles/article-entry.tsx
@@ -1,5 +1,5 @@
 import { SyntheticEvent } from 'react'
-import { Image, H3 } from '@titicaca/core-elements'
+import { Image, H3 } from '@titicaca/tds-ui'
 import { StaticIntersectionObserver } from '@titicaca/intersection-observer'
 
 import { ArticleListingData } from './types'

--- a/packages/tds-widget/src/poi-detail/recommended-articles/more-button.tsx
+++ b/packages/tds-widget/src/poi-detail/recommended-articles/more-button.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Button } from '@titicaca/core-elements'
+import { Button } from '@titicaca/tds-ui'
 
 export default styled(Button)`
   width: 100%;

--- a/packages/tds-widget/src/poi-detail/recommended-articles/recommended-articles.tsx
+++ b/packages/tds-widget/src/poi-detail/recommended-articles/recommended-articles.tsx
@@ -5,6 +5,7 @@ import {
   Container,
   H1,
   formatMarginPadding,
+  Carousel,
 } from '@titicaca/tds-ui'
 import { useTranslation } from '@titicaca/next-i18next'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
@@ -14,7 +15,6 @@ import {
   fetchInventoryItems,
 } from '@titicaca/app-installation-cta'
 import { InventoryItemMeta } from '@titicaca/type-definitions'
-import { Carousel } from '@titicaca/carousel'
 
 import { fetchRecommendedArticles } from './api-client'
 import { ArticleListingData } from './types'

--- a/packages/tds-widget/src/poi-detail/recommended-articles/recommended-articles.tsx
+++ b/packages/tds-widget/src/poi-detail/recommended-articles/recommended-articles.tsx
@@ -5,7 +5,7 @@ import {
   Container,
   H1,
   formatMarginPadding,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { useTranslation } from '@titicaca/next-i18next'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { TransitionType, useTransitionModal } from '@titicaca/modals'

--- a/packages/tds-widget/src/poi-list-elements/carousel-element.tsx
+++ b/packages/tds-widget/src/poi-list-elements/carousel-element.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-import { Text, Container, Image } from '@titicaca/core-elements'
+import { Text, Container, Image } from '@titicaca/tds-ui'
 import { OverlayScrapButton } from '@titicaca/scrap-button'
 import { FrameRatioAndSizes } from '@titicaca/type-definitions'
 import { Carousel, CarouselSizes } from '@titicaca/carousel'

--- a/packages/tds-widget/src/poi-list-elements/carousel-element.tsx
+++ b/packages/tds-widget/src/poi-list-elements/carousel-element.tsx
@@ -1,8 +1,13 @@
 import { ReactNode } from 'react'
-import { Text, Container, Image } from '@titicaca/tds-ui'
+import {
+  Text,
+  Container,
+  Image,
+  Carousel,
+  CarouselSizes,
+} from '@titicaca/tds-ui'
 import { OverlayScrapButton } from '@titicaca/scrap-button'
 import { FrameRatioAndSizes } from '@titicaca/type-definitions'
-import { Carousel, CarouselSizes } from '@titicaca/carousel'
 
 import { POI_IMAGE_PLACEHOLDERS } from './constants'
 import { getTypeNames } from './get-type-names'

--- a/packages/tds-widget/src/poi-list-elements/compact-poi-list-element.tsx
+++ b/packages/tds-widget/src/poi-list-elements/compact-poi-list-element.tsx
@@ -4,7 +4,7 @@ import {
   SquareImage,
   ResourceListItem,
   Container,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { OutlineScrapButton } from '@titicaca/scrap-button'
 
 import {

--- a/packages/tds-widget/src/poi-list-elements/poi-card-element/poi-card-element.tsx
+++ b/packages/tds-widget/src/poi-list-elements/poi-card-element/poi-card-element.tsx
@@ -1,12 +1,7 @@
 import { MouseEventHandler } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
-import {
-  Container,
-  Text,
-  Card as OriginalCard,
-  Image,
-} from '@titicaca/core-elements'
+import { Container, Text, Card as OriginalCard, Image } from '@titicaca/tds-ui'
 import { ImageMeta, TranslatedProperty } from '@titicaca/type-definitions'
 import {
   ReviewScrapStat,

--- a/packages/tds-widget/src/pricing/fixed-pricing-v2/index.tsx
+++ b/packages/tds-widget/src/pricing/fixed-pricing-v2/index.tsx
@@ -10,7 +10,7 @@ import {
   Skeleton,
   safeAreaInsetMixin,
   paddingMixin,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { formatNumber } from '@titicaca/view-utilities'
 
 import PurchaseButton from './purchase-button'

--- a/packages/tds-widget/src/pricing/fixed-pricing-v2/purchase-button-loading-indicator.tsx
+++ b/packages/tds-widget/src/pricing/fixed-pricing-v2/purchase-button-loading-indicator.tsx
@@ -1,5 +1,5 @@
 import styled, { keyframes } from 'styled-components'
-import { FlexBox } from '@titicaca/core-elements'
+import { FlexBox } from '@titicaca/tds-ui'
 
 interface IndicatorProps {
   loading: boolean

--- a/packages/tds-widget/src/pricing/fixed-pricing-v2/purchase-button.tsx
+++ b/packages/tds-widget/src/pricing/fixed-pricing-v2/purchase-button.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@titicaca/core-elements'
+import { Button } from '@titicaca/tds-ui'
 
 import PurchaseButtonLoadingIndicator from './purchase-button-loading-indicator'
 

--- a/packages/tds-widget/src/pricing/fixed-pricing.tsx
+++ b/packages/tds-widget/src/pricing/fixed-pricing.tsx
@@ -9,7 +9,7 @@ import {
   Button,
   MarginPadding,
   paddingMixin,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { formatNumber } from '@titicaca/view-utilities'
 
 export interface FixedPricingProps {

--- a/packages/tds-widget/src/pricing/pricing.tsx
+++ b/packages/tds-widget/src/pricing/pricing.tsx
@@ -2,12 +2,7 @@ import { ReactNode } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
 import styled, { css } from 'styled-components'
 import { formatNumber } from '@titicaca/view-utilities'
-import {
-  Container,
-  Text,
-  MarginPadding,
-  GlobalColors,
-} from '@titicaca/core-elements'
+import { Container, Text, MarginPadding, GlobalColors } from '@titicaca/tds-ui'
 import { GlobalSizes } from '@titicaca/type-definitions'
 
 import FixedPricing, { FixedPricingProps } from './fixed-pricing'

--- a/packages/tds-widget/src/recommended-contents/recommended-contents.tsx
+++ b/packages/tds-widget/src/recommended-contents/recommended-contents.tsx
@@ -1,11 +1,6 @@
 import { SyntheticEvent } from 'react'
 import styled, { css } from 'styled-components'
-import {
-  Text,
-  MarginPadding,
-  Responsive,
-  Container,
-} from '@titicaca/core-elements'
+import { Text, MarginPadding, Responsive, Container } from '@titicaca/tds-ui'
 import { StaticIntersectionObserver as IntersectionObserver } from '@titicaca/intersection-observer'
 
 const RecommendedContentsContainer = styled.section<{

--- a/packages/tds-widget/src/replies/guide-text.tsx
+++ b/packages/tds-widget/src/replies/guide-text.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@titicaca/next-i18next'
-import { FlexBox, Text, Icon } from '@titicaca/core-elements'
+import { FlexBox, Text, Icon } from '@titicaca/tds-ui'
 import { useHistoryFunctions } from '@titicaca/react-contexts'
 
 import { useRepliesContext } from './context'

--- a/packages/tds-widget/src/replies/list/index.tsx
+++ b/packages/tds-widget/src/replies/list/index.tsx
@@ -1,6 +1,6 @@
 import { Container, HR1, List, Text } from '@titicaca/core-elements'
 import { useTranslation } from '@titicaca/next-i18next'
-import { Confirm } from '@titicaca/modals'
+import { Confirm } from '@titicaca/tds-ui'
 import { useHistoryFunctions, useUriHash } from '@titicaca/react-contexts'
 import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 

--- a/packages/tds-widget/src/replies/list/index.tsx
+++ b/packages/tds-widget/src/replies/list/index.tsx
@@ -1,6 +1,5 @@
-import { Container, HR1, List, Text } from '@titicaca/tds-ui'
+import { Container, HR1, List, Text, Confirm } from '@titicaca/tds-ui'
 import { useTranslation } from '@titicaca/next-i18next'
-import { Confirm } from '@titicaca/tds-ui'
 import { useHistoryFunctions, useUriHash } from '@titicaca/react-contexts'
 import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 

--- a/packages/tds-widget/src/replies/list/index.tsx
+++ b/packages/tds-widget/src/replies/list/index.tsx
@@ -1,4 +1,4 @@
-import { Container, HR1, List, Text } from '@titicaca/core-elements'
+import { Container, HR1, List, Text } from '@titicaca/tds-ui'
 import { useTranslation } from '@titicaca/next-i18next'
 import { Confirm } from '@titicaca/tds-ui'
 import { useHistoryFunctions, useUriHash } from '@titicaca/react-contexts'

--- a/packages/tds-widget/src/replies/list/not-exist-replies.tsx
+++ b/packages/tds-widget/src/replies/list/not-exist-replies.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@titicaca/next-i18next'
-import { Container, HR1, Text } from '@titicaca/core-elements'
+import { Container, HR1, Text } from '@titicaca/tds-ui'
 
 export default function NotExistReplies() {
   const { t } = useTranslation('common-web')

--- a/packages/tds-widget/src/replies/list/reply.tsx
+++ b/packages/tds-widget/src/replies/list/reply.tsx
@@ -1,13 +1,7 @@
 import { useState, useCallback } from 'react'
 import { useTranslation, getTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
-import {
-  Container,
-  FlexBox,
-  List,
-  SquareImage,
-  Text,
-} from '@titicaca/core-elements'
+import { Container, FlexBox, List, SquareImage, Text } from '@titicaca/tds-ui'
 import { formatTimestamp, findFoldedPosition } from '@titicaca/view-utilities'
 import { useAppCallback, useSessionCallback } from '@titicaca/ui-flow'
 import { TransitionType } from '@titicaca/modals'

--- a/packages/tds-widget/src/replies/list/reply.tsx
+++ b/packages/tds-widget/src/replies/list/reply.tsx
@@ -17,7 +17,7 @@ import {
   useHistoryFunctions,
   useIsomorphicNavigation,
 } from '@titicaca/react-contexts'
-import { ActionSheet, ActionSheetItem } from '@titicaca/action-sheet'
+import { ActionSheet, ActionSheetItem } from '@titicaca/tds-ui'
 
 import { Reply as ReplyType, Writer } from '../types'
 import { likeReply, unlikeReply } from '../replies-api-client'

--- a/packages/tds-widget/src/replies/list/reply.tsx
+++ b/packages/tds-widget/src/replies/list/reply.tsx
@@ -1,7 +1,15 @@
 import { useState, useCallback } from 'react'
 import { useTranslation, getTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
-import { Container, FlexBox, List, SquareImage, Text } from '@titicaca/tds-ui'
+import {
+  Container,
+  FlexBox,
+  List,
+  SquareImage,
+  Text,
+  ActionSheet,
+  ActionSheetItem,
+} from '@titicaca/tds-ui'
 import { formatTimestamp, findFoldedPosition } from '@titicaca/view-utilities'
 import { useAppCallback, useSessionCallback } from '@titicaca/ui-flow'
 import { TransitionType } from '@titicaca/modals'
@@ -11,7 +19,6 @@ import {
   useHistoryFunctions,
   useIsomorphicNavigation,
 } from '@titicaca/react-contexts'
-import { ActionSheet, ActionSheetItem } from '@titicaca/tds-ui'
 
 import { Reply as ReplyType, Writer } from '../types'
 import { likeReply, unlikeReply } from '../replies-api-client'

--- a/packages/tds-widget/src/replies/register.tsx
+++ b/packages/tds-widget/src/replies/register.tsx
@@ -1,7 +1,7 @@
 import { ForwardedRef, forwardRef } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
-import { Container, FlexBox, HR1 } from '@titicaca/core-elements'
+import { Container, FlexBox, HR1 } from '@titicaca/tds-ui'
 import { useLoginCtaModal } from '@titicaca/modals'
 import { useSessionAvailability } from '@titicaca/react-contexts'
 import { useSessionCallback } from '@titicaca/ui-flow'

--- a/packages/tds-widget/src/replies/replies.tsx
+++ b/packages/tds-widget/src/replies/replies.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
-import { Container, safeAreaInsetMixin } from '@titicaca/core-elements'
+import { Container, safeAreaInsetMixin } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 
 import { fetchReplies, fetchChildReplies } from './replies-api-client'

--- a/packages/tds-widget/src/resource-list-elements/extended-resource-list-element.stories.tsx
+++ b/packages/tds-widget/src/resource-list-elements/extended-resource-list-element.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/react'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import Pricing from '@titicaca/pricing'
 
 import ExtendedResourceListElement from './extended-resource-list-element'

--- a/packages/tds-widget/src/resource-list-elements/extended-resource-list-element.tsx
+++ b/packages/tds-widget/src/resource-list-elements/extended-resource-list-element.tsx
@@ -10,7 +10,7 @@ import {
   List,
   Image,
   FlexBox,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { ImageMeta } from '@titicaca/type-definitions'
 
 import ReviewScrapStat from './review-scrap-stat'

--- a/packages/tds-widget/src/resource-list-elements/resource-list-element-stats.tsx
+++ b/packages/tds-widget/src/resource-list-elements/resource-list-element-stats.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 function ResourceListElementStats({
   stats,

--- a/packages/tds-widget/src/resource-list-elements/review-scrap-stat.tsx
+++ b/packages/tds-widget/src/resource-list-elements/review-scrap-stat.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@titicaca/next-i18next'
-import { Container, Rating } from '@titicaca/core-elements'
+import { Container, Rating } from '@titicaca/tds-ui'
 import { formatNumber } from '@titicaca/view-utilities'
 
 import ResourceListElementStats from './resource-list-element-stats'

--- a/packages/tds-widget/src/review/components/filter.tsx
+++ b/packages/tds-widget/src/review/components/filter.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import styled from 'styled-components'
 import { useTranslation } from '@titicaca/next-i18next'
-import { FlexBox, Text, Container } from '@titicaca/core-elements'
+import { FlexBox, Text, Container } from '@titicaca/tds-ui'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 
 import { useReviewFilters } from './filter-context'

--- a/packages/tds-widget/src/review/components/full-list-button.tsx
+++ b/packages/tds-widget/src/review/components/full-list-button.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Button } from '@titicaca/core-elements'
+import { Button } from '@titicaca/tds-ui'
 import { useAppCallback, useSessionCallback } from '@titicaca/ui-flow'
 import { TransitionType } from '@titicaca/modals'
 import { useEventTrackingContext } from '@titicaca/react-contexts'

--- a/packages/tds-widget/src/review/components/infinite-list/infinite-list.tsx
+++ b/packages/tds-widget/src/review/components/infinite-list/infinite-list.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { List, Spinner } from '@titicaca/core-elements'
+import { List, Spinner } from '@titicaca/tds-ui'
 import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 import { StaticIntersectionObserver } from '@titicaca/intersection-observer'
 

--- a/packages/tds-widget/src/review/components/mileage-button.tsx
+++ b/packages/tds-widget/src/review/components/mileage-button.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 import { useTranslation } from 'react-i18next'

--- a/packages/tds-widget/src/review/components/my-review-action-sheet.tsx
+++ b/packages/tds-widget/src/review/components/my-review-action-sheet.tsx
@@ -1,6 +1,6 @@
-import { ActionSheet, ActionSheetItem } from '@titicaca/action-sheet'
+import { ActionSheet, ActionSheetItem } from '@titicaca/tds-ui'
 import { useTranslation } from '@titicaca/next-i18next'
-import { Confirm } from '@titicaca/modals'
+import { Confirm } from '@titicaca/tds-ui'
 import {
   useHistoryFunctions,
   useUriHash,

--- a/packages/tds-widget/src/review/components/my-review-action-sheet.tsx
+++ b/packages/tds-widget/src/review/components/my-review-action-sheet.tsx
@@ -1,6 +1,5 @@
-import { ActionSheet, ActionSheetItem } from '@titicaca/tds-ui'
+import { ActionSheet, ActionSheetItem, Confirm } from '@titicaca/tds-ui'
 import { useTranslation } from '@titicaca/next-i18next'
-import { Confirm } from '@titicaca/tds-ui'
 import {
   useHistoryFunctions,
   useUriHash,

--- a/packages/tds-widget/src/review/components/others-review-action-sheet.tsx
+++ b/packages/tds-widget/src/review/components/others-review-action-sheet.tsx
@@ -1,4 +1,4 @@
-import { ActionSheet, ActionSheetItem } from '@titicaca/action-sheet'
+import { ActionSheet, ActionSheetItem } from '@titicaca/tds-ui'
 import { useTranslation } from '@titicaca/next-i18next'
 import { useUriHash, useHistoryFunctions } from '@titicaca/react-contexts'
 

--- a/packages/tds-widget/src/review/components/review-element/comment.tsx
+++ b/packages/tds-widget/src/review/components/review-element/comment.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 export default function Comment({ children }: PropsWithChildren<unknown>) {
   return (

--- a/packages/tds-widget/src/review/components/review-element/index.tsx
+++ b/packages/tds-widget/src/review/components/review-element/index.tsx
@@ -1,4 +1,4 @@
-import { Container, FlexBox, List, Rating, Text } from '@titicaca/core-elements'
+import { Container, FlexBox, List, Rating, Text } from '@titicaca/tds-ui'
 import { StaticIntersectionObserver as IntersectionObserver } from '@titicaca/intersection-observer'
 import { TransitionType } from '@titicaca/modals'
 import { useTranslation } from '@titicaca/next-i18next'

--- a/packages/tds-widget/src/review/components/review-element/media/elements.ts
+++ b/packages/tds-widget/src/review/components/review-element/media/elements.ts
@@ -1,4 +1,4 @@
-import { Container, FlexBox } from '@titicaca/core-elements'
+import { Container, FlexBox } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 
 export const GridWrapper = styled(Container)`

--- a/packages/tds-widget/src/review/components/review-element/media/image.tsx
+++ b/packages/tds-widget/src/review/components/review-element/media/image.tsx
@@ -1,4 +1,4 @@
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import { ImageMeta } from '@titicaca/type-definitions'
 import styled from 'styled-components'
 

--- a/packages/tds-widget/src/review/components/review-element/media/video.tsx
+++ b/packages/tds-widget/src/review/components/review-element/media/video.tsx
@@ -1,5 +1,5 @@
 import { ImageMeta } from '@titicaca/type-definitions'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import { useIntersection } from '@titicaca/intersection-observer'
 import { useEffect, useState } from 'react'
 import { useDeviceContext } from '@titicaca/react-contexts'

--- a/packages/tds-widget/src/review/components/review-element/pinned-message.tsx
+++ b/packages/tds-widget/src/review/components/review-element/pinned-message.tsx
@@ -1,6 +1,6 @@
 import { MouseEventHandler, useEffect, useRef, useState } from 'react'
 import moment from 'moment'
-import { Button, FlexBox, Text } from '@titicaca/core-elements'
+import { Button, FlexBox, Text } from '@titicaca/tds-ui'
 import { useTranslation } from '@titicaca/next-i18next'
 
 import { BasePinnedMessageFragment } from '../../data/graphql'

--- a/packages/tds-widget/src/review/components/review-element/user.tsx
+++ b/packages/tds-widget/src/review/components/review-element/user.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren, MouseEventHandler } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
-import { Container, Text } from '@titicaca/core-elements'
+import { Container, Text } from '@titicaca/tds-ui'
 
 import { BaseUserFragment } from '../../data/graphql'
 

--- a/packages/tds-widget/src/review/components/review-placeholder-with-rating.tsx
+++ b/packages/tds-widget/src/review/components/review-placeholder-with-rating.tsx
@@ -1,7 +1,7 @@
 import { SyntheticEvent, useCallback } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
-import { Button, Container, Rating, Text } from '@titicaca/core-elements'
+import { Button, Container, Rating, Text } from '@titicaca/tds-ui'
 import { useAppCallback, useSessionCallback } from '@titicaca/ui-flow'
 import { TransitionType } from '@titicaca/modals'
 import { useEventTrackingContext } from '@titicaca/react-contexts'

--- a/packages/tds-widget/src/review/components/reviews-shorten.tsx
+++ b/packages/tds-widget/src/review/components/reviews-shorten.tsx
@@ -1,6 +1,6 @@
 import { ComponentType, useEffect } from 'react'
 import styled from 'styled-components'
-import { FlexBox, Section, Text } from '@titicaca/core-elements'
+import { FlexBox, Section, Text } from '@titicaca/tds-ui'
 import { LoginCtaModalProvider } from '@titicaca/modals'
 import { useTranslation } from '@titicaca/next-i18next'
 import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'

--- a/packages/tds-widget/src/review/components/reviews.tsx
+++ b/packages/tds-widget/src/review/components/reviews.tsx
@@ -1,7 +1,7 @@
 import { ComponentType, useEffect } from 'react'
 import styled from 'styled-components'
 import { Trans } from '@titicaca/next-i18next'
-import { FlexBox, Section, Container, Text } from '@titicaca/core-elements'
+import { FlexBox, Section, Container, Text } from '@titicaca/tds-ui'
 import { formatNumber } from '@titicaca/view-utilities'
 import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 import { LoginCtaModalProvider } from '@titicaca/modals'

--- a/packages/tds-widget/src/review/components/shorten-list/reviews-list.tsx
+++ b/packages/tds-widget/src/review/components/shorten-list/reviews-list.tsx
@@ -1,4 +1,4 @@
-import { List, Spinner } from '@titicaca/core-elements'
+import { List, Spinner } from '@titicaca/tds-ui'
 import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 import { useEffect, useMemo, useState } from 'react'
 

--- a/packages/tds-widget/src/review/components/sorting-options-action-sheet.tsx
+++ b/packages/tds-widget/src/review/components/sorting-options-action-sheet.tsx
@@ -1,4 +1,4 @@
-import { ActionSheet, ActionSheetItem } from '@titicaca/action-sheet'
+import { ActionSheet, ActionSheetItem } from '@titicaca/tds-ui'
 import { useUriHash, useHistoryFunctions } from '@titicaca/react-contexts'
 
 import { useReviewSortingOptions } from './sorting-context'

--- a/packages/tds-widget/src/review/components/sorting-options.tsx
+++ b/packages/tds-widget/src/review/components/sorting-options.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import styled from 'styled-components'
-import { FlexBox, Text } from '@titicaca/core-elements'
+import { FlexBox, Text } from '@titicaca/tds-ui'
 import { useHistoryFunctions } from '@titicaca/react-contexts'
 
 import { useReviewSortingOptions } from './sorting-context'

--- a/packages/tds-widget/src/review/components/write-button.tsx
+++ b/packages/tds-widget/src/review/components/write-button.tsx
@@ -1,4 +1,4 @@
-import { ButtonBase } from '@titicaca/core-elements'
+import { ButtonBase } from '@titicaca/tds-ui'
 import { TransitionType } from '@titicaca/modals'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { useAppCallback, useSessionCallback } from '@titicaca/ui-flow'

--- a/packages/tds-widget/src/search/search.tsx
+++ b/packages/tds-widget/src/search/search.tsx
@@ -10,11 +10,7 @@ import {
   PropsWithChildren,
 } from 'react'
 import styled, { css } from 'styled-components'
-import {
-  Container,
-  LayeringMixinProps,
-  SearchNavbar,
-} from '@titicaca/core-elements'
+import { Container, LayeringMixinProps, SearchNavbar } from '@titicaca/tds-ui'
 import { useUserAgentContext } from '@titicaca/react-contexts'
 import {
   openKeyboard,

--- a/packages/tds-widget/src/social-reviews/external-links.tsx
+++ b/packages/tds-widget/src/social-reviews/external-links.tsx
@@ -9,7 +9,7 @@ import {
   H3,
   FlexBox,
   FlexBoxItem,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { MouseEvent } from 'react'
 
 const ExternalLinkEntry = styled(List.Item)`

--- a/packages/tds-widget/src/social-reviews/social-review.tsx
+++ b/packages/tds-widget/src/social-reviews/social-review.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@titicaca/next-i18next'
-import { Section } from '@titicaca/core-elements'
+import { Section } from '@titicaca/tds-ui'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { useNavigate } from '@titicaca/router'
 

--- a/packages/tds-widget/src/user-verification/verification-request.tsx
+++ b/packages/tds-widget/src/user-verification/verification-request.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
-import { Modal } from '@titicaca/modals'
+import { Modal } from '@titicaca/tds-ui'
 import { Text } from '@titicaca/core-elements'
 
 import { useUserVerification } from './use-user-verification'

--- a/packages/tds-widget/src/user-verification/verification-request.tsx
+++ b/packages/tds-widget/src/user-verification/verification-request.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
-import { Modal } from '@titicaca/tds-ui'
-import { Text } from '@titicaca/tds-ui'
+import { Modal, Text } from '@titicaca/tds-ui'
 
 import { useUserVerification } from './use-user-verification'
 

--- a/packages/tds-widget/src/user-verification/verification-request.tsx
+++ b/packages/tds-widget/src/user-verification/verification-request.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
 import { Modal } from '@titicaca/tds-ui'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 import { useUserVerification } from './use-user-verification'
 

--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -40,9 +40,7 @@
     ]
   },
   "dependencies": {
-    "@titicaca/carousel": "workspace:*",
     "@titicaca/content-type-definitions": "8.11.0",
-    "@titicaca/core-elements": "workspace:*",
     "@titicaca/fetcher": "workspace:*",
     "@titicaca/intersection-observer": "workspace:*",
     "@titicaca/map": "workspace:*",
@@ -50,10 +48,11 @@
     "@titicaca/react-hooks": "workspace:*",
     "@titicaca/router": "workspace:*",
     "@titicaca/standard-action-handler": "workspace:*",
+    "@titicaca/tds-ui": "workspace:*",
+    "@titicaca/tds-widget": "workspace:*",
     "@titicaca/triple-media": "workspace:*",
     "@titicaca/type-definitions": "workspace:*",
     "@titicaca/ui-flow": "workspace:*",
-    "@titicaca/tds-widget": "workspace:*",
     "moment": "^2.29.4",
     "qs": "^6.11.2"
   },

--- a/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
+++ b/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
-import { Button } from '@titicaca/core-elements'
+import { Button } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 import {
   useHistoryFunctions,

--- a/packages/triple-document/src/elements/coupon/index.tsx
+++ b/packages/triple-document/src/elements/coupon/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { Text, Container } from '@titicaca/core-elements'
+import { Text, Container } from '@titicaca/tds-ui'
 import { useEventTrackerWithMetadata } from '@titicaca/react-contexts'
 import { VerificationType } from '@titicaca/user-verification'
 

--- a/packages/triple-document/src/elements/coupon/modals.tsx
+++ b/packages/triple-document/src/elements/coupon/modals.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from '@titicaca/next-i18next'
-import { Text } from '@titicaca/tds-ui'
-import { Modal, Alert } from '@titicaca/tds-ui'
+import { Text, Modal, Alert } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 import { useUriHash, useHistoryFunctions } from '@titicaca/react-contexts'
 import { useNavigate } from '@titicaca/router'

--- a/packages/triple-document/src/elements/coupon/modals.tsx
+++ b/packages/triple-document/src/elements/coupon/modals.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from '@titicaca/next-i18next'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 import { Modal, Alert } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 import { useUriHash, useHistoryFunctions } from '@titicaca/react-contexts'

--- a/packages/triple-document/src/elements/coupon/modals.tsx
+++ b/packages/triple-document/src/elements/coupon/modals.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from '@titicaca/next-i18next'
 import { Text } from '@titicaca/core-elements'
-import { Modal, Alert } from '@titicaca/modals'
+import { Modal, Alert } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 import { useUriHash, useHistoryFunctions } from '@titicaca/react-contexts'
 import { useNavigate } from '@titicaca/router'

--- a/packages/triple-document/src/elements/embedded.tsx
+++ b/packages/triple-document/src/elements/embedded.tsx
@@ -1,8 +1,7 @@
 import { ComponentType } from 'react'
-import { Container } from '@titicaca/tds-ui'
+import { Container, Carousel } from '@titicaca/tds-ui'
 import TripleMedia from '@titicaca/triple-media'
 import { ImageMeta } from '@titicaca/type-definitions'
-import { Carousel } from '@titicaca/carousel'
 
 import { TripleElementData, ElementSet } from '../types'
 import { useImageClickHandler } from '../prop-context/image-click-handler'

--- a/packages/triple-document/src/elements/embedded.tsx
+++ b/packages/triple-document/src/elements/embedded.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from 'react'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import TripleMedia from '@titicaca/triple-media'
 import { ImageMeta } from '@titicaca/type-definitions'
 import { Carousel } from '@titicaca/carousel'

--- a/packages/triple-document/src/elements/external-video.tsx
+++ b/packages/triple-document/src/elements/external-video.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { borderRadiusMixin } from '@titicaca/core-elements'
+import { borderRadiusMixin } from '@titicaca/tds-ui'
 
 const VideoContainer = styled.div<{ borderRadius: number }>`
   position: relative;

--- a/packages/triple-document/src/elements/images.tsx
+++ b/packages/triple-document/src/elements/images.tsx
@@ -1,7 +1,4 @@
-import {
-  ImageCarouselElementContainer,
-  ImageCaption,
-} from '@titicaca/core-elements'
+import { ImageCarouselElementContainer, ImageCaption } from '@titicaca/tds-ui'
 import TripleMedia from '@titicaca/triple-media'
 import { ImageMeta } from '@titicaca/type-definitions'
 import { DocumentImageDisplayType } from '@titicaca/content-type-definitions'

--- a/packages/triple-document/src/elements/index.ts
+++ b/packages/triple-document/src/elements/index.ts
@@ -1,4 +1,4 @@
-import { HR1, HR2, HR3, HR4, HR5, HR6 } from '@titicaca/core-elements'
+import { HR1, HR2, HR3, HR4, HR5, HR6 } from '@titicaca/tds-ui'
 
 import { ElementSet } from '../types'
 

--- a/packages/triple-document/src/elements/itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary.tsx
@@ -8,7 +8,7 @@ import {
   FlexBox,
   FlexBoxItem,
   Button,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import type {
   TransportationType,
   Itinerary,

--- a/packages/triple-document/src/elements/itinerary/itinerary-map.tsx
+++ b/packages/triple-document/src/elements/itinerary/itinerary-map.tsx
@@ -1,5 +1,5 @@
 import { useCallback, MouseEvent } from 'react'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import {
   MapView,
   HotelCircleMarker,

--- a/packages/triple-document/src/elements/links.tsx
+++ b/packages/triple-document/src/elements/links.tsx
@@ -7,7 +7,7 @@ import {
   SquareImage,
   SimpleLink,
   Text,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { ImageMeta } from '@titicaca/type-definitions'
 
 import { Link } from '../types'

--- a/packages/triple-document/src/elements/list.tsx
+++ b/packages/triple-document/src/elements/list.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 
 import { TripleElementData, Link } from '../types'
 

--- a/packages/triple-document/src/elements/note.tsx
+++ b/packages/triple-document/src/elements/note.tsx
@@ -1,4 +1,4 @@
-import { Segment, Text } from '@titicaca/core-elements'
+import { Segment, Text } from '@titicaca/tds-ui'
 
 export default function Note({
   value: { title, body },

--- a/packages/triple-document/src/elements/pois.tsx
+++ b/packages/triple-document/src/elements/pois.tsx
@@ -6,7 +6,7 @@ import {
   PoiListElementProps,
   PoiListElementType,
 } from '@titicaca/poi-list-elements'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 import { useResourceClickHandler } from '../prop-context/resource-click-handler'
 

--- a/packages/triple-document/src/elements/regions.tsx
+++ b/packages/triple-document/src/elements/regions.tsx
@@ -1,7 +1,7 @@
 import { MouseEventHandler } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
-import { ResourceListItem, Image } from '@titicaca/core-elements'
+import { ResourceListItem, Image } from '@titicaca/tds-ui'
 
 import { RegionData } from '../types'
 import { useResourceClickHandler } from '../prop-context/resource-click-handler'

--- a/packages/triple-document/src/elements/shared/display-containers.tsx
+++ b/packages/triple-document/src/elements/shared/display-containers.tsx
@@ -5,7 +5,7 @@ import {
   Container,
   ImageBlockElementContainer,
   ImageCarouselElementContainer,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 
 import DocumentCarousel from './document-carousel'
 

--- a/packages/triple-document/src/elements/shared/document-carousel.tsx
+++ b/packages/triple-document/src/elements/shared/document-carousel.tsx
@@ -1,6 +1,5 @@
 import { PropsWithChildren } from 'react'
-import { MarginPadding } from '@titicaca/tds-ui'
-import { Carousel } from '@titicaca/carousel'
+import { MarginPadding, Carousel } from '@titicaca/tds-ui'
 
 export default function DocumentCarousel({
   margin,

--- a/packages/triple-document/src/elements/shared/document-carousel.tsx
+++ b/packages/triple-document/src/elements/shared/document-carousel.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react'
-import { MarginPadding } from '@titicaca/core-elements'
+import { MarginPadding } from '@titicaca/tds-ui'
 import { Carousel } from '@titicaca/carousel'
 
 export default function DocumentCarousel({

--- a/packages/triple-document/src/elements/shared/resource-list.tsx
+++ b/packages/triple-document/src/elements/shared/resource-list.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react'
-import { List } from '@titicaca/core-elements'
+import { List } from '@titicaca/tds-ui'
 
 export default function ResourceList({ children }: PropsWithChildren<unknown>) {
   return <List margin={{ top: 20, left: 30, right: 30 }}>{children}</List>

--- a/packages/triple-document/src/elements/table.tsx
+++ b/packages/triple-document/src/elements/table.tsx
@@ -3,7 +3,7 @@ import {
   ContainerProps,
   Table as TableView,
   TableProps,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 
 export default function Table({
   value: { table },

--- a/packages/triple-document/src/elements/text/headings.tsx
+++ b/packages/triple-document/src/elements/text/headings.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from 'react'
-import { H1, H2, H3, H4 } from '@titicaca/core-elements'
+import { H1, H2, H3, H4 } from '@titicaca/tds-ui'
 
 interface HeadingProps {
   href?: string

--- a/packages/triple-document/src/elements/text/plain.tsx
+++ b/packages/triple-document/src/elements/text/plain.tsx
@@ -1,5 +1,5 @@
 import { useCallback, SyntheticEvent } from 'react'
-import { Text, Paragraph } from '@titicaca/core-elements'
+import { Text, Paragraph } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 
 import { useLinkClickHandler } from '../../prop-context/link-click-handler'

--- a/packages/triple-document/src/elements/tna/index.tsx
+++ b/packages/triple-document/src/elements/tna/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { HR2 } from '@titicaca/core-elements'
+import { HR2 } from '@titicaca/tds-ui'
 import { get } from '@titicaca/fetcher'
 
 import { TnaProductsResponse } from './types'

--- a/packages/triple-document/src/elements/tna/price-policy-coupon-info.tsx
+++ b/packages/triple-document/src/elements/tna/price-policy-coupon-info.tsx
@@ -1,4 +1,4 @@
-import { Container, Text } from '@titicaca/core-elements'
+import { Container, Text } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 import { useTranslation } from '@titicaca/next-i18next'
 

--- a/packages/triple-document/src/elements/tna/product.tsx
+++ b/packages/triple-document/src/elements/tna/product.tsx
@@ -1,6 +1,6 @@
 import { MouseEventHandler, SyntheticEvent, useCallback } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
-import { Text, Tag, Container, Image, Rating } from '@titicaca/core-elements'
+import { Text, Tag, Container, Image, Rating } from '@titicaca/tds-ui'
 import { formatNumber } from '@titicaca/view-utilities'
 import { StaticIntersectionObserver } from '@titicaca/intersection-observer'
 import { OverlayScrapButton } from '@titicaca/scrap-button'

--- a/packages/triple-document/src/elements/tna/slot.tsx
+++ b/packages/triple-document/src/elements/tna/slot.tsx
@@ -1,6 +1,6 @@
 import { SyntheticEvent, useCallback, useState } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
-import { Container, H1, List, Button } from '@titicaca/core-elements'
+import { Container, H1, List, Button } from '@titicaca/tds-ui'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { useNavigate } from '@titicaca/router'
 import { useTheme } from 'styled-components'

--- a/packages/triple-document/src/elements/tna/types.ts
+++ b/packages/triple-document/src/elements/tna/types.ts
@@ -1,5 +1,5 @@
 import { CSSProperties, SyntheticEvent } from 'react'
-import { TagColors } from '@titicaca/core-elements'
+import { TagColors } from '@titicaca/tds-ui'
 
 type Price = string | number
 

--- a/packages/triple-document/src/triple-document.stories.tsx
+++ b/packages/triple-document/src/triple-document.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import { useScrollToAnchor } from '@titicaca/react-hooks'
 import { rest } from 'msw'
 import { useEffect } from 'react'

--- a/packages/triple-email-document/package.json
+++ b/packages/triple-email-document/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@titicaca/core-elements": "workspace:*",
+    "@titicaca/tds-ui": "workspace:*",
     "@titicaca/type-definitions": "workspace:*"
   },
   "devDependencies": {

--- a/packages/triple-email-document/src/common/box.ts
+++ b/packages/triple-email-document/src/common/box.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { MarginPadding } from '@titicaca/core-elements'
+import { MarginPadding } from '@titicaca/tds-ui'
 
 const Box = styled.td<{ padding?: MarginPadding }>`
   /* stylelint-disable function-whitespace-after */

--- a/packages/triple-email-document/src/common/fluid-table.ts
+++ b/packages/triple-email-document/src/common/fluid-table.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { marginMixin, MarginPadding } from '@titicaca/core-elements'
+import { marginMixin, MarginPadding } from '@titicaca/tds-ui'
 
 const FluidTable = styled.table<{ margin?: MarginPadding }>`
   width: 100%;

--- a/packages/triple-email-document/src/elements/embedded.tsx
+++ b/packages/triple-email-document/src/elements/embedded.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from 'react'
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 import { FluidTable, Box } from '../common'
 

--- a/packages/triple-email-document/src/elements/links.tsx
+++ b/packages/triple-email-document/src/elements/links.tsx
@@ -1,5 +1,5 @@
 import { HTMLAttributes, PropsWithChildren } from 'react'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import styled from 'styled-components'
 
 import { FluidTable, Box as DefaultBox } from '../common'

--- a/packages/triple-header/package.json
+++ b/packages/triple-header/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@titicaca/core-elements": "workspace:*",
+    "@titicaca/tds-ui": "workspace:*",
     "@titicaca/router": "workspace:*",
     "@titicaca/standard-action-handler": "workspace:*",
     "@titicaca/type-definitions": "workspace:*",

--- a/packages/triple-header/src/frame/frame.tsx
+++ b/packages/triple-header/src/frame/frame.tsx
@@ -1,5 +1,5 @@
 import { ComponentType, useCallback, useMemo } from 'react'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import { initialize } from '@titicaca/standard-action-handler'
 import styled, { css } from 'styled-components'
 import { ContextOptions } from '@titicaca/standard-action-handler/src/types'

--- a/packages/triple-header/src/frame/text.tsx
+++ b/packages/triple-header/src/frame/text.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/tds-ui'
 
 import { MotionContainer } from '../motion-container'
 import { Link, LinkEventHandler } from '../types'

--- a/packages/triple-header/src/layer/layer.tsx
+++ b/packages/triple-header/src/layer/layer.tsx
@@ -1,4 +1,4 @@
-import { Container, MarginPadding } from '@titicaca/core-elements'
+import { Container, MarginPadding } from '@titicaca/tds-ui'
 import styled, { css } from 'styled-components'
 
 import { FrameData, TransitionType } from '../types'

--- a/packages/triple-header/src/layer/transitions/rolling.tsx
+++ b/packages/triple-header/src/layer/transitions/rolling.tsx
@@ -7,7 +7,7 @@ import {
   Fragment,
   useMemo,
 } from 'react'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import styled, { css } from 'styled-components'
 
 const RollingContainer = styled(Container)<{ isTransition: boolean }>`

--- a/packages/triple-header/src/triple-header.tsx
+++ b/packages/triple-header/src/triple-header.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useLayoutEffect } from 'react'
-import { Container } from '@titicaca/core-elements'
+import { Container } from '@titicaca/tds-ui'
 import styled, { css } from 'styled-components'
 
 import { Layer } from './layer'

--- a/packages/triple-header/src/types.ts
+++ b/packages/triple-header/src/types.ts
@@ -1,4 +1,4 @@
-import { MarginPadding } from '@titicaca/core-elements'
+import { MarginPadding } from '@titicaca/tds-ui'
 import { SyntheticEvent } from 'react'
 
 import { ImageFrame } from './frame/image'

--- a/packages/triple-media/package.json
+++ b/packages/triple-media/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@titicaca/core-elements": "workspace:*",
+    "@titicaca/tds-ui": "workspace:*",
     "@titicaca/tds-widget": "workspace:*",
     "@titicaca/type-definitions": "workspace:*"
   },

--- a/packages/triple-media/src/triple-media.tsx
+++ b/packages/triple-media/src/triple-media.tsx
@@ -4,7 +4,7 @@ import {
   Image,
   MarginPadding,
   OptimizedImgProps,
-} from '@titicaca/core-elements'
+} from '@titicaca/tds-ui'
 import { ImageSource } from '@titicaca/image-source'
 import { ImageMeta, FrameRatioAndSizes } from '@titicaca/type-definitions'
 

--- a/packages/web-storage/src/boundary.tsx
+++ b/packages/web-storage/src/boundary.tsx
@@ -1,4 +1,4 @@
-import { Alert } from '@titicaca/modals'
+import { Alert } from '@titicaca/tds-ui'
 import { WithTranslation, withTranslation } from '@titicaca/next-i18next'
 import { Component, ReactNode } from 'react'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,77 +190,7 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
 
-  packages/action-sheet:
-    dependencies:
-      '@titicaca/tds-ui':
-        specifier: workspace:*
-        version: link:../tds-ui
-    devDependencies:
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      styled-components:
-        specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.22.11)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-
-  packages/carousel:
-    dependencies:
-      '@egjs/flicking':
-        specifier: ^3.9.3
-        version: 3.9.3
-      '@egjs/react-flicking':
-        specifier: ^3.8.3
-        version: 3.8.3
-      '@titicaca/core-elements':
-        specifier: workspace:*
-        version: link:../core-elements
-      '@titicaca/intersection-observer':
-        specifier: workspace:*
-        version: link:../intersection-observer
-      '@titicaca/type-definitions':
-        specifier: workspace:*
-        version: link:../type-definitions
-    devDependencies:
-      '@titicaca/react-contexts':
-        specifier: workspace:*
-        version: link:../react-contexts
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      styled-components:
-        specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.22.11)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-
   packages/constants: {}
-
-  packages/core-elements:
-    dependencies:
-      '@titicaca/tds-ui':
-        specifier: workspace:*
-        version: link:../tds-ui
-    devDependencies:
-      '@titicaca/tds-theme':
-        specifier: workspace:*
-        version: link:../tds-theme
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      styled-components:
-        specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.22.11)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-
-  packages/drawer-button:
-    dependencies:
-      '@titicaca/core-elements':
-        specifier: workspace:*
-        version: link:../core-elements
-    devDependencies:
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      styled-components:
-        specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.22.11)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
 
   packages/fetcher:
     dependencies:
@@ -321,12 +251,12 @@ importers:
       '@react-google-maps/api':
         specifier: ^2.19.2
         version: 2.19.2(react-dom@18.2.0)(react@18.2.0)
-      '@titicaca/core-elements':
-        specifier: workspace:*
-        version: link:../core-elements
       '@titicaca/router':
         specifier: workspace:*
         version: link:../router
+      '@titicaca/tds-ui':
+        specifier: workspace:*
+        version: link:../tds-ui
       '@titicaca/type-definitions':
         specifier: workspace:*
         version: link:../type-definitions
@@ -373,9 +303,6 @@ importers:
 
   packages/modals:
     dependencies:
-      '@titicaca/core-elements':
-        specifier: workspace:*
-        version: link:../core-elements
       '@titicaca/tds-ui':
         specifier: workspace:*
         version: link:../tds-ui
@@ -398,19 +325,6 @@ importers:
       utility-types:
         specifier: ^3.10.0
         version: 3.10.0
-
-  packages/popup:
-    dependencies:
-      '@titicaca/tds-ui':
-        specifier: workspace:*
-        version: link:../tds-ui
-    devDependencies:
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      styled-components:
-        specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.22.11)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
 
   packages/react-contexts:
     dependencies:
@@ -582,25 +496,6 @@ importers:
         specifier: ^18.6.4
         version: 18.6.4
 
-  packages/slider:
-    dependencies:
-      '@titicaca/core-elements':
-        specifier: workspace:*
-        version: link:../core-elements
-      '@titicaca/view-utilities':
-        specifier: workspace:*
-        version: link:../view-utilities
-      react-compound-slider:
-        specifier: ^3.4.0
-        version: 3.4.0(react@18.2.0)
-    devDependencies:
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      styled-components:
-        specifier: ^5.3.11
-        version: 5.3.11(@babel/core@7.22.11)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
-
   packages/standard-action-handler:
     dependencies:
       '@titicaca/router':
@@ -646,9 +541,9 @@ importers:
 
   packages/static-map:
     dependencies:
-      '@titicaca/core-elements':
+      '@titicaca/tds-ui':
         specifier: workspace:*
-        version: link:../core-elements
+        version: link:../tds-ui
     devDependencies:
       '@titicaca/type-definitions':
         specifier: workspace:*
@@ -686,15 +581,18 @@ importers:
 
   packages/tds-ui:
     dependencies:
+      '@egjs/flicking':
+        specifier: ^3.9.3
+        version: 3.9.3
+      '@egjs/react-flicking':
+        specifier: ^3.8.3
+        version: 3.8.3
       '@floating-ui/react':
         specifier: ^0.25.4
         version: 0.25.4(react-dom@18.2.0)(react@18.2.0)
       '@titicaca/content-utilities':
         specifier: ^8.12.0
         version: 8.12.0
-      '@titicaca/core-elements':
-        specifier: workspace:*
-        version: link:../core-elements
       '@titicaca/intersection-observer':
         specifier: workspace:*
         version: link:../intersection-observer
@@ -704,6 +602,9 @@ importers:
       '@titicaca/view-utilities':
         specifier: workspace:*
         version: link:../view-utilities
+      react-compound-slider:
+        specifier: ^3.4.0
+        version: 3.4.0(react@18.2.0)
       react-input-mask:
         specifier: ^2.0.4
         version: 2.0.4(react-dom@18.2.0)(react@18.2.0)
@@ -835,15 +736,9 @@ importers:
 
   packages/triple-document:
     dependencies:
-      '@titicaca/carousel':
-        specifier: workspace:*
-        version: link:../carousel
       '@titicaca/content-type-definitions':
         specifier: 8.11.0
         version: 8.11.0
-      '@titicaca/core-elements':
-        specifier: workspace:*
-        version: link:../core-elements
       '@titicaca/fetcher':
         specifier: workspace:*
         version: link:../fetcher
@@ -865,6 +760,9 @@ importers:
       '@titicaca/standard-action-handler':
         specifier: workspace:*
         version: link:../standard-action-handler
+      '@titicaca/tds-ui':
+        specifier: workspace:*
+        version: link:../tds-ui
       '@titicaca/tds-widget':
         specifier: workspace:*
         version: link:../tds-widget
@@ -911,9 +809,9 @@ importers:
 
   packages/triple-email-document:
     dependencies:
-      '@titicaca/core-elements':
+      '@titicaca/tds-ui':
         specifier: workspace:*
-        version: link:../core-elements
+        version: link:../tds-ui
       '@titicaca/type-definitions':
         specifier: workspace:*
         version: link:../type-definitions
@@ -933,15 +831,15 @@ importers:
 
   packages/triple-header:
     dependencies:
-      '@titicaca/core-elements':
-        specifier: workspace:*
-        version: link:../core-elements
       '@titicaca/router':
         specifier: workspace:*
         version: link:../router
       '@titicaca/standard-action-handler':
         specifier: workspace:*
         version: link:../standard-action-handler
+      '@titicaca/tds-ui':
+        specifier: workspace:*
+        version: link:../tds-ui
       '@titicaca/type-definitions':
         specifier: workspace:*
         version: link:../type-definitions
@@ -973,9 +871,9 @@ importers:
 
   packages/triple-media:
     dependencies:
-      '@titicaca/core-elements':
+      '@titicaca/tds-ui':
         specifier: workspace:*
-        version: link:../core-elements
+        version: link:../tds-ui
       '@titicaca/tds-widget':
         specifier: workspace:*
         version: link:../tds-widget


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

tds-ui import path 수정

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- action-sheet, modal, popup, core-elements, carousel 패키지 대신 tds-ui로 import 합니다.