### PR TITLE
[Poi-list-elements] POI 리스트에서 스크랩 버튼을 숨길 수 있도록 함

### DIFF
--- a/packages/poi-list-elements/src/carousel-element.tsx
+++ b/packages/poi-list-elements/src/carousel-element.tsx
@@ -34,6 +34,7 @@ function PoiCarouselElement<T extends PoiListElementType>({
   imageFrame,
   onImpress,
   optimized,
+  guestMode,
 }: PoiListElementBaseProps<T> & {
   actionButtonElement?: ActionButtonElement
   description?: ReactNode
@@ -57,6 +58,17 @@ function PoiCarouselElement<T extends PoiListElementType>({
     regionNames?.ko ||
     regionNames?.en ||
     regionNames?.local
+  const ActionButton = actionButtonElement || (
+    <Container
+      position="absolute"
+      css={{
+        top: '3px',
+        right: '3px',
+      }}
+    >
+      <OverlayScrapButton resource={poi} size={36} />
+    </Container>
+  )
 
   return (
     <Carousel.Item
@@ -96,17 +108,7 @@ function PoiCarouselElement<T extends PoiListElementType>({
           : vicinity}
       </Text>
 
-      {actionButtonElement || (
-        <Container
-          position="absolute"
-          css={{
-            top: '3px',
-            right: '3px',
-          }}
-        >
-          <OverlayScrapButton resource={poi} size={36} />
-        </Container>
-      )}
+      {!guestMode ? ActionButton : null}
 
       {additionalInfo}
     </Carousel.Item>

--- a/packages/poi-list-elements/src/carousel-element.tsx
+++ b/packages/poi-list-elements/src/carousel-element.tsx
@@ -44,6 +44,7 @@ function PoiCarouselElement<T extends PoiListElementType>({
   imageFrame?: FrameRatioAndSizes
   onImpress?: () => void
   optimized?: boolean
+  guestMode?: boolean
 }) {
   if (!poi) {
     return null

--- a/packages/poi-list-elements/src/compact-poi-list-element.tsx
+++ b/packages/poi-list-elements/src/compact-poi-list-element.tsx
@@ -17,6 +17,7 @@ import { getTypeNames } from './get-type-names'
 interface CompactPoiListElementBaseProps<T extends PoiListElementType>
   extends PoiListElementBaseProps<T> {
   actionButtonElement?: ActionButtonElement
+  guestMode?: boolean
 }
 
 export type CompactPoiListElementProps<T extends PoiListElementType> =

--- a/packages/poi-list-elements/src/compact-poi-list-element.tsx
+++ b/packages/poi-list-elements/src/compact-poi-list-element.tsx
@@ -41,6 +41,7 @@ export function CompactPoiListElement<T extends PoiListElementType>({
     source: { names, image, areas, vicinity },
   },
   onClick,
+  guestMode,
 }: CompactPoiListElementProps<T>) {
   const [actionButtonWidth, setActionButtonWidth] = useState(0)
   const actionButtonRef = useRef<HTMLDivElement & { width?: number }>(null)
@@ -60,6 +61,19 @@ export function CompactPoiListElement<T extends PoiListElementType>({
     regionNames?.ko ||
     regionNames?.en ||
     regionNames?.local
+  const ActionButton = actionButtonElement ? (
+    <div ref={actionButtonRef}>{actionButtonElement}</div>
+  ) : (
+    <Container
+      position="absolute"
+      css={{
+        top: 0,
+        right: 0,
+      }}
+    >
+      <OutlineScrapButton resource={poi} size={34} />
+    </Container>
+  )
 
   return (
     <ResourceListItem onClick={onClick}>
@@ -91,19 +105,7 @@ export function CompactPoiListElement<T extends PoiListElementType>({
           .join(' · ')}
       </Text>
 
-      {actionButtonElement ? (
-        <div ref={actionButtonRef}>{actionButtonElement}</div>
-      ) : (
-        <Container
-          position="absolute"
-          css={{
-            top: 0,
-            right: 0,
-          }}
-        >
-          <OutlineScrapButton resource={poi} size={34} />
-        </Container>
-      )}
+      {!guestMode ? ActionButton : null}
     </ResourceListItem>
   )
 }

--- a/packages/poi-list-elements/src/types.ts
+++ b/packages/poi-list-elements/src/types.ts
@@ -9,6 +9,7 @@ export type ActionButtonElement = ReactNode
 
 export interface PoiListElementBaseProps<T extends PoiListElementType> {
   poi: T
+  guestMode?: boolean
   onClick?: MouseEventHandler<HTMLLIElement>
 }
 

--- a/packages/poi-list-elements/src/types.ts
+++ b/packages/poi-list-elements/src/types.ts
@@ -9,7 +9,6 @@ export type ActionButtonElement = ReactNode
 
 export interface PoiListElementBaseProps<T extends PoiListElementType> {
   poi: T
-  guestMode?: boolean
   onClick?: MouseEventHandler<HTMLLIElement>
 }
 

--- a/packages/triple-document/src/elements/pois.tsx
+++ b/packages/triple-document/src/elements/pois.tsx
@@ -9,6 +9,7 @@ import {
 import { Text } from '@titicaca/core-elements'
 
 import { useResourceClickHandler } from '../prop-context/resource-click-handler'
+import { useGuestMode } from '../prop-context/guest-mode'
 
 import ResourceList from './shared/resource-list'
 import DocumentCarousel from './shared/document-carousel'
@@ -43,6 +44,7 @@ export default function Pois<T extends ExtendedPoiListElementData>({
     pois: T[]
   }
 }) {
+  const guestMode = useGuestMode()
   const onResourceClick = useResourceClickHandler()
 
   const Container = display === 'list' ? ResourceList : DocumentCarousel
@@ -74,6 +76,7 @@ export default function Pois<T extends ExtendedPoiListElementData>({
             display,
             poi,
           })}
+          guestMode={guestMode}
         />
       ))}
     </Container>

--- a/packages/triple-document/src/index.ts
+++ b/packages/triple-document/src/index.ts
@@ -8,6 +8,7 @@ export { Slot } from './elements/tna/slot'
 export { PricePolicyCouponInfo } from './elements/tna/price-policy-coupon-info'
 
 export { useDeepLink } from './prop-context/deep-link'
+export { useGuestMode } from './prop-context/guest-mode'
 export { useImageClickHandler } from './prop-context/image-click-handler'
 export { useImageSource } from './prop-context/image-source'
 export { useLinkClickHandler } from './prop-context/link-click-handler'

--- a/packages/triple-document/src/prop-context/guest-mode.ts
+++ b/packages/triple-document/src/prop-context/guest-mode.ts
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react'
+
+const GuestModeContext = createContext<boolean | undefined>(undefined)
+
+/**
+ * guestMode
+ * true인 경우, 로그인이 필요한 동작(스크랩, 리뷰쓰기)등이 불가능하며, 앱으로 연결되는 루트를 차단합니다.
+ */
+export const GuestModeProvider = GuestModeContext.Provider
+
+export function useGuestMode() {
+  return useContext(GuestModeContext)
+}

--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -21,6 +21,7 @@ import { DeepLinkProvider } from './prop-context/deep-link'
 import { MediaConfigProvider } from './prop-context/media-config'
 import ELEMENTS from './elements'
 import useEventResourceTracker from './use-resource-event-tracker'
+import { GuestModeProvider } from './prop-context/guest-mode'
 
 export function TripleDocument({
   children,
@@ -34,6 +35,7 @@ export function TripleDocument({
   videoAutoPlay,
   hideVideoControls,
   optimized = false,
+  guestMode,
 }: {
   customElements?: ElementSet
   children: TripleElementData[]
@@ -97,33 +99,36 @@ export function TripleDocument({
                 hideVideoControls={hideVideoControls}
                 optimized={optimized}
               >
-                {children.map(({ type, value }, i) => {
-                  const RegularElement = ELEMENTS[type]
-                  const CustomElement = customElements[type]
+                <GuestModeProvider value={guestMode}>
+                  {children.map(({ type, value }, i) => {
+                    const RegularElement = ELEMENTS[type]
+                    const CustomElement = customElements[type]
 
-                  const Element = CustomElement || RegularElement
+                    const Element = CustomElement || RegularElement
 
-                  return (
-                    Element && (
-                      <Element
-                        key={i}
-                        value={value}
-                        {...(CustomElement
-                          ? {
-                              onResourceClick: resourceClickHandler,
-                              onImageClick,
-                              onLinkClick: linkClickHandler,
-                              ImageSource: imageSourceComponent,
-                              deepLink,
-                              videoAutoPlay,
-                              hideVideoControls,
-                              optimized,
-                            }
-                          : {})}
-                      />
+                    return (
+                      Element && (
+                        <Element
+                          key={i}
+                          value={value}
+                          {...(CustomElement
+                            ? {
+                                onResourceClick: resourceClickHandler,
+                                onImageClick,
+                                onLinkClick: linkClickHandler,
+                                ImageSource: imageSourceComponent,
+                                deepLink,
+                                videoAutoPlay,
+                                hideVideoControls,
+                                optimized,
+                                guestMode,
+                              }
+                            : {})}
+                        />
+                      )
                     )
-                  )
-                })}
+                  })}
+                </GuestModeProvider>
               </MediaConfigProvider>
             </DeepLinkProvider>
           </ImageSourceProvider>

--- a/packages/triple-document/src/types.ts
+++ b/packages/triple-document/src/types.ts
@@ -46,6 +46,7 @@ export type TripleDocumentContext = {
   onTNAProductsFetch?: TnaProductsFetcher
   imageSourceComponent?: ImageSourceType
   deepLink?: string
+  guestMode?: boolean
 } & MediaConfig
 
 export interface ElementSet {


### PR DESCRIPTION
## PR 설명
POI 리스트에서 스크랩 버튼을 숨길 수 있도록 합니다. '서울콘' 행사 대응용 작업입니다. 
- [서울콘 관련 문서](https://inpk.atlassian.net/wiki/spaces/SPC/pages/341443028)
- [컨텐트웹에서 숨겨야 하는 영역 및 기능 목록 시트](https://docs.google.com/spreadsheets/d/1HN9_vul_qMcLjHGXf5c5I9hKVcU2HIGA3ewTzb7Jeg8/edit#gid=0)

## 변경 내역
'서울콘' 행사를 통해 컨텐트웹(triple-content-web)의 페이지로 유입된 사용자들은 모두 비로그인 상태이며, 로그인이 필요한 기능을 사용할 수 없습니다. 더불어 트리플앱으로의 연결을 유도하는 루트도 보지 않아야 합니다.
- 그래서 Triple Document에 포함된 `Pois` 컴포넌트(POI list) 내 로그인 및 앱과의 연결과 관련된 부분들을 특정한 값을 기준으로 분기하기 위하여, `guestMode` 값을 받을 수 있도록 추가했습니다.
- `guestMode`가 `true`인 경우, POI list의 스크랩 버튼을 숨깁니다.

## 논의하고 싶은 점
'페이지에서 로그인이 필요한 동작(스크랩, 리뷰쓰기)등이 불가능하며, 앱으로 연결되는 루트에 접근할 수 없음'이라는 기획을 적용하기 위해, 관련 기능을 분기하는 기준 플래그를 `guestMode`라고 이름붙였습니다.
서울콘 `seoulcon` 이라고 이름붙일지 고민했으나, Triple Document에 특정 이벤트 이름이 들어가는것이 적절하지 않을 수 있겠다고 생각했어요. 하지만 아직 서울콘 외에 다른 비슷한 이벤트는 없는 상황이라(가능성은 있으나) 명확하게 `seoulcon`이라고 이름붙이는것이 나을까? 싶기도 합니다. 어떤 이름이 적절할까요?

- https://github.com/titicacadev/triple-frontend/pull/2991 에서도 마찬가지로 `guestMode`라는 플래그명을 사용하였습니다.

## 체크리스트
- [x] content-web dev QA

## 스크린샷 & URL
<img width="867" alt="스크린샷 2023-11-07 오후 5 56 22" src="https://github.com/titicacadev/triple-frontend/assets/46276783/2cbf4779-0cf2-44ff-adf0-c97fc98d6ab6">

- 샘플 URL : https://triple-dev.titicaca-corp.com/content/seoul-con/articles/92c37833-aa4a-4e29-912b-907e6b6d24b6?lang=en