### PR TITLE
[Chat] Message에 sender 정보를 포함하는 api 변경에 대응합니다.

### DIFF
--- a/packages/chat/src/chat-bubble/chat-bubble.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble.tsx
@@ -7,7 +7,6 @@ import {
   OtherUnreadInterface,
   PostMessageActionType,
   TextPayload,
-  UserInfoInterface,
   UserType,
 } from '../types'
 import { getProfileImageUrl } from '../utils'
@@ -16,7 +15,7 @@ import { ChatBubbleStyle } from '../types/ui'
 import { ChatBubbleUI } from './chat-bubble-ui'
 
 interface ChatBubbleProps {
-  userInfo: UserInfoInterface
+  my: boolean
   message: MessageInterface
   otherReadInfo?: OtherUnreadInterface[]
   displayTarget: UserType
@@ -29,9 +28,9 @@ interface ChatBubbleProps {
 }
 
 const ChatBubble = ({
+  my,
   message,
-  message: { senderId, createdAt },
-  userInfo: { me, others },
+  message: { sender, createdAt },
   otherReadInfo,
   displayTarget: componentDisplayTarget,
   postMessageAction,
@@ -41,11 +40,6 @@ const ChatBubble = ({
   blindedText,
   bubbleStyle,
 }: ChatBubbleProps) => {
-  const otherUserInfo = useMemo(
-    () => others.find((other) => other.id === senderId),
-    [senderId, others],
-  )
-
   const unreadCount =
     !disableUnreadCount && otherReadInfo
       ? otherReadInfo.reduce(
@@ -92,11 +86,9 @@ const ChatBubble = ({
 
   return (
     <ChatBubbleUI
-      type={me.id !== senderId ? 'received' : 'sent'}
-      profileImageUrl={
-        otherUserInfo ? getProfileImageUrl(otherUserInfo) : undefined
-      }
-      profileName={otherUserInfo?.profile.name}
+      type={my ? 'sent' : 'received'}
+      profileImageUrl={my ? undefined : getProfileImageUrl(sender)}
+      profileName={sender.profile.name}
       unreadCount={unreadCount}
       createdAt={createdAt}
       payload={payload}

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -7,6 +7,7 @@ import { closeKeyboard } from '@titicaca/triple-web-to-native-interfaces'
 import { Container } from '@titicaca/core-elements'
 
 import {
+  HasUnreadOfRoomInterface,
   ImagePayload,
   MessageInterface,
   PostMessageType,
@@ -48,7 +49,7 @@ export interface ChatProps {
   getUnreadRoom?: (option: {
     roomId: string
     lastSeenMessageId: number
-  }) => void
+  }) => Promise<HasUnreadOfRoomInterface>
   room: RoomInterface
   notifyNewMessage?: (lastMessage: MessageInterface) => void
   showFailToast?: (message: string) => void
@@ -112,10 +113,22 @@ export const Chat = ({
       return
     }
 
-    await getUnreadRoom?.({
+    const unreadRoomResult = await getUnreadRoom?.({
       roomId: room.id,
       lastSeenMessageId: lastMessageId,
     })
+    const { hasUnread = false, others = [] } = unreadRoomResult || {}
+
+    const otherUnreadInfo = others.map(({ memberId, lastSeenMessageId }) => ({
+      memberId,
+      lastSeenMessageId: Number(lastSeenMessageId),
+    }))
+    dispatch({
+      action: ChatActions.UPDATE,
+      otherUnreadInfo,
+    })
+
+    return hasUnread
   }, [lastMessageId, getUnreadRoom, room.id])
 
   useChatMessage({

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -113,22 +113,10 @@ export const Chat = ({
       return
     }
 
-    const unreadRoomResult = await getUnreadRoom?.({
+    await getUnreadRoom?.({
       roomId: room.id,
       lastSeenMessageId: lastMessageId,
     })
-    const { hasUnread = false, others = [] } = unreadRoomResult || {}
-
-    const otherUnreadInfo = others.map(({ memberId, lastSeenMessageId }) => ({
-      memberId,
-      lastSeenMessageId: Number(lastSeenMessageId),
-    }))
-    dispatch({
-      action: ChatActions.UPDATE,
-      otherUnreadInfo,
-    })
-
-    return hasUnread
   }, [lastMessageId, getUnreadRoom, room.id])
 
   useChatMessage({

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -14,7 +14,7 @@ import {
   RoomInterface,
   TextPayload,
   UpdateChatData,
-  UserInfoInterface,
+  UserInterface,
   UserType,
 } from '../types'
 import ChatBubble from '../chat-bubble'
@@ -30,10 +30,7 @@ export const CHAT_CONTAINER_ID = 'chat-inner-container'
 
 export interface ChatProps {
   displayTarget: UserType
-  /**
-   * me(sender), others(receiver)에 대한 기본 정보
-   */
-  userInfo: UserInfoInterface
+  me: UserInterface
   /**
    * 초기 메시지들
    */
@@ -72,7 +69,7 @@ export interface ChatProps {
  */
 export const Chat = ({
   displayTarget,
-  userInfo,
+  me,
   room,
   messages: initMessages,
   beforeSentMessages: initBeforeSentMessages,
@@ -136,7 +133,7 @@ export const Chat = ({
 
   useChatMessage({
     roomId: room.id,
-    userMeId: userInfo.me.id,
+    userMeId: me.id,
     notifyNewMessage,
     dispatch,
     updateChatData,
@@ -232,10 +229,10 @@ export const Chat = ({
         message: {
           id: new Date().getTime(),
           roomId: room.id,
-          senderId: userInfo.me.id,
+          senderId: me.id,
           payload,
           displayTarget: 'all',
-          sender: userInfo.me,
+          sender: me,
         },
       })
 
@@ -305,52 +302,46 @@ export const Chat = ({
         <HiddenElement />
       </IntersectionObserver>
       <Container ref={chatRoomRef} id={CHAT_CONTAINER_ID} {...props}>
-        {userInfo ? (
-          <>
-            <ul id="messages_list">
-              {[...messages, ...beforeSentMessages].map(
-                (message: MessageInterface) => (
-                  <li key={message.id}>
-                    <ChatBubble
-                      my={userInfo.me.id === message.sender.id}
-                      displayTarget={displayTarget}
-                      message={message}
-                      postMessageAction={
-                        postMessage ? postMessageAction : undefined
-                      }
-                      otherReadInfo={otherUnreadInfo}
-                      onRetryButtonClick={onRetry}
-                      onRetryCancelButtonClick={onRetryCancel}
-                      disableUnreadCount={disableUnreadCount}
-                      blindedText={blindedText}
-                      bubbleStyle={bubbleStyle}
-                    />
-                  </li>
-                ),
-              )}
-            </ul>
-            <ul id="failed_messages_list">
-              {failedMessages.map((message: MessageInterface) => (
-                <li key={message.id}>
-                  <ChatBubble
-                    my
-                    displayTarget={displayTarget}
-                    message={message}
-                    postMessageAction={
-                      postMessage ? postMessageAction : undefined
-                    }
-                    otherReadInfo={otherUnreadInfo}
-                    onRetryButtonClick={onRetry}
-                    onRetryCancelButtonClick={onRetryCancel}
-                    disableUnreadCount={disableUnreadCount}
-                    blindedText={blindedText}
-                    bubbleStyle={bubbleStyle}
-                  />
-                </li>
-              ))}
-            </ul>
-          </>
-        ) : null}
+        <ul id="messages_list">
+          {[...messages, ...beforeSentMessages].map(
+            (message: MessageInterface) => (
+              <li key={message.id}>
+                <ChatBubble
+                  my={me.id === message.sender.id}
+                  displayTarget={displayTarget}
+                  message={message}
+                  postMessageAction={
+                    postMessage ? postMessageAction : undefined
+                  }
+                  otherReadInfo={otherUnreadInfo}
+                  onRetryButtonClick={onRetry}
+                  onRetryCancelButtonClick={onRetryCancel}
+                  disableUnreadCount={disableUnreadCount}
+                  blindedText={blindedText}
+                  bubbleStyle={bubbleStyle}
+                />
+              </li>
+            ),
+          )}
+        </ul>
+        <ul id="failed_messages_list">
+          {failedMessages.map((message: MessageInterface) => (
+            <li key={message.id}>
+              <ChatBubble
+                my
+                displayTarget={displayTarget}
+                message={message}
+                postMessageAction={postMessage ? postMessageAction : undefined}
+                otherReadInfo={otherUnreadInfo}
+                onRetryButtonClick={onRetry}
+                onRetryCancelButtonClick={onRetryCancel}
+                disableUnreadCount={disableUnreadCount}
+                blindedText={blindedText}
+                bubbleStyle={bubbleStyle}
+              />
+            </li>
+          ))}
+        </ul>
       </Container>
       <HiddenElement ref={bottomRef} />
     </>

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -235,6 +235,7 @@ export const Chat = ({
           senderId: userInfo.me.id,
           payload,
           displayTarget: 'all',
+          sender: userInfo.me,
         },
       })
 
@@ -311,9 +312,9 @@ export const Chat = ({
                 (message: MessageInterface) => (
                   <li key={message.id}>
                     <ChatBubble
+                      my={userInfo.me.id === message.sender.id}
                       displayTarget={displayTarget}
                       message={message}
-                      userInfo={userInfo}
                       postMessageAction={
                         postMessage ? postMessageAction : undefined
                       }
@@ -332,9 +333,9 @@ export const Chat = ({
               {failedMessages.map((message: MessageInterface) => (
                 <li key={message.id}>
                   <ChatBubble
+                    my
                     displayTarget={displayTarget}
                     message={message}
-                    userInfo={userInfo}
                     postMessageAction={
                       postMessage ? postMessageAction : undefined
                     }

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -7,7 +7,6 @@ import { closeKeyboard } from '@titicaca/triple-web-to-native-interfaces'
 import { Container } from '@titicaca/core-elements'
 
 import {
-  HasUnreadOfRoomInterface,
   ImagePayload,
   MessageInterface,
   PostMessageType,
@@ -49,7 +48,7 @@ export interface ChatProps {
   getUnreadRoom?: (option: {
     roomId: string
     lastSeenMessageId: number
-  }) => Promise<HasUnreadOfRoomInterface>
+  }) => void
   room: RoomInterface
   notifyNewMessage?: (lastMessage: MessageInterface) => void
   showFailToast?: (message: string) => void

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -71,6 +71,7 @@ export interface MessageInterface {
   displayTarget?: UserType[] | DisplayTargetAll
   alternative?: TextPayload | ImagePayload | RichPayload
   blindedAt?: string
+  sender: UserInterface
 }
 
 export interface UserInterface {

--- a/packages/chat/src/utils/constants.ts
+++ b/packages/chat/src/utils/constants.ts
@@ -37,33 +37,17 @@ export const MEDIA_ARGS: ChatContextValue = {
 
 export const CHAT_ARGS: ChatProps = {
   displayTarget: UserType.TNA_PARTNER,
-  userInfo: {
-    me: {
-      id: '61ea67f0de3e37001997a80f',
-      type: UserType.TNA_PARTNER,
-      identifier: '130',
-      code: 'TNA_BPM',
-      profile: {
-        name: 'TNA_BPM',
-        thumbnail:
-          'https://s3.ap-northeast-2.amazonaws.com/triple-tna-dev/partner/logo/1e2496ab-8725-4df4-84c7-db9804d3c71d.jpeg',
-        message: '',
-      },
+  me: {
+    id: '61ea67f0de3e37001997a80f',
+    type: UserType.TNA_PARTNER,
+    identifier: '130',
+    code: 'TNA_BPM',
+    profile: {
+      name: 'TNA_BPM',
+      thumbnail:
+        'https://s3.ap-northeast-2.amazonaws.com/triple-tna-dev/partner/logo/1e2496ab-8725-4df4-84c7-db9804d3c71d.jpeg',
+      message: '',
     },
-    others: [
-      {
-        id: '6344be9953749900140bca42',
-        type: UserType.TRIPLE_USER,
-        identifier: '4043',
-        code: '_KA2408084137-1661761357899',
-        profile: {
-          name: '후라이',
-          thumbnail:
-            'https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/52557846-363d-430a-9afd-1cd7fd4fe0b4.jpeg',
-          message: '',
-        },
-      },
-    ],
   },
   getMessages: async () => {
     return [
@@ -96,6 +80,18 @@ export const CHAT_ARGS: ChatProps = {
           message:
             '안녕하세요.\nTNA_BPM입니다. 예약해주셔서 감사합니다!\n\n궁금한 점이 있으시면 TNA_BPM 문의를 편하게 이용해주세요.',
         },
+        sender: {
+          id: '61ea67f0de3e37001997a80f',
+          type: UserType.TNA_PARTNER,
+          identifier: '130',
+          code: 'TNA_BPM',
+          profile: {
+            name: 'TNA_BPM',
+            thumbnail:
+              'https://s3.ap-northeast-2.amazonaws.com/triple-tna-dev/partner/logo/1e2496ab-8725-4df4-84c7-db9804d3c71d.jpeg',
+            message: '',
+          },
+        },
       },
       {
         id: 5749,
@@ -106,6 +102,18 @@ export const CHAT_ARGS: ChatProps = {
         payload: {
           type: MessageType.TEXT,
           message: '테스트 메시지',
+        },
+        sender: {
+          id: '6344be9953749900140bca42',
+          type: UserType.TRIPLE_USER,
+          identifier: '4043',
+          code: '1',
+          profile: {
+            name: '후라이',
+            thumbnail:
+              'https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/52557846-363d-430a-9afd-1cd7fd4fe0b4.jpeg',
+            message: '',
+          },
         },
       },
     ]
@@ -153,6 +161,18 @@ export const CHAT_ARGS: ChatProps = {
         type: MessageType.TEXT,
         message: '테스트 메시지',
       },
+      sender: {
+        id: '6344be9953749900140bca42',
+        type: UserType.TRIPLE_USER,
+        identifier: '4043',
+        code: '1',
+        profile: {
+          name: '후라이',
+          thumbnail:
+            'https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/52557846-363d-430a-9afd-1cd7fd4fe0b4.jpeg',
+          message: '',
+        },
+      },
     },
     unreadCount: 0,
     metadata: {
@@ -171,6 +191,18 @@ export const CHAT_ARGS: ChatProps = {
           createdAt: '2022-11-04T06:44:57.017Z',
           displayTarget: 'all',
           payload,
+          sender: {
+            id: '61ea67f0de3e37001997a80f',
+            type: UserType.TNA_PARTNER,
+            identifier: '130',
+            code: 'TNA_BPM',
+            profile: {
+              name: 'TNA_BPM',
+              thumbnail:
+                'https://s3.ap-northeast-2.amazonaws.com/triple-tna-dev/partner/logo/1e2496ab-8725-4df4-84c7-db9804d3c71d.jpeg',
+              message: '',
+            },
+          },
         },
       ],
     }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[Chat] Message에 sender 정보를 포함하는 api 변경에 대응합니다.
- userInfo를 제거하고 각 message에 sender 정보가 포함되도록 수정합니다. (행사챗에서 사용자수가 1000명이 넘어가니 감당이 안되는군요😂)
- userInfo 대신 유저의 정보(me)를 받도록 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
