### PR TITLE
[Chat refactor] 메시지 리스트를 렌더링하는 Messages 컴포넌트 생성

### DIFF
--- a/packages/chat/src/bubble-container/bubble-container.tsx
+++ b/packages/chat/src/bubble-container/bubble-container.tsx
@@ -19,19 +19,24 @@ const CHAT_CONTAINER_STYLES = {
   width: '100%',
 } as const
 
-type SentBubbleContainerProp = PropsWithChildren<{
+interface ContainerBaseProp {
   id: string
   /** 메시지 생성 시간 */
   createdAt?: string // Date?
-  /** 전송 실패한 메시지 재전송 시도 함수 */
-  onRetry?: () => void
-  /** 전송 실패한 메시지 삭제 함수 */
-  onRetryCancel?: () => void
   /** 해당 메시지를 읽지 않은 유저의 수 */
   unreadCount: number | null
   /** 시간 정보 등의 정보의 노출 여부 */
   showInfo?: boolean
-}>
+}
+
+type SentBubbleContainerProp = PropsWithChildren<
+  ContainerBaseProp & {
+    /** 전송 실패한 메시지 재전송 시도 함수 */
+    onRetry?: () => void
+    /** 전송 실패한 메시지 삭제 함수 */
+    onRetryCancel?: () => void
+  }
+>
 
 function SentBubbleContainer({
   id,
@@ -64,26 +69,21 @@ function SentBubbleContainer({
   )
 }
 
-type ReceivedBubbleContainerProp = PropsWithChildren<{
-  id: string
-  /** 메시지 생성 시간 */
-  createdAt?: string // Date?
-  /** 메시지 발신인 정보 */
-  profile?: {
-    photo?: string
-    name: string
-    userId: string
-    unregistered?: boolean
+type ReceivedBubbleContainerProp = PropsWithChildren<
+  ContainerBaseProp & {
+    /** 메시지 발신인 정보 */
+    user?: {
+      photo?: string
+      name: string
+      userId: string
+      unregistered?: boolean
+    }
   }
-  /** 해당 메시지를 읽지 않은 유저의 수 */
-  unreadCount: number | null
-  /** 시간 정보 등의 정보의 노출 여부 */
-  showInfo?: boolean
-}>
+>
 
 function ReceivedBubbleContainer({
   id,
-  profile,
+  user,
   unreadCount,
   createdAt,
   showInfo,
@@ -94,10 +94,10 @@ function ReceivedBubbleContainer({
       id={`${DEFAULT_MESSAGE_ID_PREFIX}-${id}`}
       css={{ ...CHAT_CONTAINER_STYLES }}
     >
-      <ProfileImage src={profile?.photo} />
+      <ProfileImage src={user?.photo} />
       <Container css={{ marginLeft: 50 }}>
         <ProfileName size="mini" alpha={0.8} margin={{ bottom: 5 }}>
-          {profile?.name || ''}
+          {user?.name || ''}
         </ProfileName>
         {children}
         {createdAt && showInfo ? (
@@ -112,9 +112,8 @@ function ReceivedBubbleContainer({
   )
 }
 
-export type BubbleContainerProp =
-  | ({ my: true } & SentBubbleContainerProp)
-  | ({ my: false } & ReceivedBubbleContainerProp)
+export type BubbleContainerProp = { my: boolean } & SentBubbleContainerProp &
+  ReceivedBubbleContainerProp
 
 export default function BubbleContainer({
   my,

--- a/packages/chat/src/bubble-container/bubble-container.tsx
+++ b/packages/chat/src/bubble-container/bubble-container.tsx
@@ -70,10 +70,10 @@ type ReceivedBubbleContainerProp = PropsWithChildren<{
   createdAt?: string // Date?
   /** 메시지 발신인 정보 */
   profile?: {
-    thumbnailUrl?: string
+    photo?: string
     name: string
     userId: string
-    unregister?: boolean
+    unregistered?: boolean
   }
   /** 해당 메시지를 읽지 않은 유저의 수 */
   unreadCount: number | null
@@ -94,7 +94,7 @@ function ReceivedBubbleContainer({
       id={`${DEFAULT_MESSAGE_ID_PREFIX}-${id}`}
       css={{ ...CHAT_CONTAINER_STYLES }}
     >
-      <ProfileImage src={profile?.thumbnailUrl} />
+      <ProfileImage src={profile?.photo} />
       <Container css={{ marginLeft: 50 }}>
         <ProfileName size="mini" alpha={0.8} margin={{ bottom: 5 }}>
           {profile?.name || ''}

--- a/packages/chat/src/bubble-container/bubble-container.tsx
+++ b/packages/chat/src/bubble-container/bubble-container.tsx
@@ -52,12 +52,13 @@ function SentBubbleContainer({
       id={`${DEFAULT_MESSAGE_ID_PREFIX}-${id}`}
       css={{ textAlign: 'right', ...CHAT_CONTAINER_STYLES }}
     >
-      {!createdAt ? (
+      {!createdAt && onRetry && onRetryCancel ? (
         <SendingFailureHandlerContainer>
           <RetryButton onClick={onRetry} />
           <DeleteButton onClick={onRetryCancel} />
         </SendingFailureHandlerContainer>
-      ) : showInfo ? (
+      ) : null}
+      {createdAt && showInfo ? (
         <BubbleInfo
           unreadCount={unreadCount}
           date={createdAt}

--- a/packages/chat/src/bubble/altered.tsx
+++ b/packages/chat/src/bubble/altered.tsx
@@ -12,9 +12,9 @@ const ExclamationMarkIcon = styled.span<{ color?: 'gray' | 'white' }>`
   height: 16px;
 `
 
-export default function BlindedBubble({
+export default function AlteredBubble({
   my,
-  blindedText,
+  alternativeText,
   ...props
 }: BlindedBubbleProp) {
   return (
@@ -24,7 +24,7 @@ export default function BlindedBubble({
           color={my ? 'white' : 'gray'}
           style={{ flex: '0 0 16px' }}
         />
-        <span>{blindedText ?? '관리자에 의해 삭제되었습니다'}</span>
+        <span>{alternativeText ?? '관리자에 의해 삭제되었습니다'}</span>
       </FlexBox>
     </Bubble>
   )

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -12,16 +12,11 @@ import {
 } from './type'
 import { ProductBubble } from './product'
 import AlteredBubble from './altered'
+import { ALTERNATIVE_TEXT_MESSAGE } from './constants'
 
 export const BubbleTypeArray = ['text', 'images', 'rich', 'product'] as const
 
 export type BubbleType = (typeof BubbleTypeArray)[number]
-
-const ALTERNATIVE_TEXT_MESSAGE = {
-  blinded: '관리자에 의해 삭제된 메세지입니다.',
-  deleted: '삭제된 메세지입니다.',
-  unfriended: '차단한 사용자의 메세지입니다.',
-}
 
 interface BubbleUIPropBase {
   type: BubbleType

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -101,11 +101,12 @@ export default function BubbleUI({
         id={id}
         my={my}
         alternativeText={
-          alternativeText || unfriended
+          alternativeText ||
+          (unfriended
             ? ALTERNATIVE_TEXT_MESSAGE.unfriended
             : blinded
             ? ALTERNATIVE_TEXT_MESSAGE.blinded
-            : ALTERNATIVE_TEXT_MESSAGE.deleted
+            : ALTERNATIVE_TEXT_MESSAGE.deleted)
         }
         hasArrow={hasArrow}
         css={css}

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -13,7 +13,7 @@ import {
 import { ProductBubble } from './product'
 import BlindedBubble from './blinded'
 
-type BubbleType = 'blinded' | 'text' | 'images' | 'rich' | 'product'
+export type BubbleType = 'blinded' | 'text' | 'images' | 'rich' | 'product'
 
 interface BubbleUIPropBase {
   type: BubbleType

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -13,7 +13,7 @@ import {
 import { ProductBubble } from './product'
 import BlindedBubble from './blinded'
 
-export type BubbleType = 'blinded' | 'text' | 'images' | 'rich' | 'product'
+export type BubbleType = 'text' | 'images' | 'rich' | 'product'
 
 interface BubbleUIPropBase {
   type: BubbleType

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -25,27 +25,27 @@ interface BubbleUIPropBase {
   type: BubbleType
 }
 
-interface TextBubbleUIProp extends BubbleUIPropBase {
+export interface TextBubbleUIProp extends BubbleUIPropBase {
   type: 'text'
   value: Pick<TextBubbleProp, 'message'>
 }
 
-interface ImageBubbleUIProp extends BubbleUIPropBase {
+export interface ImageBubbleUIProp extends BubbleUIPropBase {
   type: 'images'
   value: Pick<ImageBubbleProp, 'images'>
 }
 
-interface RichBubbleUIProp extends BubbleUIPropBase {
+export interface RichBubbleUIProp extends BubbleUIPropBase {
   type: 'rich'
   value: Pick<RichBubbleProp, 'blocks'>
 }
 
-interface ProductBubbleUIProp extends BubbleUIPropBase {
+export interface ProductBubbleUIProp extends BubbleUIPropBase {
   type: 'product'
   value: Pick<ProductBubbleProp, 'product'>
 }
 
-type BubbleUIProps = (
+export type BubbleUIProps = (
   | TextBubbleUIProp
   | ImageBubbleUIProp
   | RichBubbleUIProp

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -11,9 +11,15 @@ import {
   TextBubbleProp,
 } from './type'
 import { ProductBubble } from './product'
-import BlindedBubble from './blinded'
+import AlteredBubble from './altered'
 
 export type BubbleType = 'text' | 'images' | 'rich' | 'product'
+
+const ALTERNATIVE_TEXT_MESSAGE = {
+  blinded: '관리자에 의해 삭제된 메세지입니다.',
+  deleted: '삭제된 메세지입니다.',
+  unfriended: '차단한 사용자의 메세지입니다.',
+}
 
 interface BubbleUIPropBase {
   type: BubbleType
@@ -48,7 +54,9 @@ type BubbleUIProps = (
   id: string
   my: boolean
   blinded?: boolean
-  blindedText?: string
+  deleted?: boolean
+  unfriended?: boolean
+  alternativeText?: string
   onBubbleClick?: BubbleProp['onClick']
   onImageBubbleClick?: ImageBubbleProp['onClick']
   onBubbleLongPress?: BubbleProp['onLongPress']
@@ -75,7 +83,9 @@ export default function BubbleUI({
   id,
   my,
   blinded,
-  blindedText,
+  deleted,
+  unfriended,
+  alternativeText,
   onBubbleClick,
   onImageBubbleClick,
   onBubbleLongPress,
@@ -88,12 +98,18 @@ export default function BubbleUI({
   hasArrow,
   css,
 }: BubbleUIProps) {
-  if (blinded) {
+  if (blinded || deleted || unfriended) {
     return (
-      <BlindedBubble
+      <AlteredBubble
         id={id}
         my={my}
-        blindedText={blindedText}
+        alternativeText={
+          alternativeText || unfriended
+            ? ALTERNATIVE_TEXT_MESSAGE.unfriended
+            : blinded
+            ? ALTERNATIVE_TEXT_MESSAGE.blinded
+            : ALTERNATIVE_TEXT_MESSAGE.deleted
+        }
         hasArrow={hasArrow}
         css={css}
       />

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -13,7 +13,9 @@ import {
 import { ProductBubble } from './product'
 import AlteredBubble from './altered'
 
-export type BubbleType = 'text' | 'images' | 'rich' | 'product'
+export const BubbleTypeArray = ['text', 'images', 'rich', 'product'] as const
+
+export type BubbleType = (typeof BubbleTypeArray)[number]
 
 const ALTERNATIVE_TEXT_MESSAGE = {
   blinded: '관리자에 의해 삭제된 메세지입니다.',

--- a/packages/chat/src/bubble/bubble.tsx
+++ b/packages/chat/src/bubble/bubble.tsx
@@ -29,7 +29,7 @@ const StyledBubble = styled(Text).attrs({
   ${({ maxWidthOffset }) =>
     `max-width: calc(100% - ${maxWidthOffset || 100}px);`}
   ${({ my, hasArrow = true }) => css`
-    background-color: ${my ? '#00BB92' : 'rgb(246,246,246)'};
+    background-color: ${my ? '#00BB92' : '#F6F6F6'};
     ${my && 'color:  var(--color-white);'}
     ${hasArrow &&
     (my ? 'border-top-right-radius: 4px;' : 'border-top-left-radius: 4px;')};

--- a/packages/chat/src/bubble/bubble.tsx
+++ b/packages/chat/src/bubble/bubble.tsx
@@ -5,11 +5,6 @@ import { useLongPress } from 'use-long-press'
 
 import { BubbleCSSProp, BubbleProp } from './type'
 
-const BACKGROUND_COLORS: { [key: string]: string } = {
-  mint: '#00BB92',
-  white: '#ffffff',
-}
-
 const StyledBubble = styled(Text).attrs({
   textAlign: 'left',
   inlineBlock: true,
@@ -34,7 +29,7 @@ const StyledBubble = styled(Text).attrs({
   ${({ maxWidthOffset }) =>
     `max-width: calc(100% - ${maxWidthOffset || 100}px);`}
   ${({ my, hasArrow = true }) => css`
-    background-color: ${BACKGROUND_COLORS[my ? 'mint' : 'white']};
+    background-color: ${my ? '#00BB92' : 'rgb(246,246,246)'};
     ${my && 'color:  var(--color-white);'}
     ${hasArrow &&
     (my ? 'border-top-right-radius: 4px;' : 'border-top-left-radius: 4px;')};

--- a/packages/chat/src/bubble/constants.ts
+++ b/packages/chat/src/bubble/constants.ts
@@ -1,0 +1,5 @@
+export const ALTERNATIVE_TEXT_MESSAGE = {
+  blinded: '관리자에 의해 삭제된 메세지입니다.',
+  deleted: '삭제된 메세지입니다.',
+  unfriended: '차단한 사용자의 메세지입니다.',
+}

--- a/packages/chat/src/bubble/type.ts
+++ b/packages/chat/src/bubble/type.ts
@@ -96,5 +96,5 @@ export type ProductBubbleProp = {
 
 export type BlindedBubbleProp = {
   my: boolean
-  blindedText?: string
+  alternativeText?: string
 } & BubbleProp

--- a/packages/chat/src/messages.stories.tsx
+++ b/packages/chat/src/messages.stories.tsx
@@ -11,7 +11,26 @@ export const Message = {
       {
         type: 'text',
         value: { message: '안녕하세요.' },
-        id: 'test',
+        id: 'text message',
+        sender: {
+          id: 'test user',
+          profile: {
+            name: 'test user',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1).toISOString(),
+      },
+      {
+        type: 'text',
+        value: {
+          message: '안녕하세요. 이 메시지는 삭제된 메시지 테스트용입니다.',
+        },
+        id: 'deleted message',
+        deleted: true,
         sender: {
           id: 'test user',
           profile: {
@@ -34,7 +53,7 @@ export const Message = {
               'https://media.triple.guide/triple-cms/c_limit,f_auto,w_1024/3ec44da6-ef5f-4804-bdd8-ab9aebc28e2b.jpeg',
           },
         },
-        id: 'test',
+        id: 'product message',
         sender: {
           id: 'test user',
           profile: {
@@ -50,7 +69,7 @@ export const Message = {
       {
         type: 'text',
         value: { message: '안녕하세요.' },
-        id: 'test',
+        id: 'my text message',
         sender: {
           id: 'test',
           profile: {
@@ -63,13 +82,91 @@ export const Message = {
         },
         createdAt: new Date(2022, 10, 1).toISOString(),
       },
+      {
+        type: 'images',
+        id: 'image message',
+        value: {
+          images: [
+            {
+              id: 'test image',
+              sizes: {
+                large: {
+                  url: 'https://res.cloudinary.com/triple-entry/image/upload/w_1024,h_1024,c_limit,f_auto/07f5ed9c-1102-4ec0-b07c-7b1b098311b2.jpg',
+                },
+              },
+            },
+          ],
+        },
+        sender: {
+          id: 'test user',
+          profile: {
+            name: 'test user',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1).toISOString(),
+      },
+      {
+        type: 'images',
+        id: 'image message2',
+        value: {
+          images: [
+            {
+              id: 'test image',
+              sizes: {
+                large: {
+                  url: 'https://res.cloudinary.com/triple-entry/image/upload/w_1024,h_1024,c_limit,f_auto/07f5ed9c-1102-4ec0-b07c-7b1b098311b2.jpg',
+                },
+              },
+            },
+            {
+              id: 'test image2',
+              sizes: {
+                large: {
+                  url: 'https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/be33afd8-c14b-4508-b1f9-8b36bfb29f64.jpeg',
+                },
+              },
+            },
+          ],
+        },
+        sender: {
+          id: 'test user',
+          profile: {
+            name: 'test user',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1).toISOString(),
+      },
     ],
-    pendingMessages: [],
+    pendingMessages: [
+      {
+        type: 'text',
+        value: { message: 'Pending Message' },
+        id: 'failed message',
+        sender: {
+          id: 'test',
+          profile: {
+            name: 'test',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+      },
+    ],
     failedMessages: [
       {
         type: 'text',
         value: { message: '안녕하세요.' },
-        id: 'test',
+        id: 'failed message',
         sender: {
           id: 'test',
           profile: {

--- a/packages/chat/src/messages.stories.tsx
+++ b/packages/chat/src/messages.stories.tsx
@@ -1,0 +1,94 @@
+import Messages from './messages'
+
+export default {
+  title: 'chat / Messages',
+  component: Messages,
+}
+
+export const Message = {
+  args: {
+    messages: [
+      {
+        type: 'text',
+        value: { message: '안녕하세요.' },
+        id: 'test',
+        sender: {
+          id: 'test user',
+          profile: {
+            name: 'test user',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1).toISOString(),
+      },
+      {
+        type: 'product',
+        value: {
+          product: {
+            customerBookingStatus: 'BOOKED',
+            productName: '상품 이름',
+            productThumbnail:
+              'https://media.triple.guide/triple-cms/c_limit,f_auto,w_1024/3ec44da6-ef5f-4804-bdd8-ab9aebc28e2b.jpeg',
+          },
+        },
+        id: 'test',
+        sender: {
+          id: 'test user',
+          profile: {
+            name: 'test user',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1).toISOString(),
+      },
+      {
+        type: 'text',
+        value: { message: '안녕하세요.' },
+        id: 'test',
+        sender: {
+          id: 'test',
+          profile: {
+            name: 'test',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1).toISOString(),
+      },
+    ],
+    pendingMessages: [],
+    failedMessages: [
+      {
+        type: 'text',
+        value: { message: '안녕하세요.' },
+        id: 'test',
+        sender: {
+          id: 'test',
+          profile: {
+            name: 'test',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+      },
+    ],
+    me: {
+      id: 'test',
+      profile: {
+        name: '테스트',
+        photo:
+          'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+      },
+    },
+  },
+}

--- a/packages/chat/src/messages.stories.tsx
+++ b/packages/chat/src/messages.stories.tsx
@@ -25,6 +25,22 @@ export const Message = {
         createdAt: new Date(2022, 10, 1).toISOString(),
       },
       {
+        type: 'another',
+        value: { text: 'Another Message.' },
+        id: 'another message',
+        sender: {
+          id: 'test user',
+          profile: {
+            name: 'test user',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1).toISOString(),
+      },
+      {
         type: 'text',
         value: {
           message: '안녕하세요. 이 메시지는 삭제된 메시지 테스트용입니다.',
@@ -185,6 +201,15 @@ export const Message = {
         name: '테스트',
         photo:
           'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+      },
+    },
+    customBubble: {
+      another: (message: { id: string; value: { text: string } }) => {
+        return (
+          <div key={message.id} css={{ display: 'inline-block' }}>
+            {message.value.text}
+          </div>
+        )
       },
     },
   },

--- a/packages/chat/src/messages.tsx
+++ b/packages/chat/src/messages.tsx
@@ -1,0 +1,45 @@
+import { ReactNode } from 'react'
+
+import { BubbleType } from './bubble/bubble-ui'
+
+const BubbleElement: { [key: string]: BubbleType } = {
+  blinded: 'blinded',
+  text: 'text',
+  images: 'images',
+  rich: 'rich',
+  product: 'product',
+}
+
+interface MessageInterface<
+  MessageId = string,
+  MessageType extends BubbleType = BubbleType,
+> {
+  id: MessageId
+  type: MessageType
+  key?: string
+}
+
+interface MessagesProp<
+  MessageId = string,
+  MessageType extends BubbleType = BubbleType,
+> {
+  messages: MessageInterface<MessageId, MessageType>[]
+  failedMessages: MessageInterface<MessageId, MessageType>[]
+  customBubble?: { [type: string]: ReactNode }
+  onRetry: () => void
+  onRetryCancel: () => void
+}
+
+export default function Messages({ messages, customBubble }: MessagesProp) {
+  return messages.map((message, idx) => {
+    const Bubble = BubbleElement[message.type]
+    const CustomBubble = customBubble?.[message.type]
+    const Element = Bubble || CustomBubble
+
+    if (!Element) {
+      throw new Error(`${message.type}에 일치하는 Bubble이 존재하지 않습니다.`)
+    }
+
+    return <div key={idx}>메시지</div>
+  })
+}

--- a/packages/chat/src/messages.tsx
+++ b/packages/chat/src/messages.tsx
@@ -1,3 +1,4 @@
+import BubbleContainer from './bubble-container/bubble-container'
 import BubbleUI, {
   ImageBubbleUIProp,
   ProductBubbleUIProp,
@@ -6,39 +7,95 @@ import BubbleUI, {
 } from './bubble/bubble-ui'
 import { UserInterface } from './types'
 
-type MessageInterface<MessageId = string, T = Record<string, never>> = {
-  id: MessageId
-  key?: string
-  sender: UserInterface
+interface MessageBase<User extends UserInterface> {
+  id: string | number
+  sender: User
+  createdAt?: string
   blinded?: boolean
   deleted?: boolean
-  unfriended?: boolean
-} & (
-  | TextBubbleUIProp
-  | ImageBubbleUIProp
-  | RichBubbleUIProp
-  | ProductBubbleUIProp
-) &
-  T
+}
+
+type MessageInterface<
+  Message extends MessageBase<User>,
+  User extends UserInterface,
+> = Message &
+  (
+    | TextBubbleUIProp
+    | ImageBubbleUIProp
+    | RichBubbleUIProp
+    | ProductBubbleUIProp
+  )
 
 interface MessagesProp<
-  MessageId extends string | number = string,
-  T = Record<string, never>,
+  Message extends MessageBase<User>,
+  User extends UserInterface,
 > {
-  messages: MessageInterface<MessageId, T>[]
-  failedMessages: MessageInterface<MessageId>[]
+  messages: MessageInterface<Message, User>[]
+  pendingMessages: MessageInterface<Message, User>[]
+  failedMessages: MessageInterface<Message, User>[]
   me: UserInterface
   onRetry?: () => void
   onRetryCancel?: () => void
 }
 
-export default function Messages<MessageId extends string | number = string>({
+export default function Messages<
+  Message extends MessageBase<User>,
+  User extends UserInterface,
+>({
   messages,
+  pendingMessages,
+  failedMessages,
   me,
-}: MessagesProp<MessageId>) {
-  return messages.map(({ id, sender, ...message }) => {
-    const my = sender.id === me.id
+  onRetry,
+  onRetryCancel,
+}: MessagesProp<Message, User>) {
+  function renderMessages(
+    type: 'normal' | 'failed' | 'pending',
+    messages: MessageInterface<Message, User>[],
+  ) {
+    return messages.map(({ id, sender, createdAt, ...message }) => {
+      const my = sender.id === me.id
 
-    return <BubbleUI key={id} id={id.toString()} my={my} {...message} />
-  })
+      return (
+        <BubbleContainer
+          key={id}
+          id={id.toString()}
+          my={my}
+          unreadCount={null}
+          createdAt={createdAt}
+          user={{
+            photo: sender.profile.photo,
+            name: sender.profile.name,
+            userId: sender.id,
+            unregistered: sender.unregistered,
+          }}
+          showInfo={message.type !== 'product'}
+          {...(type === 'failed' && {
+            onRetry,
+            onRetryCancel,
+          })}
+        >
+          <BubbleUI
+            key={id}
+            id={id.toString()}
+            my={my}
+            {...message}
+            unfriended={sender.unfriended}
+          />
+        </BubbleContainer>
+      )
+    })
+  }
+
+  return (
+    <>
+      <div id="messages_list">{renderMessages('normal', messages)}</div>
+      <div id="failed_messages_list">
+        {renderMessages('pending', pendingMessages)}
+      </div>
+      <div id="pending_messages_list">
+        {renderMessages('failed', failedMessages)}
+      </div>
+    </>
+  )
 }

--- a/packages/chat/src/messages.tsx
+++ b/packages/chat/src/messages.tsx
@@ -136,10 +136,10 @@ export default function Messages<
   return (
     <>
       <div id="messages_list">{renderMessages('normal', messages)}</div>
-      <div id="failed_messages_list">
+      <div id="pending_messages_list">
         {renderMessages('pending', pendingMessages)}
       </div>
-      <div id="pending_messages_list">
+      <div id="failed_messages_list">
         {renderMessages('failed', failedMessages)}
       </div>
     </>

--- a/packages/chat/src/messages.tsx
+++ b/packages/chat/src/messages.tsx
@@ -1,5 +1,6 @@
 import BubbleContainer from './bubble-container/bubble-container'
 import BubbleUI, {
+  BubbleUIProps,
   ImageBubbleUIProp,
   ProductBubbleUIProp,
   RichBubbleUIProp,
@@ -48,7 +49,12 @@ export default function Messages<
   me,
   onRetry,
   onRetryCancel,
-}: MessagesProp<Message, User>) {
+  ...bubbleProps
+}: MessagesProp<Message, User> &
+  Omit<
+    BubbleUIProps,
+    'id' | 'my' | 'blinded' | 'deleted' | 'unfriended' | 'type' | 'value'
+  >) {
   function renderMessages(
     type: 'normal' | 'failed' | 'pending',
     messages: MessageInterface<Message, User>[],
@@ -71,16 +77,21 @@ export default function Messages<
           }}
           showInfo={message.type !== 'product'}
           {...(type === 'failed' && {
-            onRetry,
-            onRetryCancel,
+            onRetry: () => {
+              onRetry?.()
+            },
+            onRetryCancel: () => {
+              onRetryCancel?.()
+            },
           })}
         >
           <BubbleUI
             key={id}
             id={id.toString()}
             my={my}
-            {...message}
             unfriended={sender.unfriended}
+            {...message}
+            {...bubbleProps}
           />
         </BubbleContainer>
       )

--- a/packages/chat/src/messages.tsx
+++ b/packages/chat/src/messages.tsx
@@ -1,44 +1,44 @@
-import { ReactNode } from 'react'
+import BubbleUI, {
+  ImageBubbleUIProp,
+  ProductBubbleUIProp,
+  RichBubbleUIProp,
+  TextBubbleUIProp,
+} from './bubble/bubble-ui'
+import { UserInterface } from './types'
 
-import { BubbleType } from './bubble/bubble-ui'
-
-const BubbleElement: { [key: string]: BubbleType } = {
-  text: 'text',
-  images: 'images',
-  rich: 'rich',
-  product: 'product',
-}
-
-interface MessageInterface<
-  MessageId = string,
-  MessageType extends BubbleType = BubbleType,
-> {
+type MessageInterface<MessageId = string, T = Record<string, never>> = {
   id: MessageId
-  type: MessageType
   key?: string
-}
+  sender: UserInterface
+  blinded?: boolean
+  deleted?: boolean
+  unfriended?: boolean
+} & (
+  | TextBubbleUIProp
+  | ImageBubbleUIProp
+  | RichBubbleUIProp
+  | ProductBubbleUIProp
+) &
+  T
 
 interface MessagesProp<
-  MessageId = string,
-  MessageType extends BubbleType = BubbleType,
+  MessageId extends string | number = string,
+  T = Record<string, never>,
 > {
-  messages: MessageInterface<MessageId, MessageType>[]
-  failedMessages: MessageInterface<MessageId, MessageType>[]
-  customBubble?: { [type: string]: ReactNode }
-  onRetry: () => void
-  onRetryCancel: () => void
+  messages: MessageInterface<MessageId, T>[]
+  failedMessages: MessageInterface<MessageId>[]
+  me: UserInterface
+  onRetry?: () => void
+  onRetryCancel?: () => void
 }
 
-export default function Messages({ messages, customBubble }: MessagesProp) {
-  return messages.map((message, idx) => {
-    const Bubble = BubbleElement[message.type]
-    const CustomBubble = customBubble?.[message.type]
-    const Element = Bubble || CustomBubble
+export default function Messages<MessageId extends string | number = string>({
+  messages,
+  me,
+}: MessagesProp<MessageId>) {
+  return messages.map(({ id, sender, ...message }) => {
+    const my = sender.id === me.id
 
-    if (!Element) {
-      throw new Error(`${message.type}에 일치하는 Bubble이 존재하지 않습니다.`)
-    }
-
-    return <div key={idx}>메시지</div>
+    return <BubbleUI key={id} id={id.toString()} my={my} {...message} />
   })
 }

--- a/packages/chat/src/messages.tsx
+++ b/packages/chat/src/messages.tsx
@@ -3,7 +3,6 @@ import { ReactNode } from 'react'
 import { BubbleType } from './bubble/bubble-ui'
 
 const BubbleElement: { [key: string]: BubbleType } = {
-  blinded: 'blinded',
   text: 'text',
   images: 'images',
   rich: 'rich',

--- a/packages/chat/src/messages.tsx
+++ b/packages/chat/src/messages.tsx
@@ -11,6 +11,8 @@ import BubbleUI, {
   TextBubbleUIProp,
 } from './bubble/bubble-ui'
 import { UserInterface } from './types'
+import AlteredBubble from './bubble/altered'
+import { ALTERNATIVE_TEXT_MESSAGE } from './bubble/constants'
 
 interface MessageBase<User extends UserInterface> {
   id: string | number
@@ -30,9 +32,8 @@ type MessageInterface<
     | RichBubbleUIProp
     | ProductBubbleUIProp
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    | { type: string; value: any }
+    | { type: string; value?: any }
   )
-//
 
 interface MessagesProp<
   Message extends MessageBase<User>,
@@ -72,9 +73,26 @@ export default function Messages<
     message: MessageInterface<Message, User>
     my: boolean
   }) {
-    const { id, sender, type, value, ...rest } = message
+    const { id, sender, type, value, blinded, deleted, ...rest } = message
+
     const CustomBubble = customBubble?.[type]
     if (CustomBubble) {
+      if (blinded || deleted || sender.unfriended) {
+        return (
+          <AlteredBubble
+            key={id}
+            id={id.toString()}
+            my={my}
+            alternativeText={
+              sender.unfriended
+                ? ALTERNATIVE_TEXT_MESSAGE.unfriended
+                : blinded
+                ? ALTERNATIVE_TEXT_MESSAGE.blinded
+                : ALTERNATIVE_TEXT_MESSAGE.deleted
+            }
+          />
+        )
+      }
       return <CustomBubble {...message} />
     }
 
@@ -87,6 +105,8 @@ export default function Messages<
         key={id}
         id={id.toString()}
         my={my}
+        blinded={blinded}
+        deleted={deleted}
         unfriended={sender.unfriended}
         type={type}
         value={value}

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -81,16 +81,17 @@ export interface MessageInterface {
 
 export interface UserInterface {
   id: string
-  type: UserType
-  code: string
+  // type: UserType
+  // code: string
   profile: ProfileInterface
-  identifier: string
+  unregistered?: boolean
+  unfriended?: boolean
+  // identifier: string
 }
 
 export interface ProfileInterface {
   name: string
-  thumbnail: string
-  message: string
+  photo: string
 }
 
 export interface UserAgentProps {

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -81,12 +81,9 @@ export interface MessageInterface {
 
 export interface UserInterface {
   id: string
-  // type: UserType
-  // code: string
   profile: ProfileInterface
   unregistered?: boolean
   unfriended?: boolean
-  // identifier: string
 }
 
 export interface ProfileInterface {

--- a/packages/chat/src/utils/image.ts
+++ b/packages/chat/src/utils/image.ts
@@ -1,8 +1,8 @@
 import { UserInterface, MetaDataInterface } from '../types'
 
 export function getProfileImageUrl(user: UserInterface) {
-  if (user.profile.thumbnail) {
-    return user.profile.thumbnail
+  if (user.profile.photo) {
+    return user.profile.photo
   } else {
     let imageNumber = 0
     try {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

메시지 리스트를 렌더링하는 Messages 컴포넌트 생성합니다. `messages`, `pendingMessages`, `failedMessages`를 prop으로 전달 시 각 메시지들을 타입에 맞는 Bubble과 함께 렌더링합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- `ContainerBaseProp` 타입 생성
- `BlindedBubble`에서 `AlteredBubble`로 변경
  -  블라인드 된 / 삭제한 / 차단한 사용자의 메시지의 UI를 한 번에 처리하기 위해 `AlteredBubble`로 변경
- `Messages` 컴포넌트 생성
  - `CustomBubble`로 prop 전달 시 TF에서 제공하는 `'text' | 'images' | 'rich' | 'product'`가 아닌 type의 메시지도 렌더링 가능. 스토리북 참고
  - 
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
