### PR TITLE
API 응답 일반화 노출 기능을 추가합니다.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
-          cache: 'pnpm'
+          # cache: 'pnpm'
 
       - name: Wait for CI
         uses: fountainhead/action-wait-for-check@v1.1.0
@@ -92,7 +92,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
-          cache: 'pnpm'
+          # cache: 'pnpm'
 
       - name: Get release version
         run: echo "DEPLOY_VERSION=v$(cat ./lerna.json | jq -r '.version')" >> $GITHUB_ENV
@@ -213,7 +213,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY_URL }}
-          cache: 'pnpm'
+          # cache: 'pnpm'
 
       - name: Get release version
         env:

--- a/packages/standard-action-handler/package.json
+++ b/packages/standard-action-handler/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@titicaca/router": "workspace:*",
     "@titicaca/scroll-to-element": "workspace:*",
+    "@titicaca/modals": "workspace:*",
     "@titicaca/triple-web-to-native-interfaces": "1.9.0",
     "@titicaca/view-utilities": "workspace:*",
     "qs": "^6.11.2"

--- a/packages/standard-action-handler/src/converse.tsx
+++ b/packages/standard-action-handler/src/converse.tsx
@@ -1,0 +1,44 @@
+import { createRoot } from 'react-dom/client'
+import { Modal } from '@titicaca/modals'
+
+import { WebActionParams } from './types'
+
+const title = 'TEST'
+const description = '성공입니다.'
+
+export default function converse({ url: { path } = {} }: WebActionParams) {
+  if (path === '/web-action/converse') {
+    if (title && description) {
+      const container = document.createElement('div')
+      const root = createRoot(container)
+
+      root.render(
+        OpenModal({ title, description, onClose: () => root.unmount() }),
+      )
+
+      return true
+    }
+  }
+}
+
+function OpenModal({
+  title,
+  description,
+  onClose,
+}: {
+  title: string
+  description: string
+  onClose: () => void
+}) {
+  return (
+    <Modal open onClose={onClose}>
+      <Modal.Title>{title}</Modal.Title>
+      <Modal.Description>{description}</Modal.Description>
+      <Modal.Actions>
+        <Modal.Action color="blue" onClick={onClose}>
+          확인
+        </Modal.Action>
+      </Modal.Actions>
+    </Modal>
+  )
+}

--- a/packages/standard-action-handler/src/converse.tsx
+++ b/packages/standard-action-handler/src/converse.tsx
@@ -6,7 +6,9 @@ import { WebActionParams } from './types'
 const title = 'TEST'
 const description = '성공입니다.'
 
