### PR TITLE
test: 서울콘 대응

### DIFF
--- a/packages/poi-detail/src/image-carousel/carousel-section.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel-section.tsx
@@ -45,7 +45,12 @@ export default function CarouselSection({
     >
       <Container position="relative">
         {images.length > 0 ? (
-          <Carousel images={images} borderRadius={borderRadius} {...props} />
+          <Carousel
+            images={images}
+            borderRadius={borderRadius}
+            guestMode={guestMode}
+            {...props}
+          />
         ) : (
           <Placeholder
             onClick={onPlaceholderClick}

--- a/packages/poi-detail/src/image-carousel/carousel-section.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel-section.tsx
@@ -18,6 +18,7 @@ export interface CarouselSectionProps extends CarouselProps {
   onBusinessHoursClick?: () => void
   onPlaceholderClick: () => void
   height?: number
+  guestMode?: boolean
 }
 
 export default function CarouselSection({
@@ -29,6 +30,7 @@ export default function CarouselSection({
   onPlaceholderClick,
   onBusinessHoursClick,
   borderRadius,
+  guestMode,
   ...props
 }: CarouselSectionProps) {
   return (
@@ -45,7 +47,11 @@ export default function CarouselSection({
         {images.length > 0 ? (
           <Carousel images={images} borderRadius={borderRadius} {...props} />
         ) : (
-          <Placeholder onClick={onPlaceholderClick} noContent={loading} />
+          <Placeholder
+            onClick={onPlaceholderClick}
+            guestMode={guestMode}
+            noContent={loading}
+          />
         )}
         {!permanentlyClosed && onBusinessHoursClick ? (
           <BusinessHoursNote

--- a/packages/poi-detail/src/image-carousel/carousel.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel.tsx
@@ -39,6 +39,7 @@ export interface CarouselProps {
   optimized?: boolean
   borderRadius?: number
   height?: number
+  guestMode?: boolean
 }
 
 export default function Carousel({
@@ -50,6 +51,7 @@ export default function Carousel({
   optimized,
   borderRadius = 6,
   height,
+  guestMode,
 }: CarouselProps) {
   const app = useTripleClientMetadata()
   const { trackEvent, trackSimpleEvent } = useEventTrackingContext()
@@ -133,7 +135,9 @@ export default function Carousel({
         )
 
   const CTA = ({ currentIndex }: { currentIndex: number }) =>
-    !app && currentIndex === SHOW_CTA_FROM_INDEX ? <CtaOverlay /> : null
+    !app && currentIndex === SHOW_CTA_FROM_INDEX && !guestMode ? (
+      <CtaOverlay />
+    ) : null
 
   return (
     <>

--- a/packages/poi-detail/src/image-carousel/carousel.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel.tsx
@@ -56,7 +56,11 @@ export default function Carousel({
   const app = useTripleClientMetadata()
   const { trackEvent, trackSimpleEvent } = useEventTrackingContext()
   const [currentPage, setCurrentPage] = useState(0)
-  const visibleImages = app ? images : images.slice(0, SHOW_CTA_FROM_INDEX + 1)
+  const visibleImages = app
+    ? images
+    : guestMode
+    ? images.slice(0, SHOW_CTA_FROM_INDEX)
+    : images.slice(0, SHOW_CTA_FROM_INDEX + 1)
 
   const handleImageClick = useCallback(
     (event?: MouseEvent, media?: ImageMeta) => {
@@ -129,10 +133,27 @@ export default function Carousel({
 
   const ConditionalPageLabel = app
     ? undefined
-    : ({ currentIndex }: { currentIndex: number }) =>
-        !totalImagesCount || currentIndex === SHOW_CTA_FROM_INDEX ? null : (
-          <PageLabel currentIndex={currentPage} totalCount={totalImagesCount} />
-        )
+    : ({ currentIndex }: { currentIndex: number }) => {
+        if (!totalImagesCount) {
+          return null
+        }
+
+        if (guestMode || currentIndex !== SHOW_CTA_FROM_INDEX) {
+          const pageLabelTotalCount =
+            guestMode && totalImagesCount > SHOW_CTA_FROM_INDEX
+              ? SHOW_CTA_FROM_INDEX
+              : totalImagesCount
+
+          return (
+            <PageLabel
+              currentIndex={currentPage}
+              totalCount={pageLabelTotalCount}
+            />
+          )
+        }
+
+        return null
+      }
 
   const CTA = ({ currentIndex }: { currentIndex: number }) =>
     !app && currentIndex === SHOW_CTA_FROM_INDEX && !guestMode ? (

--- a/packages/poi-detail/src/image-carousel/index.tsx
+++ b/packages/poi-detail/src/image-carousel/index.tsx
@@ -14,6 +14,7 @@ type ImageCarouselProps = Pick<
   | 'optimized'
   | 'borderRadius'
   | 'height'
+  | 'guestMode'
 >
 
 export default function ImageCarousel(props: ImageCarouselProps) {

--- a/packages/poi-detail/src/image-carousel/placeholder.tsx
+++ b/packages/poi-detail/src/image-carousel/placeholder.tsx
@@ -39,12 +39,14 @@ const ImagePlaceholderContent = styled.div<{ large?: boolean }>`
 interface ImagePlaceholderProps {
   large?: boolean
   noContent?: boolean
+  guestMode?: boolean
   onClick: () => void
 }
 
 function ImagePlaceholder({
   large,
   noContent,
+  guestMode,
   onClick,
 }: ImagePlaceholderProps) {
   const { t } = useTranslation('common-web')
@@ -52,7 +54,10 @@ function ImagePlaceholder({
   return (
     <ImagePlaceholderContainer large={large} onClick={onClick}>
       <ImagePlaceholderContent large={large}>
-        {noContent ? null : (
+        {noContent ? null : guestMode ? (
+          // TODO : 아이콘 교체
+          <PlaceholderIcon src="https://assets.triple.guide/images/img-empty-photo-m@4x.png" />
+        ) : (
           <>
             <PlaceholderIcon src="https://assets.triple.guide/images/img-empty-photo-m@4x.png" />
             <Text size="small" color="gray" alpha={0.3}>
@@ -71,19 +76,30 @@ function ImagePlaceholder({
 interface ResponsiveImagePlaceholderProps {
   onClick: () => void
   noContent?: boolean
+  guestMode?: boolean
 }
 
 export default function ResponsiveImagePlaceholder({
   onClick,
   noContent,
+  guestMode,
 }: ResponsiveImagePlaceholderProps) {
   return (
     <>
       <Responsive maxWidth={706}>
-        <ImagePlaceholder noContent={noContent} onClick={onClick} />
+        <ImagePlaceholder
+          noContent={noContent}
+          guestMode={guestMode}
+          onClick={onClick}
+        />
       </Responsive>
       <Responsive minWidth={707}>
-        <ImagePlaceholder noContent={noContent} large onClick={onClick} />
+        <ImagePlaceholder
+          noContent={noContent}
+          guestMode={guestMode}
+          large
+          onClick={onClick}
+        />
       </Responsive>
     </>
   )

--- a/packages/poi-list-elements/src/carousel-element.tsx
+++ b/packages/poi-list-elements/src/carousel-element.tsx
@@ -34,6 +34,7 @@ function PoiCarouselElement<T extends PoiListElementType>({
   imageFrame,
   onImpress,
   optimized,
+  guestMode,
 }: PoiListElementBaseProps<T> & {
   actionButtonElement?: ActionButtonElement
   description?: ReactNode
@@ -52,7 +53,17 @@ function PoiCarouselElement<T extends PoiListElementType>({
 
   const name = nameOverride || names.ko || names.en || names.local
   const regionName = regionNames?.ko || regionNames?.en || regionNames?.local
-
+  const ActionElement = actionButtonElement || (
+    <Container
+      position="absolute"
+      css={{
+        top: '3px',
+        right: '3px',
+      }}
+    >
+      <OverlayScrapButton resource={poi} size={36} />
+    </Container>
+  )
   return (
     <Carousel.Item
       size={carouselSize || 'small'}
@@ -91,17 +102,7 @@ function PoiCarouselElement<T extends PoiListElementType>({
           : vicinity}
       </Text>
 
-      {actionButtonElement || (
-        <Container
-          position="absolute"
-          css={{
-            top: '3px',
-            right: '3px',
-          }}
-        >
-          <OverlayScrapButton resource={poi} size={36} />
-        </Container>
-      )}
+      {!guestMode ? ActionElement : null}
 
       {additionalInfo}
     </Carousel.Item>

--- a/packages/poi-list-elements/src/carousel-element.tsx
+++ b/packages/poi-list-elements/src/carousel-element.tsx
@@ -51,7 +51,8 @@ function PoiCarouselElement<T extends PoiListElementType>({
 
   const { names: regionNames } = region?.source || {}
 
-  const name = nameOverride || names.ko || names.en || names.local
+  const name =
+    nameOverride || names.primary || names.ko || names.en || names.local
   const regionName = regionNames?.ko || regionNames?.en || regionNames?.local
   const ActionElement = actionButtonElement || (
     <Container

--- a/packages/poi-list-elements/src/compact-poi-list-element.tsx
+++ b/packages/poi-list-elements/src/compact-poi-list-element.tsx
@@ -7,6 +7,8 @@ import {
 } from '@titicaca/core-elements'
 import { OutlineScrapButton } from '@titicaca/scrap-button'
 
+import { useGuestMode } from '../../triple-document/src/prop-context/guest-mode'
+
 import {
   PoiListElementBaseProps,
   ActionButtonElement,
@@ -42,6 +44,7 @@ export function CompactPoiListElement<T extends PoiListElementType>({
   },
   onClick,
 }: CompactPoiListElementProps<T>) {
+  const guestMode = useGuestMode()
   const [actionButtonWidth, setActionButtonWidth] = useState(0)
   const actionButtonRef = useRef<HTMLDivElement & { width?: number }>(null)
 
@@ -86,7 +89,7 @@ export function CompactPoiListElement<T extends PoiListElementType>({
           .join(' · ')}
       </Text>
 
-      {actionButtonElement ? (
+      {actionButtonElement && !guestMode ? (
         <div ref={actionButtonRef}>{actionButtonElement}</div>
       ) : (
         <Container

--- a/packages/poi-list-elements/src/compact-poi-list-element.tsx
+++ b/packages/poi-list-elements/src/compact-poi-list-element.tsx
@@ -56,6 +56,19 @@ export function CompactPoiListElement<T extends PoiListElementType>({
 
   const name = nameOverride || names.ko || names.en || names.local
   const regionName = regionNames?.ko || regionNames?.en || regionNames?.local
+  const ActionElement = actionButtonElement ? (
+    <div ref={actionButtonRef}>{actionButtonElement}</div>
+  ) : (
+    <Container
+      position="absolute"
+      css={{
+        top: 0,
+        right: 0,
+      }}
+    >
+      <OutlineScrapButton resource={poi} size={34} />
+    </Container>
+  )
 
   return (
     <ResourceListItem onClick={onClick}>
@@ -87,19 +100,7 @@ export function CompactPoiListElement<T extends PoiListElementType>({
           .join(' · ')}
       </Text>
 
-      {actionButtonElement && !guestMode ? (
-        <div ref={actionButtonRef}>{actionButtonElement}</div>
-      ) : (
-        <Container
-          position="absolute"
-          css={{
-            top: 0,
-            right: 0,
-          }}
-        >
-          <OutlineScrapButton resource={poi} size={34} />
-        </Container>
-      )}
+      {!guestMode ? ActionElement : null}
     </ResourceListItem>
   )
 }

--- a/packages/poi-list-elements/src/compact-poi-list-element.tsx
+++ b/packages/poi-list-elements/src/compact-poi-list-element.tsx
@@ -7,8 +7,6 @@ import {
 } from '@titicaca/core-elements'
 import { OutlineScrapButton } from '@titicaca/scrap-button'
 
-import { useGuestMode } from '../../triple-document/src/prop-context/guest-mode'
-
 import {
   PoiListElementBaseProps,
   ActionButtonElement,
@@ -43,8 +41,8 @@ export function CompactPoiListElement<T extends PoiListElementType>({
     source: { names, image, areas, vicinity },
   },
   onClick,
+  guestMode,
 }: CompactPoiListElementProps<T>) {
-  const guestMode = useGuestMode()
   const [actionButtonWidth, setActionButtonWidth] = useState(0)
   const actionButtonRef = useRef<HTMLDivElement & { width?: number }>(null)
 

--- a/packages/poi-list-elements/src/extended-poi-list-element.tsx
+++ b/packages/poi-list-elements/src/extended-poi-list-element.tsx
@@ -4,8 +4,6 @@ import ExtendedResourceListElement, {
 } from '@titicaca/resource-list-element'
 import { useScrapsContext } from '@titicaca/react-contexts'
 
-import { useGuestMode } from '../../triple-document/src/prop-context/guest-mode'
-
 import { POI_IMAGE_PLACEHOLDERS } from './constants'
 import { PoiListElementBaseProps, PoiListElementType } from './types'
 
@@ -56,10 +54,10 @@ export function ExtendedPoiListElement<T extends PoiListElementType>({
   isAdvertisement,
   notes,
   optimized,
+  guestMode,
 }: ExtendedPoiListElementProps<T> & { optimized?: boolean }) {
   const { t } = useTranslation('common-web')
 
-  const guestMode = useGuestMode()
   const { deriveCurrentStateAndCount } = useScrapsContext()
   const {
     source: { starRating },

--- a/packages/poi-list-elements/src/extended-poi-list-element.tsx
+++ b/packages/poi-list-elements/src/extended-poi-list-element.tsx
@@ -4,6 +4,8 @@ import ExtendedResourceListElement, {
 } from '@titicaca/resource-list-element'
 import { useScrapsContext } from '@titicaca/react-contexts'
 
+import { useGuestMode } from '../../triple-document/src/prop-context/guest-mode'
+
 import { POI_IMAGE_PLACEHOLDERS } from './constants'
 import { PoiListElementBaseProps, PoiListElementType } from './types'
 
@@ -57,6 +59,7 @@ export function ExtendedPoiListElement<T extends PoiListElementType>({
 }: ExtendedPoiListElementProps<T> & { optimized?: boolean }) {
   const { t } = useTranslation('common-web')
 
+  const guestMode = useGuestMode()
   const { deriveCurrentStateAndCount } = useScrapsContext()
   const {
     source: { starRating },
@@ -105,7 +108,7 @@ export function ExtendedPoiListElement<T extends PoiListElementType>({
       reviewsRating={reviewsRatingWithGraphql ?? rawReviewsRating}
       scrapsCount={scrapsCount}
       onClick={onClick}
-      hideScrapButton={hideScrapButton}
+      hideScrapButton={hideScrapButton || guestMode}
       maxCommentLines={maxCommentLines}
       isAdvertisement={isAdvertisement}
       optimized={optimized}

--- a/packages/poi-list-elements/src/types.ts
+++ b/packages/poi-list-elements/src/types.ts
@@ -10,6 +10,7 @@ export type ActionButtonElement = ReactNode
 export interface PoiListElementBaseProps<T extends PoiListElementType> {
   poi: T
   onClick?: MouseEventHandler<HTMLLIElement>
+  guestMode?: boolean
 }
 
 type PoiType = 'attraction' | 'restaurant' | 'hotel'

--- a/packages/static-map/src/static-map.tsx
+++ b/packages/static-map/src/static-map.tsx
@@ -84,6 +84,7 @@ function StaticMap({
   mapScale = '2',
   markerImage,
   responsiveVariants,
+  language = 'ko',
   onClick,
 }: {
   type?: PoiType
@@ -95,6 +96,7 @@ function StaticMap({
   mapScale?: string
   markerImage?: string
   responsiveVariants?: ResponsiveVariant[]
+  language?: string
   onClick?: (e: SyntheticEvent) => void
 }) {
   const srcSet = responsiveVariants
@@ -105,7 +107,7 @@ function StaticMap({
         mapScale: responsiveMapScale = 2,
         zoom: responsiveZoom = 13,
       }) => {
-        return `/api/maps/static-map?size=${mapSize}&scale=${responsiveMapScale}&center=${lat}%2C${lon}&zoom=${responsiveZoom} ${viewport}`
+        return `/api/maps/static-map?size=${mapSize}&scale=${responsiveMapScale}&center=${lat}%2C${lon}&zoom=${responsiveZoom}&language=${language} ${viewport}`
       },
     )
     .join(', ')
@@ -118,7 +120,7 @@ function StaticMap({
             <source media="(min-width: 600px)" srcSet={srcSet} />
           ) : null}
           <StaticMapImage
-            src={`/api/maps/static-map?size=${mapSize}&scale=${mapScale}&center=${lat}%2C${lon}&zoom=${zoom}`}
+            src={`/api/maps/static-map?size=${mapSize}&scale=${mapScale}&center=${lat}%2C${lon}&zoom=${zoom}&language=${language}`}
           />
         </StaticMapPicture>
       </StaticMapContainer>

--- a/packages/static-map/src/static-map.tsx
+++ b/packages/static-map/src/static-map.tsx
@@ -84,7 +84,7 @@ function StaticMap({
   mapScale = '2',
   markerImage,
   responsiveVariants,
-  language = 'ko',
+  language,
   onClick,
 }: {
   type?: PoiType
@@ -99,6 +99,8 @@ function StaticMap({
   language?: string
   onClick?: (e: SyntheticEvent) => void
 }) {
+  const languageQuery = language ? `&language=${language}` : ''
+
   const srcSet = responsiveVariants
     ?.map(
       ({
@@ -107,7 +109,7 @@ function StaticMap({
         mapScale: responsiveMapScale = 2,
         zoom: responsiveZoom = 13,
       }) => {
-        return `/api/maps/static-map?size=${mapSize}&scale=${responsiveMapScale}&center=${lat}%2C${lon}&zoom=${responsiveZoom}&language=${language} ${viewport}`
+        return `/api/maps/static-map?size=${mapSize}&scale=${responsiveMapScale}&center=${lat}%2C${lon}&zoom=${responsiveZoom}${languageQuery} ${viewport}`
       },
     )
     .join(', ')
@@ -120,7 +122,7 @@ function StaticMap({
             <source media="(min-width: 600px)" srcSet={srcSet} />
           ) : null}
           <StaticMapImage
-            src={`/api/maps/static-map?size=${mapSize}&scale=${mapScale}&center=${lat}%2C${lon}&zoom=${zoom}&language=${language}`}
+            src={`/api/maps/static-map?size=${mapSize}&scale=${mapScale}&center=${lat}%2C${lon}&zoom=${zoom}${languageQuery}`}
           />
         </StaticMapPicture>
       </StaticMapContainer>

--- a/packages/triple-document/src/elements/pois.tsx
+++ b/packages/triple-document/src/elements/pois.tsx
@@ -9,6 +9,7 @@ import {
 import { Text } from '@titicaca/core-elements'
 
 import { useResourceClickHandler } from '../prop-context/resource-click-handler'
+import { useGuestMode } from '../prop-context/guest-mode'
 
 import ResourceList from './shared/resource-list'
 import DocumentCarousel from './shared/document-carousel'
@@ -43,6 +44,7 @@ export default function Pois<T extends ExtendedPoiListElementData>({
     pois: T[]
   }
 }) {
+  const guestMode = useGuestMode()
   const onResourceClick = useResourceClickHandler()
 
   const Container = display === 'list' ? ResourceList : DocumentCarousel
@@ -74,6 +76,7 @@ export default function Pois<T extends ExtendedPoiListElementData>({
             display,
             poi,
           })}
+          guestMode={guestMode}
         />
       ))}
     </Container>

--- a/packages/triple-document/src/index.ts
+++ b/packages/triple-document/src/index.ts
@@ -8,6 +8,7 @@ export { Slot } from './elements/tna/slot'
 export { PricePolicyCouponInfo } from './elements/tna/price-policy-coupon-info'
 
 export { useDeepLink } from './prop-context/deep-link'
+export { useGuestMode } from './prop-context/guest-mode'
 export { useImageClickHandler } from './prop-context/image-click-handler'
 export { useImageSource } from './prop-context/image-source'
 export { useLinkClickHandler } from './prop-context/link-click-handler'

--- a/packages/triple-document/src/prop-context/guest-mode.ts
+++ b/packages/triple-document/src/prop-context/guest-mode.ts
@@ -1,0 +1,10 @@
+import { createContext, useContext } from 'react'
+
+const GuestModeContext = createContext<boolean | undefined>(undefined)
+
+/** guestMode : true인 경우, 로그인이 필요한 동작(스크랩, 리뷰쓰기)등이 불가능하며, 앱으로 연결되는 루트를 차단합니다. */
+export const GuestModeProvider = GuestModeContext.Provider
+
+export function useGuestMode() {
+  return useContext(GuestModeContext)
+}

--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -21,6 +21,7 @@ import { DeepLinkProvider } from './prop-context/deep-link'
 import { MediaConfigProvider } from './prop-context/media-config'
 import ELEMENTS from './elements'
 import useEventResourceTracker from './use-resource-event-tracker'
+import { GuestModeProvider } from './prop-context/guest-mode'
 
 export function TripleDocument({
   children,
@@ -34,6 +35,7 @@ export function TripleDocument({
   videoAutoPlay,
   hideVideoControls,
   optimized = false,
+  guestMode,
 }: {
   customElements?: ElementSet
   children: TripleElementData[]
@@ -97,33 +99,35 @@ export function TripleDocument({
                 hideVideoControls={hideVideoControls}
                 optimized={optimized}
               >
-                {children.map(({ type, value }, i) => {
-                  const RegularElement = ELEMENTS[type]
-                  const CustomElement = customElements[type]
+                <GuestModeProvider value={guestMode}>
+                  {children.map(({ type, value }, i) => {
+                    const RegularElement = ELEMENTS[type]
+                    const CustomElement = customElements[type]
 
-                  const Element = CustomElement || RegularElement
+                    const Element = CustomElement || RegularElement
 
-                  return (
-                    Element && (
-                      <Element
-                        key={i}
-                        value={value}
-                        {...(CustomElement
-                          ? {
-                              onResourceClick: resourceClickHandler,
-                              onImageClick,
-                              onLinkClick: linkClickHandler,
-                              ImageSource: imageSourceComponent,
-                              deepLink,
-                              videoAutoPlay,
-                              hideVideoControls,
-                              optimized,
-                            }
-                          : {})}
-                      />
+                    return (
+                      Element && (
+                        <Element
+                          key={i}
+                          value={value}
+                          {...(CustomElement
+                            ? {
+                                onResourceClick: resourceClickHandler,
+                                onImageClick,
+                                onLinkClick: linkClickHandler,
+                                ImageSource: imageSourceComponent,
+                                deepLink,
+                                videoAutoPlay,
+                                hideVideoControls,
+                                optimized,
+                              }
+                            : {})}
+                        />
+                      )
                     )
-                  )
-                })}
+                  })}
+                </GuestModeProvider>
               </MediaConfigProvider>
             </DeepLinkProvider>
           </ImageSourceProvider>

--- a/packages/triple-document/src/types.ts
+++ b/packages/triple-document/src/types.ts
@@ -46,6 +46,7 @@ export type TripleDocumentContext = {
   onTNAProductsFetch?: TnaProductsFetcher
   imageSourceComponent?: ImageSourceType
   deepLink?: string
+  guestMode?: boolean
 } & MediaConfig
 
 export interface ElementSet {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
#### 서울콘에서 보여주는 영역과 로직 분기
1. Triple document에 guestMode를 추가, poi list에서 스크랩 하트 아이콘을 숨김
  guestMode는 로그인 관련 영역과 로직, App으로의 연결을 유도하는 영역과 로직을 숨기는 flag
2. ImageCarousel에  guestMode or readonly 등의 prop 전달 가능하도록 수정
  위의 guestMode와 마찬가지로, 해당 플래그를 기준으로 사진 없을 때 표시방식을 분기하고 사진을 5장까지만 노출
#### 서울콘에서 영문 데이터만 보여주기
1. Static Map에서 language를 prop으로 전달
  구글 static map에 language 쿼리 전달 가능하도록

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
