### PR TITLE
ci의 test coverage의 maxWorker를 2로 고정합니다.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,13 +144,9 @@ jobs:
 
       - run: pnpm install
 
-      - name: Get number of CPU cores
-        id: cpu-cores
-        uses: SimenB/github-actions-cpu-cores@v1
-
       - name: Generate coverage report
         id: test
-        run: pnpm run test:coverage -- --ci --reporters github-actions --reporters summary --maxWorkers ${{ steps.cpu-cores.outputs.count }}
+        run: pnpm run test:coverage -- --ci --reporters github-actions --reporters summary --maxWorkers 2
 
       - name: Notify testing failure
         if: failure() && steps.test.outcome == 'failure'


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
ci의 test job이 coverage의 maxWorker가 4일 때 fail하고 있습니다. maxWorker를 2로 고정합니다. ([관련 스레드](https://interpark.slack.com/archives/C05EUG8UYP6/p1699322851538249))
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->