### PR TITLE
[Chat refactor] Bubble의 default click 설정

### DIFF
--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -55,6 +55,8 @@
   },
   "devDependencies": {
     "@titicaca/react-contexts": "workspace:*",
+    "@titicaca/i18n": "workspace:*",
+    "@titicaca/next-i18next": "13.8.5",
     "@types/isomorphic-fetch": "^0.0.38",
     "react": "^18.2.0",
     "styled-components": "^5.3.11"

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -43,6 +43,8 @@
     "@titicaca/color-palette": "workspace:*",
     "@titicaca/core-elements": "workspace:*",
     "@titicaca/intersection-observer": "workspace:*",
+    "@titicaca/react-triple-client-interfaces": "workspace:*",
+    "@titicaca/router": "workspace:*",
     "@titicaca/triple-fallback-action": "workspace:*",
     "@titicaca/triple-web-to-native-interfaces": "1.9.0",
     "@titicaca/type-definitions": "workspace:*",

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -70,6 +70,7 @@ export type BubbleUIProps = (
   maxWidthOffset?: BubbleProp['maxWidthOffset']
   cloudinaryName?: string
   mediaUrlBase?: string
+  appUrlScheme?: string
   hasArrow?: boolean
   css?: CSSProp
 }
@@ -92,6 +93,7 @@ export default function BubbleUI({
   maxWidthOffset,
   cloudinaryName,
   mediaUrlBase,
+  appUrlScheme,
   hasArrow,
   css,
 }: BubbleUIProps) {
@@ -130,6 +132,7 @@ export default function BubbleUI({
       return (
         <ImageBubble
           images={value.images}
+          appUrlScheme={appUrlScheme}
           onClick={onImageBubbleClick}
           onLongPress={onImageBubbleLongPress}
           css={css}
@@ -171,8 +174,6 @@ export default function BubbleUI({
           css={css}
         />
       )
-    //   case MessageType.DELETED:
-    //     return <DeletedBubble />
     default:
       throw new Error('지원하지 않는 메시지 타입입니다.')
   }

--- a/packages/chat/src/bubble/image.tsx
+++ b/packages/chat/src/bubble/image.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { useLongPress } from 'use-long-press'
 
 import { MetaDataInterface } from '../types'
+import { navigateToImage } from '../utils'
 
 import { ImageItem } from './item'
 import { ImageBubbleProp } from './type'
@@ -17,7 +18,12 @@ const ImageRow = styled.div`
 
 const MAX_IMAGE_WIDTH = 247
 
-export function ImageBubble({ images, onClick, onLongPress }: ImageBubbleProp) {
+export function ImageBubble({
+  images,
+  appUrlScheme,
+  onClick,
+  onLongPress,
+}: ImageBubbleProp) {
   const allocatedImages = allocateImages(images)
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
@@ -44,7 +50,11 @@ export function ImageBubble({ images, onClick, onLongPress }: ImageBubbleProp) {
               key={image.id}
               src={image.sizes.large.url}
               onClick={(e) => {
-                onClick?.(e, images, image.index)
+                if (onClick) {
+                  onClick?.(e, images, image.index)
+                } else if (appUrlScheme) {
+                  navigateToImage({ appUrlScheme, images, index })
+                }
               }}
               css={
                 images.length === 2 || images.length === 4

--- a/packages/chat/src/bubble/text.tsx
+++ b/packages/chat/src/bubble/text.tsx
@@ -1,3 +1,5 @@
+import useATagNavigator from '../utils/a-tag-navigator'
+
 import { TextItem } from './item'
 import { Bubble } from './bubble'
 import { TextBubbleProp } from './type'
@@ -40,9 +42,11 @@ function getDefaultBackgroundColor(my: boolean) {
  */
 
 export function TextBubble({ message, ...props }: TextBubbleProp) {
+  const aTagNavigator = useATagNavigator()
+
   return (
     <Bubble {...props}>
-      <TextItem text={message} />
+      <TextItem text={message} onClick={(e) => aTagNavigator(e)} />
     </Bubble>
   )
 }

--- a/packages/chat/src/bubble/type.ts
+++ b/packages/chat/src/bubble/type.ts
@@ -81,6 +81,7 @@ export type RichBubbleProp = {
 
 export interface ImageBubbleProp {
   images: MetaDataInterface[]
+  appUrlScheme?: string
   onClick?: (
     e: MouseEvent,
     images: MetaDataInterface[],

--- a/packages/chat/src/i18n.d.ts
+++ b/packages/chat/src/i18n.d.ts
@@ -1,0 +1,11 @@
+import '@titicaca/next-i18next'
+import { I18nCommonWebKeys } from '@titicaca/i18n'
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'common-web'
+    resources: {
+      'common-web': I18nCommonWebKeys
+    }
+  }
+}

--- a/packages/chat/src/messages.tsx
+++ b/packages/chat/src/messages.tsx
@@ -45,8 +45,8 @@ interface MessagesProp<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   customBubble?: { [key: string]: ComponentType<any> }
   me: UserInterface
-  onRetry?: () => void
-  onRetryCancel?: () => void
+  onRetry?: (message: MessageInterface<Message, User>) => void
+  onRetryCancel?: (message: MessageInterface<Message, User>) => void
 }
 
 export default function Messages<
@@ -140,10 +140,10 @@ export default function Messages<
           showInfo={type !== 'product'}
           {...(listType === 'failed' && {
             onRetry: () => {
-              onRetry?.()
+              onRetry?.(message)
             },
             onRetryCancel: () => {
-              onRetryCancel?.()
+              onRetryCancel?.(message)
             },
           })}
         >

--- a/packages/chat/src/utils/a-tag-navigator.ts
+++ b/packages/chat/src/utils/a-tag-navigator.ts
@@ -1,11 +1,10 @@
-import { useExternalHrefHandler } from '@titicaca/router/src/external/href-handler'
 import { MouseEvent } from 'react'
 import { useEnv } from '@titicaca/react-contexts'
-import { useHrefToProps } from '@titicaca/router'
+import { useExternalRouter, useHrefToProps } from '@titicaca/router'
 import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 
 export default function useATagNavigator() {
-  const handleHrefExternally = useExternalHrefHandler()
+  const routeExternally = useExternalRouter()
   const { webUrlBase } = useEnv()
   const convertHrefToProps = useHrefToProps()
   const app = useTripleClientMetadata()
@@ -22,14 +21,10 @@ export default function useATagNavigator() {
           : originHref
 
       if (href) {
-        handleHrefExternally({
+        routeExternally({
           href,
           target: 'new',
           noNavbar: true,
-          stopDefaultHandler: () => {
-            event.preventDefault()
-            event.stopPropagation()
-          },
         })
       }
     }

--- a/packages/chat/src/utils/a-tag-navigator.ts
+++ b/packages/chat/src/utils/a-tag-navigator.ts
@@ -1,0 +1,39 @@
+import { useExternalHrefHandler } from '@titicaca/router/src/external/href-handler'
+import { MouseEvent } from 'react'
+import { useEnv } from '@titicaca/react-contexts'
+import { useHrefToProps } from '@titicaca/router'
+import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
+
+export default function useATagNavigator() {
+  const handleHrefExternally = useExternalHrefHandler()
+  const { webUrlBase } = useEnv()
+  const convertHrefToProps = useHrefToProps()
+  const app = useTripleClientMetadata()
+
+  const aTagNavigator = (event: MouseEvent) => {
+    const eventTarget = event.target as HTMLElement
+
+    if (eventTarget.tagName === 'A') {
+      const originHref = eventTarget.getAttribute('href') ?? ''
+
+      const href =
+        originHref.includes(webUrlBase) && app
+          ? convertHrefToProps(originHref).href
+          : originHref
+
+      if (href) {
+        handleHrefExternally({
+          href,
+          target: 'new',
+          noNavbar: true,
+          stopDefaultHandler: () => {
+            event.preventDefault()
+            event.stopPropagation()
+          },
+        })
+      }
+    }
+  }
+
+  return aTagNavigator
+}

--- a/packages/chat/src/utils/image.ts
+++ b/packages/chat/src/utils/image.ts
@@ -1,3 +1,7 @@
+import qs from 'querystring'
+
+import { generateUrl } from '@titicaca/view-utilities'
+
 import { UserInterface, MetaDataInterface } from '../types'
 
 export function getProfileImageUrl(user: UserInterface) {
@@ -36,4 +40,20 @@ export function generatePreviewImage({
     width,
     customWidth,
   )},q_auto,f_auto/${cloudinaryId}.jpeg`
+}
+
+export function navigateToImage({
+  appUrlScheme,
+  images,
+  index = 0,
+}: {
+  appUrlScheme: string
+  images: MetaDataInterface[]
+  index?: number
+}) {
+  window.location.href = generateUrl({
+    scheme: appUrlScheme,
+    path: '/images',
+    query: qs.stringify({ images: JSON.stringify(images), index }),
+  })
 }

--- a/packages/chat/src/utils/index.ts
+++ b/packages/chat/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './image'
+export { default as useATagNavigator } from './a-tag-navigator'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,12 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0(react@18.2.0)
     devDependencies:
+      '@titicaca/i18n':
+        specifier: workspace:*
+        version: link:../i18n
+      '@titicaca/next-i18next':
+        specifier: 13.8.5
+        version: 13.8.5(i18next@22.5.1)(next@13.4.13)(react-i18next@12.3.1)(react@18.2.0)
       '@titicaca/react-contexts':
         specifier: workspace:*
         version: link:../react-contexts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,6 +412,12 @@ importers:
       '@titicaca/intersection-observer':
         specifier: workspace:*
         version: link:../intersection-observer
+      '@titicaca/react-triple-client-interfaces':
+        specifier: workspace:*
+        version: link:../react-triple-client-interfaces
+      '@titicaca/router':
+        specifier: workspace:*
+        version: link:../router
       '@titicaca/triple-fallback-action':
         specifier: workspace:*
         version: link:../triple-fallback-action


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
`ImageBubble`과 `TextBubble, RichBubble` 내의 a tag의 default click 이벤트를 설정합니다. `ImageBubble`의 경우 앱 내에서 이미지를 클릭 시 이미지 확대뷰를 노출합니다. `TextBubble, RichBubble` 내의 a tag 클릭 시 해당 링크를 오픈합니다. 
`a-tag-navigator.ts` 기능을 개발하면서 사용한 router 패키지에서 `i18n.d.ts` 파일을 요구해 이를 추가합니다. 해당 파일에서 import 중인 패키지들을 devDependency에 추가합니다.

`Messages` 컴포넌트에서 onRetry, onRetryCancel 클릭 이벤트를 전달합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
