### PR TITLE
[chat] beforeSendMessages를 리듀서에서 제거합니다.

### DIFF
--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -72,7 +72,7 @@ export const Chat = ({
   me,
   room,
   messages: initMessages,
-  beforeSentMessages: initBeforeSentMessages,
+  beforeSentMessages = [],
 
   postMessage,
   getMessages,
@@ -95,7 +95,6 @@ export const Chat = ({
     {
       messages,
       failedMessages,
-      beforeSentMessages,
       hasPrevMessage,
       otherUnreadInfo,
       lastMessageId,
@@ -151,14 +150,6 @@ export const Chat = ({
   }, [isIos])
 
   useEffect(() => {
-    initBeforeSentMessages &&
-      dispatch({
-        action: ChatActions.BEFORE_SEND,
-        message: initBeforeSentMessages,
-      })
-  }, [])
-
-  useEffect(() => {
     ;(async function () {
       if (!room.id) {
         return
@@ -211,11 +202,6 @@ export const Chat = ({
     }
 
     if (success) {
-      beforeSentMessages.length > 0 &&
-        dispatch({
-          action: ChatActions.BEFORE_SEND,
-          message: [],
-        })
       dispatch({
         action: ChatActions.POST,
         messages: newMessages,

--- a/packages/chat/src/chat/reducer.ts
+++ b/packages/chat/src/chat/reducer.ts
@@ -5,7 +5,6 @@ export enum ChatActions {
   PAST, // 과거 메시지
   NEW, // 메시지 수신
   POST, // 메시지 전송
-  BEFORE_SEND, // 메시지 전송 완료 전
   FAILED_TO_POST, // 메시지 전송 실패
   UPDATE, // 읽음 표시 업데이트
   REMOVE_FROM_FAILED, // 전송 실패 메세지 재전송 또는 삭제
@@ -38,10 +37,6 @@ export type ChatAction =
   | {
       action: ChatActions.POST
       messages: MessageInterface[]
-    }
-  | {
-      action: ChatActions.BEFORE_SEND
-      message: MessageInterface[]
     }
   | {
       action: ChatActions.FAILED_TO_POST
@@ -87,13 +82,6 @@ export const ChatReducer = (
         messages: mergeMessages(state.messages, action.messages),
         lastMessageId: Number(action.messages[action.messages.length - 1].id),
       }
-
-    case ChatActions.BEFORE_SEND: {
-      return {
-        ...state,
-        beforeSentMessages: [...action.message],
-      }
-    }
 
     case ChatActions.NEW:
       return {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- beforeSendMessage를 리듀서에서 제거하여 postMessageAction 시 메세지가 중복 노출되는 현상을 방지합니다. ([관련 스레드](https://interpark.slack.com/archives/C05EVPMGL13/p1699329762625319?thread_ts=1697008302.408819&cid=C05EVPMGL13))
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
