### PR TITLE
[Chat refactor] BubbleUI의 prop 변경

### DIFF
--- a/packages/chat/src/bubble/blinded.tsx
+++ b/packages/chat/src/bubble/blinded.tsx
@@ -1,8 +1,6 @@
 import { FlexBox } from '@titicaca/core-elements'
 import styled from 'styled-components'
 
-import { useChat } from '../chat'
-
 import { Bubble } from './bubble'
 import { BlindedBubbleProp } from './type'
 
@@ -19,14 +17,8 @@ export default function BlindedBubble({
   blindedText,
   ...props
 }: BlindedBubbleProp) {
-  const { textBubbleMaxWidthOffset } = useChat()
   return (
-    <Bubble
-      maxWidthOffset={textBubbleMaxWidthOffset}
-      my={my}
-      css={{ margin: my ? '0 0 0 8px' : undefined }}
-      {...props}
-    >
+    <Bubble my={my} css={{ margin: my ? '0 0 0 8px' : undefined }} {...props}>
       <FlexBox flex alignItems="center" gap="4px">
         <ExclamationMarkIcon
           color={my ? 'white' : 'gray'}

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -1,8 +1,10 @@
+import { CSSProp } from 'styled-components'
+
 import { TextBubble } from './text'
 import { ImageBubble } from './image'
 import { RichBubble } from './rich'
 import {
-  BlindedBubbleProp,
+  BubbleProp,
   ImageBubbleProp,
   ProductBubbleProp,
   RichBubbleProp,
@@ -13,29 +15,148 @@ import BlindedBubble from './blinded'
 
 type BubbleType = 'blinded' | 'text' | 'images' | 'rich' | 'product'
 
-interface BubbleUIProp<Type extends BubbleType> {
-  type: Type
+interface BubbleTypeType {
+  type: BubbleType
 }
 
-type BubbleUIProps =
-  | (BubbleUIProp<'blinded'> & BlindedBubbleProp)
-  | (BubbleUIProp<'text'> & TextBubbleProp)
-  | (BubbleUIProp<'images'> & ImageBubbleProp)
-  | (BubbleUIProp<'rich'> & RichBubbleProp)
-  | (BubbleUIProp<'product'> & ProductBubbleProp)
+interface TextBubbleUIProp extends BubbleTypeType {
+  type: 'text'
+  value: Pick<TextBubbleProp, 'message'>
+}
 
-export default function BubbleUI({ ...bubble }: BubbleUIProps) {
-  switch (bubble.type) {
-    case 'blinded':
-      return <BlindedBubble {...bubble} />
+interface ImageBubbleUIProp extends BubbleTypeType {
+  type: 'images'
+  value: Pick<ImageBubbleProp, 'images'>
+}
+
+interface RichBubbleUIProp extends BubbleTypeType {
+  type: 'rich'
+  value: Pick<RichBubbleProp, 'blocks'>
+}
+
+interface ProductBubbleUIProp extends BubbleTypeType {
+  type: 'product'
+  value: Pick<ProductBubbleProp, 'product'>
+}
+
+type BubbleUIProps = (
+  | TextBubbleUIProp
+  | ImageBubbleUIProp
+  | RichBubbleUIProp
+  | ProductBubbleUIProp
+) & {
+  id: string
+  my: boolean
+  blinded?: boolean
+  blindedText?: string
+  onBubbleClick?: BubbleProp['onClick']
+  onImageBubbleClick?: ImageBubbleProp['onClick']
+  onBubbleLongPress?: BubbleProp['onLongPress']
+  onImageBubbleLongPress?: ImageBubbleProp['onLongPress']
+  onRichBubbleBlockClick?: {
+    image?: RichBubbleProp['onImageClick']
+    beforeButtonRouting?: RichBubbleProp['onButtonClickBeforeRouting']
+  }
+  richBubbleStyle?: {
+    textItemStyle?: CSSProp
+    imageItemStyle?: CSSProp
+    buttonITemStyle?: CSSProp
+  }
+  maxWidthOffset?: BubbleProp['maxWidthOffset']
+  cloudinaryName?: string
+  mediaUrlBase?: string
+  hasArrow?: boolean
+  css?: CSSProp
+}
+
+export default function BubbleUI({
+  type,
+  value,
+  id,
+  my,
+  blinded,
+  blindedText,
+  onBubbleClick,
+  onImageBubbleClick,
+  onBubbleLongPress,
+  onImageBubbleLongPress,
+  onRichBubbleBlockClick,
+  richBubbleStyle,
+  maxWidthOffset,
+  cloudinaryName,
+  mediaUrlBase,
+  hasArrow,
+  css,
+}: BubbleUIProps) {
+  if (blinded) {
+    return (
+      <BlindedBubble
+        id={id}
+        my={my}
+        blindedText={blindedText}
+        hasArrow={hasArrow}
+        css={css}
+      />
+    )
+  }
+  switch (type) {
     case 'text':
-      return <TextBubble {...bubble} />
+      return (
+        <TextBubble
+          id={id}
+          my={my}
+          message={value.message}
+          onClick={onBubbleClick}
+          onLongPress={onBubbleLongPress}
+          hasArrow={hasArrow}
+          css={css}
+        />
+      )
     case 'images':
-      return <ImageBubble {...bubble} />
+      return (
+        <ImageBubble
+          images={value.images}
+          onClick={onImageBubbleClick}
+          onLongPress={onImageBubbleLongPress}
+          css={css}
+        />
+      )
     case 'rich':
-      return <RichBubble {...bubble} />
+      if (!cloudinaryName || !mediaUrlBase) {
+        throw new Error('cloudinaryName 또는 mediaUrlBase가 존재하지 않습니다.')
+      }
+      return (
+        <RichBubble
+          id={id}
+          my={my}
+          blocks={value.blocks}
+          cloudinaryName={cloudinaryName}
+          mediaUrlBase={mediaUrlBase}
+          onClick={onBubbleClick}
+          onLongPress={onBubbleLongPress}
+          onImageClick={onRichBubbleBlockClick?.image}
+          onButtonClickBeforeRouting={
+            onRichBubbleBlockClick?.beforeButtonRouting
+          }
+          buttonItemStyle={richBubbleStyle?.buttonITemStyle}
+          imageItemStyle={richBubbleStyle?.imageItemStyle}
+          textItemStyle={richBubbleStyle?.textItemStyle}
+          hasArrow={hasArrow}
+          maxWidthOffset={maxWidthOffset}
+        />
+      )
     case 'product':
-      return <ProductBubble {...bubble} />
+      return (
+        <ProductBubble
+          id={id}
+          my={my}
+          product={value.product}
+          onClick={onBubbleClick}
+          onLongPress={onBubbleLongPress}
+          maxWidthOffset={maxWidthOffset}
+          css={css}
+        />
+      )
     //   case MessageType.DELETED:
     //     return <DeletedBubble />
     default:

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -60,7 +60,7 @@ type BubbleUIProps = (
   richBubbleStyle?: {
     textItemStyle?: CSSProp
     imageItemStyle?: CSSProp
-    buttonITemStyle?: CSSProp
+    buttonItemStyle?: CSSProp
   }
   maxWidthOffset?: BubbleProp['maxWidthOffset']
   cloudinaryName?: string
@@ -138,7 +138,7 @@ export default function BubbleUI({
           onButtonClickBeforeRouting={
             onRichBubbleBlockClick?.beforeButtonRouting
           }
-          buttonItemStyle={richBubbleStyle?.buttonITemStyle}
+          buttonItemStyle={richBubbleStyle?.buttonItemStyle}
           imageItemStyle={richBubbleStyle?.imageItemStyle}
           textItemStyle={richBubbleStyle?.textItemStyle}
           hasArrow={hasArrow}

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -15,26 +15,26 @@ import BlindedBubble from './blinded'
 
 type BubbleType = 'blinded' | 'text' | 'images' | 'rich' | 'product'
 
-interface BubbleTypeType {
+interface BubbleUIPropBase {
   type: BubbleType
 }
 
-interface TextBubbleUIProp extends BubbleTypeType {
+interface TextBubbleUIProp extends BubbleUIPropBase {
   type: 'text'
   value: Pick<TextBubbleProp, 'message'>
 }
 
-interface ImageBubbleUIProp extends BubbleTypeType {
+interface ImageBubbleUIProp extends BubbleUIPropBase {
   type: 'images'
   value: Pick<ImageBubbleProp, 'images'>
 }
 
-interface RichBubbleUIProp extends BubbleTypeType {
+interface RichBubbleUIProp extends BubbleUIPropBase {
   type: 'rich'
   value: Pick<RichBubbleProp, 'blocks'>
 }
 
-interface ProductBubbleUIProp extends BubbleTypeType {
+interface ProductBubbleUIProp extends BubbleUIPropBase {
   type: 'product'
   value: Pick<ProductBubbleProp, 'product'>
 }

--- a/packages/chat/src/bubble/bubble.tsx
+++ b/packages/chat/src/bubble/bubble.tsx
@@ -1,30 +1,13 @@
 import styled, { css } from 'styled-components'
 import { Text } from '@titicaca/core-elements'
-import { PropsWithChildren, MouseEvent } from 'react'
-import {
-  LongPressCallbackMeta,
-  LongPressReactEvents,
-  useLongPress,
-} from 'use-long-press'
+import { PropsWithChildren } from 'react'
+import { useLongPress } from 'use-long-press'
+
+import { BubbleCSSProp, BubbleProp } from './type'
 
 const BACKGROUND_COLORS: { [key: string]: string } = {
   mint: '#00BB92',
   white: '#ffffff',
-}
-
-interface BubbleCSSProp {
-  maxWidthOffset?: number
-  my: boolean
-  hasArrow?: boolean
-}
-export type BubbleProp = BubbleCSSProp & {
-  id: string
-  onClick?: (messageId: string, e: MouseEvent) => void
-  onLongPress?: (
-    messageId: string,
-    target: LongPressReactEvents<Element>,
-    context: LongPressCallbackMeta<unknown>,
-  ) => void
 }
 
 const StyledBubble = styled(Text).attrs({

--- a/packages/chat/src/bubble/bubble.tsx
+++ b/packages/chat/src/bubble/bubble.tsx
@@ -59,7 +59,7 @@ export function Bubble({
   )
 
   return (
-    <StyledBubble onClick={(e) => onClick?.(id, e)} {...props} {...bind()}>
+    <StyledBubble onClick={(e) => onClick?.(e, id)} {...props} {...bind()}>
       {children}
     </StyledBubble>
   )

--- a/packages/chat/src/bubble/product.tsx
+++ b/packages/chat/src/bubble/product.tsx
@@ -1,7 +1,6 @@
 import { Color } from '@titicaca/color-palette'
 import { FlexBox, Text } from '@titicaca/core-elements'
 
-import { useChat } from '../chat'
 import { CustomerBookingStatus } from '../types'
 
 import {
@@ -36,7 +35,6 @@ export const ProductBubble = ({
   product,
   ...props
 }: ProductBubbleProp) => {
-  const { textBubbleFontSize } = useChat()
   const {
     customerBookingStatus,
     productName,
@@ -55,7 +53,6 @@ export const ProductBubble = ({
         width: 'calc(100% - 15px)',
         maxWidth: '768px',
         margin: my ? '0 0 0 8px' : undefined,
-        size: textBubbleFontSize,
       }}
       {...props}
     >

--- a/packages/chat/src/bubble/rich.tsx
+++ b/packages/chat/src/bubble/rich.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components'
 
-import { useChat } from '../chat'
 import { generatePreviewImage } from '../utils'
 
 import { ImageItem, TextItem } from './item'
@@ -35,24 +34,14 @@ export function RichBubble({
   cloudinaryName,
   mediaUrlBase,
   onImageClick,
+  onButtonClickBeforeRouting,
   textItemStyle,
   imageItemStyle,
   buttonItemStyle,
   ...props
 }: RichBubbleProp) {
-  const {
-    textBubbleFontSize,
-    textBubbleMaxWidthOffset,
-    onRichBubbleButtonBeforeRouting: onButtonBeforeRouting,
-  } = useChat()
-
   return (
-    <Bubble
-      my={my}
-      maxWidthOffset={textBubbleMaxWidthOffset}
-      css={{ margin: my ? '0 0 0 8px' : undefined, size: textBubbleFontSize }}
-      {...props}
-    >
+    <Bubble my={my} css={{ margin: my ? '0 0 0 8px' : undefined }} {...props}>
       {blocks.map((block, index) => {
         switch (block.type) {
           case 'text':
@@ -82,7 +71,7 @@ export function RichBubble({
               <Button
                 key={index}
                 href={block.action.param}
-                onClick={onButtonBeforeRouting}
+                onClick={onButtonClickBeforeRouting}
                 css={buttonItemStyle}
               >
                 {block.label}

--- a/packages/chat/src/bubble/type.ts
+++ b/packages/chat/src/bubble/type.ts
@@ -53,7 +53,7 @@ export interface BubbleCSSProp {
 
 export type BubbleProp = BubbleCSSProp & {
   id: string
-  onClick?: (messageId: string, e: MouseEvent) => void
+  onClick?: (e: MouseEvent, messageId: string) => void
   onLongPress?: (
     messageId: string,
     target: LongPressReactEvents<Element>,

--- a/packages/chat/src/bubble/type.ts
+++ b/packages/chat/src/bubble/type.ts
@@ -71,6 +71,7 @@ export type RichBubbleProp = {
   cloudinaryName: string
   mediaUrlBase: string
   onImageClick?: (imageInfos: MetaDataInterface[]) => void
+  onButtonClickBeforeRouting?: () => void
   textItemStyle?: CSSProp
   imageItemStyle?: CSSProp
   buttonItemStyle?: CSSProp

--- a/packages/chat/src/bubble/type.ts
+++ b/packages/chat/src/bubble/type.ts
@@ -45,11 +45,12 @@ export interface RichItemButton extends RichItem {
   }
 }
 
-interface BubbleCSSProp {
+export interface BubbleCSSProp {
   maxWidthOffset?: number
   my: boolean
   hasArrow?: boolean
 }
+
 export type BubbleProp = BubbleCSSProp & {
   id: string
   onClick?: (messageId: string, e: MouseEvent) => void
@@ -58,6 +59,7 @@ export type BubbleProp = BubbleCSSProp & {
     target: LongPressReactEvents<Element>,
     context: LongPressCallbackMeta<unknown>,
   ) => void
+  css?: CSSProp
 }
 
 export type TextBubbleProp = {

--- a/packages/chat/src/chat/chat-context.ts
+++ b/packages/chat/src/chat/chat-context.ts
@@ -5,12 +5,11 @@ import {
   SetStateAction,
   useContext,
 } from 'react'
-import { GlobalSizes } from '@titicaca/type-definitions'
 
 import { MetaDataInterface, PostMessageActionType } from '../types'
 
 export interface ChatContextValue {
-  textBubbleFontSize: GlobalSizes | number
+  textBubbleFontSize: number
   textBubbleMaxWidthOffset: number
   mediaUrlBase: string
   cloudinaryName: string

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -393,47 +393,40 @@ function getBubbleProp({
   textBubbleFontSize?: number
   textBubbleMaxWidthOffset?: number
 }): ComponentProps<typeof BubbleUI> {
-  if (blinded) {
-    return {
-      type: 'blinded',
-      id: messageId,
-      my,
-    }
+  const bla = {
+    id: messageId,
+    my,
+    blinded,
+    maxWidthOffset: textBubbleMaxWidthOffset,
+    mediaUrlBase:
+      process.env.NEXT_PUBLIC_MEDIA_URL_BASE || 'https://media.triple.guide',
+    cloudinaryName: process.env.NEXT_PUBLIC_CLOUDINARY_NAME || 'triple-cms',
+    css: { size: textBubbleFontSize },
   }
   switch (messagePayload.type) {
     case 'text':
       return {
         type: 'text',
-        id: messageId,
-        my,
-        maxWidthOffset: textBubbleMaxWidthOffset,
-        message: messagePayload.message,
-        css: { size: textBubbleFontSize },
+        value: { message: messagePayload.message },
+        ...bla,
       }
     case 'images':
       return {
         type: 'images',
-        images: messagePayload.images,
+        value: { images: messagePayload.images },
+        ...bla,
       }
     case 'rich':
       return {
         type: 'rich',
-        id: messageId,
-        my,
-        maxWidthOffset: textBubbleMaxWidthOffset,
-        blocks: messagePayload.items,
-        mediaUrlBase:
-          process.env.NEXT_PUBLIC_MEDIA_URL_BASE ||
-          'https://media.triple.guide',
-        cloudinaryName: process.env.NEXT_PUBLIC_CLOUDINARY_NAME || 'triple-cms',
-        css: { size: textBubbleFontSize },
+        value: { blocks: messagePayload.items },
+        ...bla,
       }
     case 'product':
       return {
         type: 'product',
-        id: messageId,
-        my,
-        product: messagePayload.product,
+        value: { product: messagePayload.product },
+        ...bla,
       }
   }
 }

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -102,7 +102,8 @@ export const Chat = ({
     getScrollContainerHeight,
   } = useScroll()
 
-  const { setPostMessage } = useChat()
+  const { setPostMessage, textBubbleFontSize, textBubbleMaxWidthOffset } =
+    useChat()
   const [
     {
       messages,
@@ -321,6 +322,8 @@ export const Chat = ({
                 messagePayload: payload,
                 my,
                 blinded: !!message.blindedAt,
+                textBubbleFontSize,
+                textBubbleMaxWidthOffset,
               })
               return (
                 <BubbleContainer
@@ -380,11 +383,15 @@ function getBubbleProp({
   messagePayload,
   my,
   blinded,
+  textBubbleFontSize,
+  textBubbleMaxWidthOffset,
 }: {
   messageId: string
   messagePayload: MessageInterface['payload']
   my: boolean
   blinded: boolean
+  textBubbleFontSize?: number
+  textBubbleMaxWidthOffset?: number
 }): ComponentProps<typeof BubbleUI> {
   if (blinded) {
     return {
@@ -399,8 +406,9 @@ function getBubbleProp({
         type: 'text',
         id: messageId,
         my,
-        maxWidthOffset: 100,
+        maxWidthOffset: textBubbleMaxWidthOffset,
         message: messagePayload.message,
+        css: { size: textBubbleFontSize },
       }
     case 'images':
       return {
@@ -412,12 +420,13 @@ function getBubbleProp({
         type: 'rich',
         id: messageId,
         my,
-        maxWidthOffset: 100,
+        maxWidthOffset: textBubbleMaxWidthOffset,
         blocks: messagePayload.items,
         mediaUrlBase:
           process.env.NEXT_PUBLIC_MEDIA_URL_BASE ||
           'https://media.triple.guide',
         cloudinaryName: process.env.NEXT_PUBLIC_CLOUDINARY_NAME || 'triple-cms',
+        css: { size: textBubbleFontSize },
       }
     case 'product':
       return {

--- a/packages/chat/src/utils/constants.ts
+++ b/packages/chat/src/utils/constants.ts
@@ -28,7 +28,7 @@ const empty = () => {}
 export const MEDIA_ARGS: ChatContextValue = {
   cloudinaryName: 'triple-cms',
   mediaUrlBase: 'https://media.triple.guide',
-  textBubbleFontSize: 'medium',
+  textBubbleFontSize: 16,
   textBubbleMaxWidthOffset: 100,
   onRichBubbleButtonBeforeRouting: empty,
   onImageBubbleClick: empty,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

`BubbleUI`는 들어오는 타입에 따라 알맞는 Bubble을 렌더링하는 역할을 합니다. 기존에는 type에 맞는 prop들만 넘길 수 있게 되어있었으나, 컴포넌트의 목적과 사용의 편리함을 위해 버블의 타입에 상관없이 종합적으로 필요한 prop을 모두 받아 `BubbleUI` 내부에서 각 Bubble에 맞는 prop을 넘기는 형태로 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
