### PR TITLE
[footer] Award Footer의 인증마크 변경

### DIFF
--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -36,6 +36,9 @@ const AwardImg = styled.img`
 
 const Tooltip = styled.div`
   display: none;
+  position: absolute;
+  bottom: calc(100% + 4px);
+  right: 0;
   width: 135px;
   border: 1px solid var(--color-brightGray);
   border-radius: 6px;
@@ -55,9 +58,6 @@ const AwardFlexBox = styled(FlexBox).attrs({
   gap: 7,
 })`
   ${AwardImg}:hover + ${Tooltip} {
-    position: absolute;
-    bottom: calc(100% + 4px);
-    right: 0;
     display: block;
   }
 `

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -13,16 +13,9 @@ const AWARD_INFO = [
   {
     id: 1,
     imageUrl:
-      'https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/c22c15f7-a48a-49da-b8f6-e784724441d1.jpeg',
-    alt: 'ISO27001',
-    text: '국제표준 정보보호 관리체계 (ISO27001) 인증 취득',
-  },
-  {
-    id: 2,
-    imageUrl:
-      'https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/a6a01895-e719-4829-9009-3ed111637826.jpeg',
-    alt: 'ISO27701',
-    text: '국제표준 정보보호 관리체계 (ISO27701) 인증 취득',
+      'https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/1060b728-6ef3-477d-a64a-0a38f5c3250e.jpeg',
+    alt: '국제표준 정보보호 인증마크 ISO27001, ISO 27701',
+    text: '국제표준 정보보호 인증 취득\nISO 27001, ISO 27701',
   },
 ]
 

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -36,13 +36,17 @@ const AwardImg = styled.img`
 
 const Tooltip = styled.div`
   display: none;
-  width: 132px;
+  width: 135px;
   border: 1px solid var(--color-brightGray);
   border-radius: 6px;
-  padding: 8px 10px;
+  padding: 8px 11px;
   background-color: var(--color-white);
   font-size: 10px;
+  font-weight: 500;
+  color: var(--color-gray800);
   line-height: 14px;
+  word-spacing: -0.5px;
+  white-space: pre-line;
 `
 
 const AwardFlexBox = styled(FlexBox).attrs({
@@ -52,7 +56,7 @@ const AwardFlexBox = styled(FlexBox).attrs({
 })`
   ${AwardImg}:hover + ${Tooltip} {
     position: absolute;
-    bottom: calc(100% + 3px);
+    bottom: calc(100% + 4px);
     right: 0;
     display: block;
   }

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -39,7 +39,6 @@ const Tooltip = styled.div`
   position: absolute;
   bottom: calc(100% + 4px);
   right: 0;
-  width: 135px;
   border: 1px solid var(--color-brightGray);
   border-radius: 6px;
   padding: 8px 11px;
@@ -48,8 +47,7 @@ const Tooltip = styled.div`
   font-weight: 500;
   color: var(--color-gray800);
   line-height: 14px;
-  word-spacing: -0.5px;
-  white-space: pre-line;
+  white-space: pre;
 `
 
 const AwardFlexBox = styled(FlexBox).attrs({


### PR DESCRIPTION
## PR 설명
triple.guide에 노출되는 award-footer 내 인증마크 및 설명(툴팁)을 변경합니다.
- [참고 문서](https://inpk.atlassian.net/wiki/spaces/SPC/pages/426902243/2023.10+-)

## 체크리스트
- [x] dev QA
- [x] staging QA

## 스크린샷
<img width="783" alt="스크린샷 2023-10-31 오후 3 52 12" src="https://github.com/titicacadev/triple-frontend/assets/46276783/544613eb-8eea-4e6c-9435-0fb873110e78">


## URL
- dev : https://triple-dev.titicaca-corp.com/
- staging : https://triple-staging.titicaca-corp.com/
