### PR TITLE
[chat] 채팅 인입 후 메시지 전송시 상품/예약정보 중복노출

### DIFF
--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -38,6 +38,10 @@ export interface ChatProps {
    * 초기 메시지들
    */
   messages?: MessageInterface[]
+  /**
+   * 보내기 전 메시지들
+   */
+  beforeSentMessages?: MessageInterface[]
   postMessage?: PostMessageType
   getMessages: (option: {
     roomId: string
@@ -71,6 +75,7 @@ export const Chat = ({
   userInfo,
   room,
   messages: initMessages,
+  beforeSentMessages = [],
 
   postMessage,
   getMessages,
@@ -146,6 +151,13 @@ export const Chat = ({
       }
     }
   }, [isIos])
+
+  useEffect(() => {
+    dispatch({
+      action: ChatActions.BEFORE_SEND,
+      message: beforeSentMessages,
+    })
+  }, [beforeSentMessages])
 
   useEffect(() => {
     ;(async function () {
@@ -253,7 +265,7 @@ export const Chat = ({
       if (isScrollReady.current && hasPrevMessage) {
         const pastMessages = await fetchPastMessages()
 
-        await dispatch({
+        dispatch({
           action: ChatActions.PAST,
           messages: pastMessages,
         })
@@ -288,24 +300,26 @@ export const Chat = ({
         {userInfo ? (
           <>
             <ul id="messages_list">
-              {messages.map((message: MessageInterface) => (
-                <li key={message.id}>
-                  <ChatBubble
-                    displayTarget={displayTarget}
-                    message={message}
-                    userInfo={userInfo}
-                    postMessageAction={
-                      postMessage ? postMessageAction : undefined
-                    }
-                    otherReadInfo={otherUnreadInfo}
-                    onRetryButtonClick={onRetry}
-                    onRetryCancelButtonClick={onRetryCancel}
-                    disableUnreadCount={disableUnreadCount}
-                    blindedText={blindedText}
-                    bubbleStyle={bubbleStyle}
-                  />
-                </li>
-              ))}
+              {[...messages, ...beforeSentMessages].map(
+                (message: MessageInterface) => (
+                  <li key={message.id}>
+                    <ChatBubble
+                      displayTarget={displayTarget}
+                      message={message}
+                      userInfo={userInfo}
+                      postMessageAction={
+                        postMessage ? postMessageAction : undefined
+                      }
+                      otherReadInfo={otherUnreadInfo}
+                      onRetryButtonClick={onRetry}
+                      onRetryCancelButtonClick={onRetryCancel}
+                      disableUnreadCount={disableUnreadCount}
+                      blindedText={blindedText}
+                      bubbleStyle={bubbleStyle}
+                    />
+                  </li>
+                ),
+              )}
             </ul>
             <ul id="failed_messages_list">
               {failedMessages.map((message: MessageInterface) => (

--- a/packages/chat/src/chat/reducer.ts
+++ b/packages/chat/src/chat/reducer.ts
@@ -5,6 +5,7 @@ export enum ChatActions {
   PAST, // 과거 메시지
   NEW, // 메시지 수신
   POST, // 메시지 전송
+  BEFORE_SEND, // 메시지 전송 완료 전
   FAILED_TO_POST, // 메시지 전송 실패
   UPDATE, // 읽음 표시 업데이트
   REMOVE_FROM_FAILED, // 전송 실패 메세지 재전송 또는 삭제
@@ -13,6 +14,7 @@ export enum ChatActions {
 export interface ChatState {
   messages: MessageInterface[]
   failedMessages: MessageInterface[]
+  beforeSentMessages: MessageInterface[]
   hasPrevMessage: boolean
   otherUnreadInfo: OtherUnreadInterface[]
   firstMessageId: number | null
@@ -36,6 +38,10 @@ export type ChatAction =
   | {
       action: ChatActions.POST
       messages: MessageInterface[]
+    }
+  | {
+      action: ChatActions.BEFORE_SEND
+      message: MessageInterface[]
     }
   | {
       action: ChatActions.FAILED_TO_POST
@@ -82,6 +88,13 @@ export const ChatReducer = (
         lastMessageId: Number(action.messages[action.messages.length - 1].id),
       }
 
+    case ChatActions.BEFORE_SEND: {
+      return {
+        ...state,
+        beforeSentMessages: [...action.message],
+      }
+    }
+
     case ChatActions.NEW:
       return {
         ...state,
@@ -117,6 +130,7 @@ export const ChatReducer = (
 export const initialChatState: ChatState = {
   messages: [],
   failedMessages: [],
+  beforeSentMessages: [],
   hasPrevMessage: true,
   otherUnreadInfo: [],
   firstMessageId: null,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
- https://inpk.atlassian.net/browse/TPB-2034

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- ~~채팅창 초기접속 > 유저채팅 프론트에서 자동메시지 보여짐 > 유저가 첫 메시지를 전송하기 전까지는 프론트에만 존재함 > 유저가 첫 메시지를 전송하면 서버에 전송된 메시지로 변경~~
- ~~위 흐름을 createdAt 을 기준으로 필터링해야 메시지가 두개씩 보이는 현상이 사라집니다.~~
- 프론트 화면에서만 가지고 있는 채팅을 구분짓기 위해 chat reducer에 `ChatActions.BEFORE_SEND` 타입과 `beforeSentMessages` 상태를 추가합니다.
- `beforeSentMessages` 는 Chat 컴포넌트의 prop으로 받아서 저장하는 역할로 두었습니다.
- 연관 PR: https://github.com/titicacadev/triple-chat-web/pull/268


## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->
- dev, staging 테스트 완료

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->

https://github.com/titicacadev/triple-frontend/assets/30427711/c35751e1-bfb4-464b-846c-e10f6c16ec5b

