### PR TITLE
[Poi-list-elements] POI의 이름과 리전명 영역에 대표어값이 가장 우선적으로 표기되도록 함

### DIFF
--- a/packages/poi-list-elements/src/carousel-element.tsx
+++ b/packages/poi-list-elements/src/carousel-element.tsx
@@ -50,8 +50,13 @@ function PoiCarouselElement<T extends PoiListElementType>({
 
   const { names: regionNames } = region?.source || {}
 
-  const name = nameOverride || names.ko || names.en || names.local
-  const regionName = regionNames?.ko || regionNames?.en || regionNames?.local
+  const name =
+    nameOverride || names.primary || names.ko || names.en || names.local
+  const regionName =
+    regionNames?.primary ||
+    regionNames?.ko ||
+    regionNames?.en ||
+    regionNames?.local
 
   return (
     <Carousel.Item

--- a/packages/poi-list-elements/src/compact-poi-list-element.tsx
+++ b/packages/poi-list-elements/src/compact-poi-list-element.tsx
@@ -53,8 +53,13 @@ export function CompactPoiListElement<T extends PoiListElementType>({
 
   const { names: regionNames } = region?.source || {}
 
-  const name = nameOverride || names.ko || names.en || names.local
-  const regionName = regionNames?.ko || regionNames?.en || regionNames?.local
+  const name =
+    nameOverride || names.primary || names.ko || names.en || names.local
+  const regionName =
+    regionNames?.primary ||
+    regionNames?.ko ||
+    regionNames?.en ||
+    regionNames?.local
 
   return (
     <ResourceListItem onClick={onClick}>


### PR DESCRIPTION
## PR 설명
서울콘용으로 영문 POI 데이터를 페이지에 노출하는 작업을 진행중입니다.
영문 데이터에는 제목과 리전의 대표어값(Primary)에 항상 영문 데이터를 넣도록 약속되어 있습니다.
따라서 가이드 상세페이지에 노출되는 POI 리스트에서, 이름과 리전명에 대표어값이 가장 우선적으로 표기되도록 합니다.

## 체크리스트
- [x] content-web dev QA

## 스크린샷 & URL
<img width="375" alt="스크린샷 2023-11-07 오후 4 52 32" src="https://github.com/titicacadev/triple-frontend/assets/46276783/17e70b23-3f80-4339-b98a-77a90d58d8df">

- 영문 가이드 샘플 : https://triple-dev.titicaca-corp.com/content/seoul-con/articles/6082feee-99ac-494b-85b1-6ffa176de7aa?lang=en

