### PR TITLE
[chat] beforeSentMessages 초기 props만 저장하도록 수정

### DIFF
--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -75,7 +75,7 @@ export const Chat = ({
   userInfo,
   room,
   messages: initMessages,
-  beforeSentMessages = [],
+  beforeSentMessages: initBeforeSentMessages = [],
 
   postMessage,
   getMessages,
@@ -98,6 +98,7 @@ export const Chat = ({
     {
       messages,
       failedMessages,
+      beforeSentMessages,
       hasPrevMessage,
       otherUnreadInfo,
       lastMessageId,
@@ -153,11 +154,12 @@ export const Chat = ({
   }, [isIos])
 
   useEffect(() => {
-    dispatch({
-      action: ChatActions.BEFORE_SEND,
-      message: beforeSentMessages,
-    })
-  }, [beforeSentMessages])
+    initBeforeSentMessages &&
+      dispatch({
+        action: ChatActions.BEFORE_SEND,
+        message: initBeforeSentMessages,
+      })
+  }, [])
 
   useEffect(() => {
     ;(async function () {
@@ -212,6 +214,11 @@ export const Chat = ({
     }
 
     if (success) {
+      beforeSentMessages.length > 0 &&
+        dispatch({
+          action: ChatActions.BEFORE_SEND,
+          message: [],
+        })
       dispatch({
         action: ChatActions.POST,
         messages: newMessages,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
- 파트너센터 채팅에서 예약건으로 랜딩되지 않는 이슈를 수정합니다.
- 지라: https://inpk.atlassian.net/browse/TPB-2044

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
- prop의 default value가 배열이나 객체일 경우 useEffect에서 같은 값으로 인식하지 못하고 계속 감지하여 루프에 빠지는 현상이 있습니다.
- 전송 후 비워주는 코드를 추가하고 초기 값만 받아서 업데이트하도록 수정합니다.

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
