### PR TITLE
[v14] react-contexts/images-context를 poi-detail/ImageCarouselProvider로 이동

### DIFF
--- a/packages/tds-widget/src/poi-detail/image-carousel/provider.tsx
+++ b/packages/tds-widget/src/poi-detail/image-carousel/provider.tsx
@@ -1,0 +1,196 @@
+import {
+  createContext,
+  useContext,
+  PropsWithChildren,
+  useMemo,
+  useCallback,
+  useReducer,
+  useEffect,
+} from 'react'
+import qs from 'qs'
+import { ImageMeta } from '@titicaca/type-definitions'
+import { get } from '@titicaca/fetcher'
+
+import reducer, {
+  loadImagesRequest,
+  loadImagesSuccess,
+  loadImagesFail,
+  reinitializeImages,
+} from './reducer'
+
+interface ImageCarouselContext {
+  images: ImageMeta[]
+  total: number
+  loading: boolean
+  actions: {
+    fetch: (cb?: () => void) => Promise<void>
+    reFetch: (cb?: () => void) => Promise<void>
+    indexOf: (target: { id: string }) => Promise<number>
+  }
+}
+
+export interface ImageCarouselProviderProps extends PropsWithChildren {
+  source: {
+    id: string
+    type: 'attraction' | 'restaurant' | 'hotel'
+  }
+  images?: ImageMeta[]
+  total?: number
+}
+
+const Context = createContext<ImageCarouselContext>({
+  images: [],
+  total: 0,
+  loading: false,
+  actions: {
+    fetch: () => Promise.resolve(),
+    reFetch: () => Promise.resolve(),
+    indexOf: () => Promise.resolve(-1),
+  },
+})
+
+const TYPE_MAPPING = {
+  attraction: 'poi',
+  restaurant: 'poi',
+  hotel: 'hotel',
+}
+
+export function ImageCarouselProvider({
+  images: initialImages,
+  total: initialTotal,
+  source: { id, type },
+  children,
+}: ImageCarouselProviderProps) {
+  const [{ loading, images, total, hasMore }, dispatch] = useReducer(reducer, {
+    loading: !initialImages,
+    images: initialImages || [],
+    total: initialTotal || 0,
+    hasMore: true,
+  })
+
+  const sendFetchRequest = useCallback(
+    async (size = 15) => {
+      const response = await fetchImages(
+        { type: TYPE_MAPPING[type] || type, id },
+        { from: images.length, size },
+      )
+
+      return response
+    },
+    [id, images.length, type],
+  )
+
+  const reFetch = useCallback(async () => {
+    if (loading) {
+      return
+    }
+
+    dispatch(loadImagesRequest())
+
+    try {
+      const { data: fetchedImages, total } = await fetchImages(
+        { type: TYPE_MAPPING[type] || type, id },
+        { from: 0, size: 15 },
+      )
+
+      dispatch(
+        reinitializeImages({
+          images: fetchedImages,
+          total,
+        }),
+      )
+    } catch (error) {
+      dispatch(loadImagesFail(error))
+    }
+  }, [loading, id, type])
+
+  const fetch = useCallback(
+    async (onFetchAfter?: () => void, force?: boolean) => {
+      if (!force && (loading || !hasMore)) {
+        return
+      }
+
+      dispatch(loadImagesRequest())
+
+      try {
+        const { data: fetchedImages, total } = await sendFetchRequest()
+
+        if (fetchedImages) {
+          dispatch(loadImagesSuccess({ images: fetchedImages, total }))
+        } else {
+          throw new Error('Response has no data property')
+        }
+      } catch (error) {
+        dispatch(loadImagesFail(error))
+      }
+
+      onFetchAfter && onFetchAfter()
+    },
+    [hasMore, loading, sendFetchRequest],
+  )
+
+  const indexOf = useCallback(
+    async ({ id: targetId }: { id: string }) => {
+      const index = images.findIndex(({ id }) => id === targetId)
+      if (index >= 0) {
+        return index
+      }
+
+      // Just fetch 30 more images to check index of clicked image.
+      // Ignore the case of unfindable image in these 45(15 + 30) images.
+      const { data: fetchedImages } = await sendFetchRequest(30)
+
+      return fetchedImages
+        ? [...images, ...fetchedImages].findIndex(({ id }) => id === targetId)
+        : -1
+    },
+    [images, sendFetchRequest],
+  )
+
+  useEffect(() => {
+    fetch(undefined, true)
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const value = useMemo(
+    () => ({
+      images,
+      total,
+      actions: {
+        fetch,
+        reFetch,
+        indexOf,
+      },
+      loading,
+    }),
+    [fetch, images, indexOf, total, loading, reFetch],
+  )
+
+  return <Context.Provider value={value}>{children}</Context.Provider>
+}
+
+async function fetchImages(
+  target: { type: string; id: string },
+  query: { from: number; size: number },
+) {
+  const querystring = qs.stringify({
+    resourceType: target.type,
+    resourceId: target.id,
+    from: query.from,
+    size: query.size,
+  })
+
+  const response = await get<{ data: ImageMeta[]; total: number }>(
+    `/api/content/images?${querystring}`,
+  )
+
+  if (response.ok === true) {
+    const { parsedBody } = response
+    return parsedBody
+  } else {
+    throw new Error(`Failed to fetch images`)
+  }
+}
+
+export function useImageCarousel() {
+  return useContext(Context)
+}

--- a/packages/tds-widget/src/poi-detail/image-carousel/reducer.ts
+++ b/packages/tds-widget/src/poi-detail/image-carousel/reducer.ts
@@ -1,0 +1,86 @@
+import { ImageMeta } from '@titicaca/type-definitions'
+
+interface ImagesState {
+  loading: boolean
+  images: ImageMeta[]
+  total: number
+  hasMore: boolean
+}
+
+const REINITIALIZE_IMAGES = 'INITIALIZE_IMAGES'
+const LOAD_IMAGES_REQUEST = 'LOAD_IMAGES_REQUEST'
+const LOAD_IMAGES_SUCCESS = 'LOAD_IMAGES_SUCCESS'
+const LOAD_IMAGES_FAIL = 'LOAD_IMAGES_FAIL'
+
+export function loadImagesRequest() {
+  return {
+    type: LOAD_IMAGES_REQUEST,
+  } as const
+}
+
+export function loadImagesSuccess(payload: {
+  images: ImageMeta[]
+  total: number
+}) {
+  return {
+    type: LOAD_IMAGES_SUCCESS,
+    payload,
+  } as const
+}
+
+export function loadImagesFail(error: unknown) {
+  return {
+    type: LOAD_IMAGES_FAIL,
+    error: true,
+    payload: error,
+  } as const
+}
+
+export function reinitializeImages(payload: {
+  images: ImageMeta[]
+  total: number
+}) {
+  return {
+    type: REINITIALIZE_IMAGES,
+    payload,
+  } as const
+}
+
+export default function reducer(
+  state: ImagesState,
+  action: ReturnType<
+    | typeof loadImagesRequest
+    | typeof loadImagesSuccess
+    | typeof loadImagesFail
+    | typeof reinitializeImages
+  >,
+): ImagesState {
+  switch (action.type) {
+    case REINITIALIZE_IMAGES:
+      return {
+        loading: !action.payload.images,
+        images: action.payload.images,
+        total: action.payload.total,
+        hasMore: true,
+      }
+    case LOAD_IMAGES_REQUEST:
+      return {
+        ...state,
+        loading: true,
+      }
+    case LOAD_IMAGES_SUCCESS:
+      return {
+        loading: false,
+        images: state.images.concat(action.payload.images),
+        total: action.payload.total,
+        hasMore: action.payload.images.length > 0,
+      }
+    case LOAD_IMAGES_FAIL:
+      return {
+        ...state,
+        loading: false,
+      }
+    default:
+      return state
+  }
+}

--- a/packages/tds-widget/src/poi-detail/index.ts
+++ b/packages/tds-widget/src/poi-detail/index.ts
@@ -1,5 +1,10 @@
 export { default as Actions } from './actions'
 export { default as DetailHeader } from './detail-header'
 export { default as ImageCarousel } from './image-carousel'
+export {
+  ImageCarouselProvider,
+  ImageCarouselProviderProps,
+  useImageCarousel,
+} from './image-carousel/provider'
 export { default as RecommendedArticles } from './recommended-articles'
 export { default as DetailHeaderV2 } from './detail-header-v2'


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

react-contexts/images-context를 poi-detail/ImageCarouselProvider로 이동

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- react-contexts/images-context는 사실상 poi-detail/ImageCarousel과 한 세트기 때문에 images-context를 poi-detail로 옮기고 `ImageCarouselProvider`로 이름을 바꿉니다.
- `useImagesContext`를 `useImageCarousel`로 이름을 바꿉니다.
- hoc를 제거합니다.