### PR TITLE
[Poi-detail] image carousel 서울콘 대응

### DIFF
--- a/packages/poi-detail/src/image-carousel/carousel-section.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel-section.tsx
@@ -46,7 +46,12 @@ export default function CarouselSection({
     >
       <Container position="relative">
         {images.length > 0 ? (
-          <Carousel images={images} borderRadius={borderRadius} {...props} />
+          <Carousel
+            images={images}
+            borderRadius={borderRadius}
+            guestMode={guestMode}
+            {...props}
+          />
         ) : (
           <Placeholder
             onClick={onPlaceholderClick}

--- a/packages/poi-detail/src/image-carousel/carousel-section.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel-section.tsx
@@ -4,6 +4,8 @@ import Carousel, { CarouselProps } from './carousel'
 import Placeholder from './placeholder'
 import { BusinessHoursNote, PermanentlyClosedNote } from './note'
 
+type PoiType = 'attraction' | 'hotel' | 'restaurant'
+
 export interface CarouselSectionProps extends CarouselProps {
   loading: boolean
   currentBusinessHours?:
@@ -20,6 +22,7 @@ export interface CarouselSectionProps extends CarouselProps {
   height?: number
   /** true인 경우, 로그인이 필요한 일부 동작을 막고, 트리플앱으로 연결되는 루트를 차단합니다 */
   guestMode?: boolean
+  type?: PoiType
 }
 
 export default function CarouselSection({

--- a/packages/poi-detail/src/image-carousel/carousel-section.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel-section.tsx
@@ -4,7 +4,7 @@ import Carousel, { CarouselProps } from './carousel'
 import Placeholder from './placeholder'
 import { BusinessHoursNote, PermanentlyClosedNote } from './note'
 
-type PoiType = 'attraction' | 'hotel' | 'restaurant'
+export type PoiType = 'attraction' | 'hotel' | 'restaurant'
 
 export interface CarouselSectionProps extends CarouselProps {
   loading: boolean
@@ -35,6 +35,7 @@ export default function CarouselSection({
   onBusinessHoursClick,
   borderRadius,
   guestMode,
+  type,
   ...props
 }: CarouselSectionProps) {
   return (
@@ -60,6 +61,7 @@ export default function CarouselSection({
             onClick={onPlaceholderClick}
             noContent={loading}
             guestMode={guestMode}
+            type={type}
           />
         )}
         {!permanentlyClosed && onBusinessHoursClick ? (

--- a/packages/poi-detail/src/image-carousel/carousel-section.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel-section.tsx
@@ -18,6 +18,8 @@ export interface CarouselSectionProps extends CarouselProps {
   onBusinessHoursClick?: () => void
   onPlaceholderClick: () => void
   height?: number
+  /** true인 경우, 로그인이 필요한 일부 동작을 막고, 트리플앱으로 연결되는 루트를 차단합니다 */
+  guestMode?: boolean
 }
 
 export default function CarouselSection({

--- a/packages/poi-detail/src/image-carousel/carousel-section.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel-section.tsx
@@ -31,6 +31,7 @@ export default function CarouselSection({
   onPlaceholderClick,
   onBusinessHoursClick,
   borderRadius,
+  guestMode,
   ...props
 }: CarouselSectionProps) {
   return (
@@ -47,7 +48,11 @@ export default function CarouselSection({
         {images.length > 0 ? (
           <Carousel images={images} borderRadius={borderRadius} {...props} />
         ) : (
-          <Placeholder onClick={onPlaceholderClick} noContent={loading} />
+          <Placeholder
+            onClick={onPlaceholderClick}
+            noContent={loading}
+            guestMode={guestMode}
+          />
         )}
         {!permanentlyClosed && onBusinessHoursClick ? (
           <BusinessHoursNote

--- a/packages/poi-detail/src/image-carousel/carousel.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel.tsx
@@ -39,6 +39,7 @@ export interface CarouselProps {
   optimized?: boolean
   borderRadius?: number
   height?: number
+  guestMode?: boolean
 }
 
 export default function Carousel({
@@ -50,6 +51,7 @@ export default function Carousel({
   optimized,
   borderRadius = 6,
   height,
+  guestMode,
 }: CarouselProps) {
   const app = useTripleClientMetadata()
   const { trackEvent, trackSimpleEvent } = useEventTrackingContext()
@@ -133,7 +135,9 @@ export default function Carousel({
         )
 
   const CTA = ({ currentIndex }: { currentIndex: number }) =>
-    !app && currentIndex === SHOW_CTA_FROM_INDEX ? <CtaOverlay /> : null
+    !app && !guestMode && currentIndex === SHOW_CTA_FROM_INDEX ? (
+      <CtaOverlay />
+    ) : null
 
   return (
     <>

--- a/packages/poi-detail/src/image-carousel/carousel.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel.tsx
@@ -129,12 +129,28 @@ export default function Carousel({
     ],
   )
 
-  const ConditionalPageLabel = app
-    ? undefined
-    : ({ currentIndex }: { currentIndex: number }) =>
-        !totalImagesCount || currentIndex === SHOW_CTA_FROM_INDEX ? null : (
-          <PageLabel currentIndex={currentPage} totalCount={totalImagesCount} />
-        )
+  const publicPageLabelRenderer = ({
+    currentIndex,
+  }: {
+    currentIndex: number
+  }) => {
+    if (!totalImagesCount) {
+      return null
+    }
+
+    if (guestMode || currentIndex !== SHOW_CTA_FROM_INDEX) {
+      const totalCount =
+        guestMode && totalImagesCount > SHOW_CTA_FROM_INDEX
+          ? SHOW_CTA_FROM_INDEX
+          : totalImagesCount
+
+      return <PageLabel currentIndex={currentPage} totalCount={totalCount} />
+    }
+
+    return null
+  }
+
+  const ConditionalPageLabel = app ? undefined : publicPageLabelRenderer
 
   const CTA = ({ currentIndex }: { currentIndex: number }) =>
     !app && !guestMode && currentIndex === SHOW_CTA_FROM_INDEX ? (

--- a/packages/poi-detail/src/image-carousel/carousel.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel.tsx
@@ -56,7 +56,9 @@ export default function Carousel({
   const app = useTripleClientMetadata()
   const { trackEvent, trackSimpleEvent } = useEventTrackingContext()
   const [currentPage, setCurrentPage] = useState(0)
-  const visibleImages = app ? images : images.slice(0, SHOW_CTA_FROM_INDEX + 1)
+  const visibleImages = app
+    ? images
+    : images.slice(0, guestMode ? SHOW_CTA_FROM_INDEX : SHOW_CTA_FROM_INDEX + 1)
 
   const handleImageClick = useCallback(
     (event?: MouseEvent, media?: ImageMeta) => {

--- a/packages/poi-detail/src/image-carousel/carousel.tsx
+++ b/packages/poi-detail/src/image-carousel/carousel.tsx
@@ -153,9 +153,7 @@ export default function Carousel({
   const ConditionalPageLabel = app ? undefined : publicPageLabelRenderer
 
   const CTA = ({ currentIndex }: { currentIndex: number }) =>
-    !app && !guestMode && currentIndex === SHOW_CTA_FROM_INDEX ? (
-      <CtaOverlay />
-    ) : null
+    !app && currentIndex === SHOW_CTA_FROM_INDEX ? <CtaOverlay /> : null
 
   return (
     <>

--- a/packages/poi-detail/src/image-carousel/index.tsx
+++ b/packages/poi-detail/src/image-carousel/index.tsx
@@ -14,6 +14,7 @@ type ImageCarouselProps = Pick<
   | 'optimized'
   | 'borderRadius'
   | 'height'
+  | 'guestMode'
 >
 
 export default function ImageCarousel(props: ImageCarouselProps) {

--- a/packages/poi-detail/src/image-carousel/index.tsx
+++ b/packages/poi-detail/src/image-carousel/index.tsx
@@ -15,6 +15,7 @@ type ImageCarouselProps = Pick<
   | 'borderRadius'
   | 'height'
   | 'guestMode'
+  | 'type'
 >
 
 export default function ImageCarousel(props: ImageCarouselProps) {

--- a/packages/poi-detail/src/image-carousel/placeholder.tsx
+++ b/packages/poi-detail/src/image-carousel/placeholder.tsx
@@ -4,6 +4,13 @@ import { Text, Responsive } from '@titicaca/core-elements'
 
 import { PoiType } from './carousel-section'
 
+const DEFAULT_ICON_URLS: Record<PoiType, string> = {
+  attraction: 'https://assets.triple.guide/images/seoulcon/default/ic_spot.svg',
+  hotel: 'https://assets.triple.guide/images/seoulcon/default/ic_hotel.svg',
+  restaurant:
+    'https://assets.triple.guide/images/seoulcon/default/ic_restaurant.svg',
+}
+
 const ImagePlaceholderContainer = styled.div<{ large?: boolean }>`
   width: 100%;
   overflow: hidden;
@@ -49,8 +56,9 @@ interface ImagePlaceholderProps {
 function ImagePlaceholder({
   large,
   noContent,
-  onClick,
   guestMode,
+  type,
+  onClick,
 }: ImagePlaceholderProps) {
   const { t } = useTranslation('common-web')
 
@@ -58,8 +66,10 @@ function ImagePlaceholder({
     <ImagePlaceholderContainer large={large} onClick={onClick}>
       <ImagePlaceholderContent large={large}>
         {noContent ? null : guestMode ? (
-          /** TODO : 아이콘 이미지 guestMode 용으로 교체  */
-          <PlaceholderIcon src="https://assets.triple.guide/images/img-empty-photo-m@4x.png" />
+          <PlaceholderIcon
+            src={DEFAULT_ICON_URLS[type || 'attraction']}
+            css={{ opacity: 0.3 }}
+          />
         ) : (
           <>
             <PlaceholderIcon src="https://assets.triple.guide/images/img-empty-photo-m@4x.png" />
@@ -77,9 +87,10 @@ function ImagePlaceholder({
 }
 
 export default function ResponsiveImagePlaceholder({
-  onClick,
   noContent,
   guestMode,
+  type,
+  onClick,
 }: Omit<ImagePlaceholderProps, 'large'>) {
   return (
     <>
@@ -87,6 +98,7 @@ export default function ResponsiveImagePlaceholder({
         <ImagePlaceholder
           noContent={noContent}
           guestMode={guestMode}
+          type={type}
           onClick={onClick}
         />
       </Responsive>
@@ -94,6 +106,7 @@ export default function ResponsiveImagePlaceholder({
         <ImagePlaceholder
           noContent={noContent}
           guestMode={guestMode}
+          type={type}
           large
           onClick={onClick}
         />

--- a/packages/poi-detail/src/image-carousel/placeholder.tsx
+++ b/packages/poi-detail/src/image-carousel/placeholder.tsx
@@ -39,6 +39,7 @@ const ImagePlaceholderContent = styled.div<{ large?: boolean }>`
 interface ImagePlaceholderProps {
   large?: boolean
   noContent?: boolean
+  guestMode?: boolean
   onClick: () => void
 }
 
@@ -68,22 +69,27 @@ function ImagePlaceholder({
   )
 }
 
-interface ResponsiveImagePlaceholderProps {
-  onClick: () => void
-  noContent?: boolean
-}
-
 export default function ResponsiveImagePlaceholder({
   onClick,
   noContent,
-}: ResponsiveImagePlaceholderProps) {
+  guestMode,
+}: Omit<ImagePlaceholderProps, 'large'>) {
   return (
     <>
       <Responsive maxWidth={706}>
-        <ImagePlaceholder noContent={noContent} onClick={onClick} />
+        <ImagePlaceholder
+          noContent={noContent}
+          guestMode={guestMode}
+          onClick={onClick}
+        />
       </Responsive>
       <Responsive minWidth={707}>
-        <ImagePlaceholder noContent={noContent} large onClick={onClick} />
+        <ImagePlaceholder
+          noContent={noContent}
+          guestMode={guestMode}
+          large
+          onClick={onClick}
+        />
       </Responsive>
     </>
   )

--- a/packages/poi-detail/src/image-carousel/placeholder.tsx
+++ b/packages/poi-detail/src/image-carousel/placeholder.tsx
@@ -27,8 +27,6 @@ const ImagePlaceholderContainer = styled.div<{ large?: boolean }>`
 `
 
 const PlaceholderIcon = styled.img`
-  width: 60px;
-  height: 60px;
   vertical-align: baseline;
 `
 
@@ -68,11 +66,15 @@ function ImagePlaceholder({
         {noContent ? null : guestMode ? (
           <PlaceholderIcon
             src={DEFAULT_ICON_URLS[type || 'attraction']}
+            width={40}
             css={{ opacity: 0.3 }}
           />
         ) : (
           <>
-            <PlaceholderIcon src="https://assets.triple.guide/images/img-empty-photo-m@4x.png" />
+            <PlaceholderIcon
+              src="https://assets.triple.guide/images/img-empty-photo-m@4x.png"
+              width={60}
+            />
             <Text size="small" color="gray" alpha={0.3}>
               {t([
                 'igosyi-ceos-beonjjae-sajineul-olryeojuseyo.',

--- a/packages/poi-detail/src/image-carousel/placeholder.tsx
+++ b/packages/poi-detail/src/image-carousel/placeholder.tsx
@@ -2,6 +2,8 @@ import { useTranslation } from '@titicaca/next-i18next'
 import styled, { css } from 'styled-components'
 import { Text, Responsive } from '@titicaca/core-elements'
 
+import { PoiType } from './carousel-section'
+
 const ImagePlaceholderContainer = styled.div<{ large?: boolean }>`
   width: 100%;
   overflow: hidden;
@@ -40,6 +42,7 @@ interface ImagePlaceholderProps {
   large?: boolean
   noContent?: boolean
   guestMode?: boolean
+  type?: PoiType
   onClick: () => void
 }
 

--- a/packages/poi-detail/src/image-carousel/placeholder.tsx
+++ b/packages/poi-detail/src/image-carousel/placeholder.tsx
@@ -47,13 +47,17 @@ function ImagePlaceholder({
   large,
   noContent,
   onClick,
+  guestMode,
 }: ImagePlaceholderProps) {
   const { t } = useTranslation('common-web')
 
   return (
     <ImagePlaceholderContainer large={large} onClick={onClick}>
       <ImagePlaceholderContent large={large}>
-        {noContent ? null : (
+        {noContent ? null : guestMode ? (
+          /** TODO : 아이콘 이미지 guestMode 용으로 교체  */
+          <PlaceholderIcon src="https://assets.triple.guide/images/img-empty-photo-m@4x.png" />
+        ) : (
           <>
             <PlaceholderIcon src="https://assets.triple.guide/images/img-empty-photo-m@4x.png" />
             <Text size="small" color="gray" alpha={0.3}>


### PR DESCRIPTION
## PR 설명
'서울콘' 행사 대응용 작업입니다. POI 상단 이미지 캐러셀에서, '서울콘' 행사 유저들에게 특정 UI 및 한정적 컨텐츠를 제공합니다.
- [서울콘 관련 문서](https://inpk.atlassian.net/wiki/spaces/SPC/pages/341443028)
- [컨텐트웹에서 숨겨야 하는 영역 및 기능 목록 시트](https://docs.google.com/spreadsheets/d/1HN9_vul_qMcLjHGXf5c5I9hKVcU2HIGA3ewTzb7Jeg8/edit#gid=1763643502)

## 논의하고 싶은 점
'guestMode' 네이밍이 적절한지 https://github.com/titicacadev/triple-frontend/pull/2990 이곳에서 논의하여 동일하게 적용하려고 합니다.

## 변경 내역
'서울콘' 행사를 통해 컨텐트웹(triple-content-web)의 페이지로 유입된 사용자들은 모두 비로그인 상태이며, 로그인이 필요한 기능을 사용할 수 없습니다. 더불어 트리플앱으로의 연결을 유도하는 루트도 보지 않아야 합니다.
- 서울콘 행사 유저의 접근을 구분하기 위해 'guestMode'라는 플래그를 추가했습니다.
- guestMode가 true인 경우
  - 사진을 최대 5장까지만 노출합니다.
    - 따라서 기존 6장째 사진에서 노출되는 '트리플 앱에서 사진 더 보기' 영역이 나타나지 않습니다.
  - 사진 인덱스(ex. 1/5)의 총 사진 수가 최대 5장까지만 나타나도록 합니다.
  - 등록된 사진이 없을 시, '사진 등록' 아이콘이 아닌 POI 타입별 디폴트 아이콘을 노출합니다.

## 체크리스트
- [x] content-web dev QA

## 스크린샷 & URL
- 일반 POI

https://github.com/titicacadev/triple-frontend/assets/46276783/0c299121-ca99-4cd6-a142-4c8692e6bc33

- 서울콘 POI

https://github.com/titicacadev/triple-frontend/assets/46276783/48af970a-29ee-430e-aa72-f767562ce281

- 서울콘 POI 샘플 URL : https://triple-dev.titicaca-corp.com/content/seoul-con/attractions/090a839c-9a18-4f1f-984e-515b7d57249d?lang=en