### PR TITLE
🚀Release v13.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## v13.9.0
+
+### chat
+
+- [Chat] received, sent 구분 기준 변경 [#2968](https://github.com/titicacadev/triple-frontend/pull/2968)
+- [chat] beforeSentMessages 초기 props만 저장하도록 수정 [#2969](https://github.com/titicacadev/triple-frontend/pull/2969)
+- [chat] beforeSentMessages 기본값 불필요하므로 제거 [#2975](https://github.com/titicacadev/triple-frontend/pull/2975)
+
+### footer
+
+- [footer] Award Footer의 인증마크 변경 [#2974](https://github.com/titicacadev/triple-frontend/pull/2974)
+
 ## v13.8.1
 
 ### chat

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "pnpm",
-  "version": "13.8.1"
+  "version": "13.9.0"
 }

--- a/packages/ab-experiments/package.json
+++ b/packages/ab-experiments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/ab-experiments",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "a/b experiments package",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/ab-experiments",

--- a/packages/action-sheet/package.json
+++ b/packages/action-sheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/action-sheet",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Action sheet component",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/action-sheet",

--- a/packages/ad-banners/package.json
+++ b/packages/ad-banners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/ad-banners",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Image banner list section for POI, hotel, article",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/ad-banners",

--- a/packages/app-banner/package.json
+++ b/packages/app-banner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/app-banner",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Common App Banner for Public Pages",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/app-banner",

--- a/packages/app-installation-cta/package.json
+++ b/packages/app-installation-cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/app-installation-cta",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Call to action components for app installation",
   "keywords": [
     "cta",

--- a/packages/author/package.json
+++ b/packages/author/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/author",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple Author UI elements",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/author",

--- a/packages/booking-completion/package.json
+++ b/packages/booking-completion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/booking-completion",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple Booking completion Page",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/booking-completion",

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/carousel",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple Carousel",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/carousel",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/chat",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "via triple-chat-frontend",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/chat",

--- a/packages/color-palette/package.json
+++ b/packages/color-palette/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/color-palette",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple Color Palette",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/color-palette",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/constants",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "triple frontend constants definitions",
   "keywords": [
     "triple",

--- a/packages/content-sharing/package.json
+++ b/packages/content-sharing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/content-sharing",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Content Sharing",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/content-sharing",

--- a/packages/core-elements/package.json
+++ b/packages/core-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/core-elements",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Core elements of Triple Design System",
   "keywords": [
     "triple",

--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/date-picker",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple - Date Picker",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/date-picker",

--- a/packages/directions-finder/package.json
+++ b/packages/directions-finder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/directions-finder",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "POI directions finder",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/directions-finder",

--- a/packages/drawer-button/package.json
+++ b/packages/drawer-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/drawer-button",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Button in drawer",
   "keywords": [
     "button",

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/fetcher",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Utilities for Triple view libraries and applications",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/fetcher",

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/footer",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Common Footer for Public Pages",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/footer",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/form",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple Form Components",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/form",

--- a/packages/hub-form/package.json
+++ b/packages/hub-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/hub-form",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Form for hub-like pages",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/hub-form",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/i18n",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple-frontend Internalization",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/i18n",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/icons",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple Icons",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/icons",

--- a/packages/image-carousel/package.json
+++ b/packages/image-carousel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/image-carousel",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple Image Carousel",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/image-carousel",

--- a/packages/intersection-observer/package.json
+++ b/packages/intersection-observer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/intersection-observer",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Shared IntersecionObserver component",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/intersection-observer",

--- a/packages/listing-filter/package.json
+++ b/packages/listing-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/listing-filter",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Listing filter UI",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/listing-filter",

--- a/packages/location-properties/package.json
+++ b/packages/location-properties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/location-properties",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Location properties: addresses, contact, URL, ...",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/location-properties",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/map",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Map component",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/map",

--- a/packages/meta-tags/package.json
+++ b/packages/meta-tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/meta-tags",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple Web Application Meta tag modules",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/meta-tags",

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/modals",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple modal dialog components",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/modals",

--- a/packages/nearby-pois/package.json
+++ b/packages/nearby-pois/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/nearby-pois",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Nearby POIs list",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/nearby-pois",

--- a/packages/poi-detail/package.json
+++ b/packages/poi-detail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/poi-detail",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Components for POI detail page",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/poi-detail",

--- a/packages/poi-list-elements/package.json
+++ b/packages/poi-list-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/poi-list-elements",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple POI UI Elements",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/poi-list-elements",

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/popup",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple Popup",
   "keywords": [
     "triple",

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/pricing",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple - pricing",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/pricing",

--- a/packages/public-header/package.json
+++ b/packages/public-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/public-header",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Common Header for Public Pages",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/public-header",

--- a/packages/react-contexts/package.json
+++ b/packages/react-contexts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/react-contexts",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "React context modules for triple web applications",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/react-contexts",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/react-hooks",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "triple frontend custom hooks",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/react-hooks",

--- a/packages/react-triple-client-interfaces/package.json
+++ b/packages/react-triple-client-interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/react-triple-client-interfaces",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "React module for Triple native client interfaces",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/react-triple-client-interfaces",

--- a/packages/recommended-contents/package.json
+++ b/packages/recommended-contents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/recommended-contents",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Recommended contents list",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/recommended-contents",

--- a/packages/replies/package.json
+++ b/packages/replies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/replies",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Replies Component",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/replies",

--- a/packages/resource-list-element/package.json
+++ b/packages/resource-list-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/resource-list-element",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple - resource-list-element",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/resource-list-element",

--- a/packages/review/package.json
+++ b/packages/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/review",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "UI Components for User Reviews from Triple Service",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/review",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/router",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple Universal Router Component and Functions",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/router",

--- a/packages/scrap-button/package.json
+++ b/packages/scrap-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/scrap-button",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Listing filter UI",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/scrap-button",

--- a/packages/scroll-spy/package.json
+++ b/packages/scroll-spy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/scroll-spy",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Scroll Spy Component",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/scroll-spy",

--- a/packages/scroll-to-element/package.json
+++ b/packages/scroll-to-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/scroll-to-element",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Scroll Functions for Triple service applications",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/scroll-to-element",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/search",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "search",
   "keywords": [
     "search"

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/slider",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Slider component",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/slider",

--- a/packages/social-reviews/package.json
+++ b/packages/social-reviews/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/social-reviews",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Social reviews section for Triple contents",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/social-reviews",

--- a/packages/standard-action-handler/package.json
+++ b/packages/standard-action-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/standard-action-handler",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Standard action handler for Triple service applications",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/standard-action-handler",

--- a/packages/static-map/package.json
+++ b/packages/static-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/static-map",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Static map component",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/static-map",

--- a/packages/static-page-contents/package.json
+++ b/packages/static-page-contents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/static-page-contents",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Static page pomponent",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/static-page-contents",

--- a/packages/style-box/package.json
+++ b/packages/style-box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/style-box",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Triple Style Box",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/style-box",

--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/triple-document",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "TripleDocument: Formatted Content System",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/triple-document",

--- a/packages/triple-email-document/package.json
+++ b/packages/triple-email-document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/triple-email-document",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "EmailDocument: Formatted Email System",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/triple-email-document",

--- a/packages/triple-fallback-action/package.json
+++ b/packages/triple-fallback-action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/triple-fallback-action",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Escape hatch for Javascript file loading failure in web pages",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/triple-fallback-action",

--- a/packages/triple-header/package.json
+++ b/packages/triple-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/triple-header",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "TripleHeader",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/triple-header",

--- a/packages/triple-media/package.json
+++ b/packages/triple-media/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/triple-media",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Media object of Triple",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/triple-media",

--- a/packages/type-definitions/package.json
+++ b/packages/type-definitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/type-definitions",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "triple frontend global type definitions",
   "keywords": [
     "triple",

--- a/packages/ui-flow/package.json
+++ b/packages/ui-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/ui-flow",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Functions, hooks, and/or components used to construct general UI flow",
   "keywords": [
     "session",

--- a/packages/user-verification/package.json
+++ b/packages/user-verification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/user-verification",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "user verification",
   "keywords": [
     "triple",

--- a/packages/view-utilities/package.json
+++ b/packages/view-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/view-utilities",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Utilities for Triple view libraries and applications",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/view-utilities",

--- a/packages/web-storage/package.json
+++ b/packages/web-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/web-storage",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "WebStorage API wrapper for Triple services",
   "license": "MIT",
   "homepage": "https://github.com/titicacadev/triple-frontend/tree/main/packages/web-storage",


### PR DESCRIPTION
## v13.9.0

### chat

- [Chat] received, sent 구분 기준 변경 [#2968](https://github.com/titicacadev/triple-frontend/pull/2968)
- [chat] beforeSentMessages 초기 props만 저장하도록 수정 [#2969](https://github.com/titicacadev/triple-frontend/pull/2969)
- [chat] beforeSentMessages 기본값 불필요하므로 제거 [#2975](https://github.com/titicacadev/triple-frontend/pull/2975)

### footer

- [footer] Award Footer의 인증마크 변경 [#2974](https://github.com/titicacadev/triple-frontend/pull/2974)