-export default function converse({ url: { path } = {} }: WebActionParams) {
+export default async function converse({
+  url: { path } = {},
+}: WebActionParams) {
   if (path === '/web-action/converse') {
     if (title && description) {
       const container = document.createElement('div')
@@ -19,6 +21,8 @@ export default function converse({ url: { path } = {} }: WebActionParams) {
       return true
     }
   }
+
+  return false
 }
 
 function OpenModal({

--- a/packages/standard-action-handler/src/converse.tsx
+++ b/packages/standard-action-handler/src/converse.tsx
@@ -4,6 +4,8 @@ import { Modal } from '@titicaca/modals'
 
 import { WebActionParams } from './types'
 
+const HASH_CONVERSE_MODAL = 'hash.converse-modal'
+
 export default async function converse({
   url: { path, query } = {},
 }: WebActionParams) {
@@ -13,11 +15,30 @@ export default async function converse({
     const { title, description } = await fetchApi(pathFromQuery)
 
     if (title && description) {
+      window.history.pushState(null, '', `#${HASH_CONVERSE_MODAL}`)
+
       const container = document.createElement('div')
       const root = createRoot(container)
 
+      const closeModal = () => {
+        window.history.back()
+      }
+
+      const handlePopstate = () => {
+        root.unmount()
+        container.remove()
+
+        window.removeEventListener('popstate', handlePopstate)
+      }
+
+      window.addEventListener('popstate', handlePopstate)
+
       root.render(
-        OpenModal({ title, description, onClose: () => root.unmount() }),
+        OpenModal({
+          title,
+          description,
+          onClose: closeModal,
+        }),
       )
 
       return true
@@ -29,7 +50,7 @@ export default async function converse({
   return false
 }
 
-function OpenModal({
+export function OpenModal({
   title,
   description,
   onClose,

--- a/packages/standard-action-handler/src/converse.tsx
+++ b/packages/standard-action-handler/src/converse.tsx
@@ -8,12 +8,9 @@ export default async function converse({
   url: { path, query } = {},
 }: WebActionParams) {
   if (path === '/web-action/converse' && query) {
-    const { path: url } = qs.parse(query) as { path: string }
+    const { path: pathFromQuery } = qs.parse(query) as { path: string }
 
-    // 예시 코드
-    const { title, body: description } = (await fetch(url).then((response) => {
-      return response.json()
-    })) as { title: string; body: string }
+    const { title, description } = await fetchApi(pathFromQuery)
 
     if (title && description) {
       const container = document.createElement('div')
@@ -25,6 +22,8 @@ export default async function converse({
 
       return true
     }
+
+    return false
   }
 
   return false
@@ -41,8 +40,10 @@ function OpenModal({
 }) {
   return (
     <Modal open onClose={onClose}>
-      <Modal.Title>{title}</Modal.Title>
-      <Modal.Description>{description}</Modal.Description>
+      <Modal.Body>
+        <Modal.Title>{title}</Modal.Title>
+        <Modal.Description>{description}</Modal.Description>
+      </Modal.Body>
       <Modal.Actions>
         <Modal.Action color="blue" onClick={onClose}>
           확인
@@ -50,4 +51,30 @@ function OpenModal({
       </Modal.Actions>
     </Modal>
   )
+}
+
+async function fetchApi(
+  url: string,
+): Promise<{ title: string; description: string }> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+
+  if (!response.ok) {
+    return {
+      title: '안내',
+      description:
+        '서비스 이용이 원활하지 않습니다.\n잠시후 다시 이용해주세요.',
+    }
+  } else {
+    const { title, description } = (await response.json()) as {
+      title: string
+      description: string
+    }
+
+    return { title, description }
+  }
 }

--- a/packages/standard-action-handler/src/converse.tsx
+++ b/packages/standard-action-handler/src/converse.tsx
@@ -1,15 +1,20 @@
+import qs from 'qs'
 import { createRoot } from 'react-dom/client'
 import { Modal } from '@titicaca/modals'
 
 import { WebActionParams } from './types'
 
-const title = 'TEST'
-const description = '성공입니다.'
-
 export default async function converse({
-  url: { path } = {},
+  url: { path, query } = {},
 }: WebActionParams) {
-  if (path === '/web-action/converse') {
+  if (path === '/web-action/converse' && query) {
+    const { path: url } = qs.parse(query) as { path: string }
+
+    // 예시 코드
+    const { title, body: description } = (await fetch(url).then((response) => {
+      return response.json()
+    })) as { title: string; body: string }
+
     if (title && description) {
       const container = document.createElement('div')
       const root = createRoot(container)

--- a/packages/standard-action-handler/src/index.ts
+++ b/packages/standard-action-handler/src/index.ts
@@ -8,6 +8,7 @@ import copyToClipboard from './copy-to-clipboard'
 import newWindow from './new-window'
 import imageDownload from './image-download'
 import scrollToElement from './scroll-to-element'
+import converse from './converse'
 import { ContextOptions } from './types'
 
 export function initialize(options: ContextOptions) {
@@ -22,6 +23,7 @@ export function initialize(options: ContextOptions) {
       newWindow,
       imageDownload,
       scrollToElement,
+      converse,
     ],
     options,
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1547,6 +1547,9 @@ importers:
 
   packages/standard-action-handler:
     dependencies:
+      '@titicaca/modals':
+        specifier: workspace:*
+        version: link:../modals
       '@titicaca/router':
         specifier: workspace:*
         version: link:../router


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

API 호출 및 응답을 모달로 확인할 수 있는 기능을 추가합니다. 
자세한 내용은 [스펙 문서](https://inpk.atlassian.net/wiki/spaces/dev/pages/418580571/API)에서 확인하실 수 있습니다.

### 기존 fetch-api 기능과 차이점

`fetch-api`는 호출만 담당하지만 `converse`는 API 반환 값을 이용해 모달을 노출하는 기능까지 포함되어있습니다.

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

### 사용법

어드민에서 응답을 받고싶은 API endpoint를 입력합니다.

형식 : `/web-action/converse?path={인코딩된 API endpoint}`
예시 : `/web-action/converse?path=%2Fapi%2Fbenefit%2Ftna-promotions%2Ffirst-buy`
- TNA 첫 구매 대상자 쿠폰 발급 API

## 변경 내역

API 응답 일반화 노출 기능을 추가합니다.

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 스크린샷 & URL

https://github.com/titicacadev/triple-frontend/assets/38130934/f65f77dc-e5a2-4b98-a01d-21cecdc1318e


<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
