### PR TITLE
[Chat] 좋아요 기능 추가

### DIFF
--- a/packages/chat/src/chat-bubble/bubble-info.tsx
+++ b/packages/chat/src/chat-bubble/bubble-info.tsx
@@ -30,7 +30,7 @@ export function BubbleInfo({
 
   return (
     <BubbleInfoContainer position="relative" display="inline-block" {...props}>
-      {thanks ? (
+      {thanks && onThanksClick ? (
         <Thanks
           count={thanks.count}
           haveMine={thanks.haveMine}

--- a/packages/chat/src/chat-bubble/bubble-info.tsx
+++ b/packages/chat/src/chat-bubble/bubble-info.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import styled from 'styled-components'
-import { Button, Container, Text } from '@titicaca/core-elements'
+import { Container, Text } from '@titicaca/core-elements'
 
 const BubbleInfoContainer = styled(Container)`
   vertical-align: bottom;
@@ -16,28 +16,16 @@ moment.locale('ko')
 export function BubbleInfo({
   unreadCount,
   date,
-  thanks,
-  onThanksClick,
   ...props
 }: {
   unreadCount: number | null
   date: string
-  thanks?: { count: number; haveMine: boolean }
-  onThanksClick?: () => void
 }) {
   const showDate = !moment().isSame(date, 'day')
   const showYear = !moment().isSame(date, 'year')
 
   return (
     <BubbleInfoContainer position="relative" display="inline-block" {...props}>
-      {thanks && onThanksClick ? (
-        <Thanks
-          count={thanks.count}
-          haveMine={thanks.haveMine}
-          onClick={onThanksClick}
-        />
-      ) : null}
-
       {unreadCount ? (
         <UnreadMessageCountText>{unreadCount}</UnreadMessageCountText>
       ) : null}
@@ -52,37 +40,5 @@ export function BubbleInfo({
         {moment(date).format('A hh:mm')}
       </Text>
     </BubbleInfoContainer>
-  )
-}
-
-const ThanksButton = styled(Button)<{ haveMine: boolean }>`
-  display: flex;
-  gap: 4px;
-  align-items: center;
-  background-color: ${({ haveMine }) =>
-    haveMine ? 'var(--color-white)' : 'var(--color-gray50)'};
-  color: ${({ haveMine }) => (haveMine ? '#1DBEB2' : 'var(--color-gray700)')};
-  ${({ haveMine }) => (haveMine ? 'border: 1px solid #1DBEB2' : '')};
-  padding: 3.5px 8px 4.5px 8px;
-  font-weight: normal;
-`
-
-function Thanks({
-  count,
-  haveMine,
-  onClick,
-}: {
-  count: number
-  haveMine: boolean
-  onClick?: () => void
-}) {
-  return (
-    <ThanksButton haveMine={haveMine} onClick={() => onClick?.()}>
-      <img
-        src="https://assets.triple-dev.titicaca-corp.com/images/ic_chat_thumbsup_on.svg"
-        alt="좋아요 아이콘"
-      />
-      {count === 0 ? null : count}
-    </ThanksButton>
   )
 }

--- a/packages/chat/src/chat-bubble/bubble-info.tsx
+++ b/packages/chat/src/chat-bubble/bubble-info.tsx
@@ -16,16 +16,22 @@ moment.locale('ko')
 export function BubbleInfo({
   unreadCount,
   date,
+  thanks,
   ...props
 }: {
   unreadCount: number | null
   date: string
+  thanks?: { count: number; haveMine: boolean }
 }) {
   const showDate = !moment().isSame(date, 'day')
   const showYear = !moment().isSame(date, 'year')
 
   return (
     <BubbleInfoContainer position="relative" display="inline-block" {...props}>
+      {thanks ? (
+        <Thanks count={thanks.count} haveMine={thanks.haveMine} />
+      ) : null}
+
       {unreadCount ? (
         <UnreadMessageCountText>{unreadCount}</UnreadMessageCountText>
       ) : null}
@@ -41,4 +47,8 @@ export function BubbleInfo({
       </Text>
     </BubbleInfoContainer>
   )
+}
+
+function Thanks({ count, haveMine }: { count: number; haveMine: boolean }) {
+  return <Text css={{ color: haveMine ? 'pink' : 'black' }}>{count}</Text>
 }

--- a/packages/chat/src/chat-bubble/bubble-info.tsx
+++ b/packages/chat/src/chat-bubble/bubble-info.tsx
@@ -55,6 +55,18 @@ export function BubbleInfo({
   )
 }
 
+const ThanksButton = styled(Button)<{ haveMine: boolean }>`
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  background-color: ${({ haveMine }) =>
+    haveMine ? 'var(--color-white)' : 'var(--color-gray50)'};
+  color: ${({ haveMine }) => (haveMine ? '#1DBEB2' : 'var(--color-gray700)')};
+  ${({ haveMine }) => (haveMine ? 'border: 1px solid #1DBEB2' : '')};
+  padding: 3.5px 8px 4.5px 8px;
+  font-weight: normal;
+`
+
 function Thanks({
   count,
   haveMine,
@@ -65,11 +77,12 @@ function Thanks({
   onClick?: () => void
 }) {
   return (
-    <Button
-      css={{ color: haveMine ? 'pink' : 'black' }}
-      onClick={() => onClick?.()}
-    >
-      {count}
-    </Button>
+    <ThanksButton haveMine={haveMine} onClick={() => onClick?.()}>
+      <img
+        src="https://assets.triple-dev.titicaca-corp.com/images/ic_chat_thumbsup_on.svg"
+        alt="좋아요 아이콘"
+      />
+      {count === 0 ? null : count}
+    </ThanksButton>
   )
 }

--- a/packages/chat/src/chat-bubble/bubble-info.tsx
+++ b/packages/chat/src/chat-bubble/bubble-info.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import styled from 'styled-components'
-import { Container, Text } from '@titicaca/core-elements'
+import { Button, Container, Text } from '@titicaca/core-elements'
 
 const BubbleInfoContainer = styled(Container)`
   vertical-align: bottom;
@@ -17,11 +17,13 @@ export function BubbleInfo({
   unreadCount,
   date,
   thanks,
+  onThanksClick,
   ...props
 }: {
   unreadCount: number | null
   date: string
   thanks?: { count: number; haveMine: boolean }
+  onThanksClick?: () => void
 }) {
   const showDate = !moment().isSame(date, 'day')
   const showYear = !moment().isSame(date, 'year')
@@ -29,7 +31,11 @@ export function BubbleInfo({
   return (
     <BubbleInfoContainer position="relative" display="inline-block" {...props}>
       {thanks ? (
-        <Thanks count={thanks.count} haveMine={thanks.haveMine} />
+        <Thanks
+          count={thanks.count}
+          haveMine={thanks.haveMine}
+          onClick={onThanksClick}
+        />
       ) : null}
 
       {unreadCount ? (
@@ -49,6 +55,21 @@ export function BubbleInfo({
   )
 }
 
-function Thanks({ count, haveMine }: { count: number; haveMine: boolean }) {
-  return <Text css={{ color: haveMine ? 'pink' : 'black' }}>{count}</Text>
+function Thanks({
+  count,
+  haveMine,
+  onClick,
+}: {
+  count: number
+  haveMine: boolean
+  onClick?: () => void
+}) {
+  return (
+    <Button
+      css={{ color: haveMine ? 'pink' : 'black' }}
+      onClick={() => onClick?.()}
+    >
+      {count}
+    </Button>
+  )
 }

--- a/packages/chat/src/chat-bubble/chat-bubble-ui.stories.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.stories.tsx
@@ -40,7 +40,7 @@ export const Text = {
     unreadCount: 1,
     createdAt: new Date(2022, 10, 1).toISOString(),
     profileName: '테스트계정',
-    thanks: { count: 1, haveMine: true },
+    thanks: { count: 1, haveMine: false },
   },
 }
 

--- a/packages/chat/src/chat-bubble/chat-bubble-ui.stories.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.stories.tsx
@@ -40,6 +40,7 @@ export const Text = {
     unreadCount: 1,
     createdAt: new Date(2022, 10, 1).toISOString(),
     profileName: '테스트계정',
+    thanks: { count: 1, haveMine: true },
   },
 }
 

--- a/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
@@ -190,6 +190,8 @@ export function ChatBubbleUI({
   onThanksClick,
   bubbleStyle,
 }: ChatBubbleUIProps) {
+  const showThanks = !blindedAt
+
   switch (type) {
     case 'sent': {
       const sentBubbleStyle = bubbleStyle?.sent
@@ -199,8 +201,7 @@ export function ChatBubbleUI({
           showBubbleInfo={payload.type !== MessageType.PRODUCT}
           unreadCount={unreadCount}
           onRetry={onRetry}
-          thanks={thanks}
-          onThanksClick={onThanksClick}
+          {...(showThanks && { thanks, onThanksClick })}
         >
           {blindedAt ? (
             <BlindedBubble
@@ -245,8 +246,7 @@ export function ChatBubbleUI({
           showBubbleInfo={payload.type !== MessageType.PRODUCT}
           profileImageUrl={profileImageUrl}
           profileName={profileName}
-          thanks={thanks}
-          onThanksClick={onThanksClick}
+          {...(showThanks && { thanks, onThanksClick })}
         >
           {blindedAt ? (
             <BlindedBubble

--- a/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
@@ -61,41 +61,42 @@ function SentChatContainer({
         ...CHAT_CONTAINER_STYLES,
       }}
     >
-      {!createdAt ? (
-        <SendingFailureHandlerContainer>
-          <RetryButton
-            onClick={async () => {
-              if (await onRetry?.()) {
-                setShow(false)
-              }
-            }}
-          />
-          <DeleteButton
-            onClick={() => {
-              onCancel?.()
-              setShow(false)
-            }}
-          />
-        </SendingFailureHandlerContainer>
-      ) : (
-        <>
-          {showBubbleInfo && (
-            <BubbleInfo
-              unreadCount={unreadCount}
-              date={createdAt}
-              css={{ marginRight: 8, textAlign: 'right' }}
+      <div>
+        {!createdAt ? (
+          <SendingFailureHandlerContainer>
+            <RetryButton
+              onClick={async () => {
+                if (await onRetry?.()) {
+                  setShow(false)
+                }
+              }}
             />
-          )}
-        </>
-      )}
-
-      {children}
+            <DeleteButton
+              onClick={() => {
+                onCancel?.()
+                setShow(false)
+              }}
+            />
+          </SendingFailureHandlerContainer>
+        ) : (
+          <>
+            {showBubbleInfo && (
+              <BubbleInfo
+                unreadCount={unreadCount}
+                date={createdAt}
+                css={{ marginRight: 8, textAlign: 'right' }}
+              />
+            )}
+          </>
+        )}
+        {children}
+      </div>
       {thanks && onThanksClick ? (
         <Thanks
           count={thanks.count}
           haveMine={thanks.haveMine}
           onClick={onThanksClick}
-          css={{ position: 'absolute', right: 10, marginTop: 6 }}
+          css={{ display: 'inline-flex', marginTop: 6, marginRight: 10 }}
         />
       ) : null}
     </Container>

--- a/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
@@ -33,6 +33,7 @@ function SentChatContainer({
   unreadCount,
   onRetry,
   onCancel,
+  thanks,
   children,
   showBubbleInfo,
 }: PropsWithChildren<{
@@ -40,6 +41,7 @@ function SentChatContainer({
   unreadCount: number | null
   onRetry?: () => Promise<boolean> | undefined
   onCancel?: () => void
+  thanks?: { count: number; haveMine: boolean }
   showBubbleInfo: boolean
 }>) {
   const [show, setShow] = useState<boolean>(true)
@@ -68,6 +70,7 @@ function SentChatContainer({
             <BubbleInfo
               unreadCount={unreadCount}
               date={createdAt}
+              thanks={thanks}
               css={{ marginRight: 8, textAlign: 'right' }}
             />
           )}
@@ -84,6 +87,7 @@ function ReceivedChatContainer({
   profileName,
   unreadCount,
   createdAt,
+  thanks,
   showBubbleInfo,
   children,
 }: {
@@ -92,6 +96,7 @@ function ReceivedChatContainer({
   unreadCount: number | null
   createdAt?: string
   showBubbleInfo: boolean
+  thanks?: { count: number; haveMine: boolean }
   children: React.ReactNode
 }) {
   return (
@@ -108,6 +113,7 @@ function ReceivedChatContainer({
           <BubbleInfo
             unreadCount={unreadCount}
             date={createdAt}
+            thanks={thanks}
             css={{ marginLeft: 8, textAlign: 'left' }}
           />
         ) : null}
@@ -139,6 +145,7 @@ export interface ChatBubbleUIProps {
    * 'sent' 타입일 때, 메시지 전송 실패할 경우 재시도를 취소하는 함수
    */
   onCancel?: () => void
+  thanks?: { count: number; haveMine: boolean }
   bubbleStyle?: ChatBubbleStyle
 }
 
@@ -152,6 +159,7 @@ export function ChatBubbleUI({
   blindedAt,
   blindedText,
   onRetry,
+  thanks,
   bubbleStyle,
 }: ChatBubbleUIProps) {
   switch (type) {
@@ -163,6 +171,7 @@ export function ChatBubbleUI({
           showBubbleInfo={payload.type !== MessageType.PRODUCT}
           unreadCount={unreadCount}
           onRetry={onRetry}
+          thanks={thanks}
         >
           {blindedAt ? (
             <BlindedBubble
@@ -207,6 +216,7 @@ export function ChatBubbleUI({
           showBubbleInfo={payload.type !== MessageType.PRODUCT}
           profileImageUrl={profileImageUrl}
           profileName={profileName}
+          thanks={thanks}
         >
           {blindedAt ? (
             <BlindedBubble

--- a/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
@@ -28,22 +28,29 @@ const CHAT_CONTAINER_STYLES = {
   width: '100%',
 } as const
 
+interface ChatContainerProps {
+  createdAt?: string
+  unreadCount: number | null
+  thanks?: { count: number; haveMine: boolean }
+  onThanksClick?: () => void
+  showBubbleInfo: boolean
+}
+
 function SentChatContainer({
   createdAt,
   unreadCount,
   onRetry,
   onCancel,
   thanks,
+  onThanksClick,
   children,
   showBubbleInfo,
-}: PropsWithChildren<{
-  createdAt?: string
-  unreadCount: number | null
-  onRetry?: () => Promise<boolean> | undefined
-  onCancel?: () => void
-  thanks?: { count: number; haveMine: boolean }
-  showBubbleInfo: boolean
-}>) {
+}: PropsWithChildren<
+  {
+    onRetry?: () => Promise<boolean> | undefined
+    onCancel?: () => void
+  } & ChatContainerProps
+>) {
   const [show, setShow] = useState<boolean>(true)
 
   return show ? (
@@ -71,6 +78,7 @@ function SentChatContainer({
               unreadCount={unreadCount}
               date={createdAt}
               thanks={thanks}
+              onThanksClick={onThanksClick}
               css={{ marginRight: 8, textAlign: 'right' }}
             />
           )}
@@ -88,17 +96,14 @@ function ReceivedChatContainer({
   unreadCount,
   createdAt,
   thanks,
+  onThanksClick,
   showBubbleInfo,
   children,
 }: {
   profileImageUrl?: string
   profileName?: string
-  unreadCount: number | null
-  createdAt?: string
-  showBubbleInfo: boolean
-  thanks?: { count: number; haveMine: boolean }
   children: React.ReactNode
-}) {
+} & ChatContainerProps) {
   return (
     <Container css={{ ...CHAT_CONTAINER_STYLES }}>
       <ProfileImage src={profileImageUrl} />
@@ -114,6 +119,7 @@ function ReceivedChatContainer({
             unreadCount={unreadCount}
             date={createdAt}
             thanks={thanks}
+            onThanksClick={onThanksClick}
             css={{ marginLeft: 8, textAlign: 'left' }}
           />
         ) : null}
@@ -145,6 +151,7 @@ export interface ChatBubbleUIProps {
    * 'sent' 타입일 때, 메시지 전송 실패할 경우 재시도를 취소하는 함수
    */
   onCancel?: () => void
+  onThanksClick?: () => void
   thanks?: { count: number; haveMine: boolean }
   bubbleStyle?: ChatBubbleStyle
 }
@@ -160,6 +167,7 @@ export function ChatBubbleUI({
   blindedText,
   onRetry,
   thanks,
+  onThanksClick,
   bubbleStyle,
 }: ChatBubbleUIProps) {
   switch (type) {
@@ -172,6 +180,7 @@ export function ChatBubbleUI({
           unreadCount={unreadCount}
           onRetry={onRetry}
           thanks={thanks}
+          onThanksClick={onThanksClick}
         >
           {blindedAt ? (
             <BlindedBubble
@@ -217,6 +226,7 @@ export function ChatBubbleUI({
           profileImageUrl={profileImageUrl}
           profileName={profileName}
           thanks={thanks}
+          onThanksClick={onThanksClick}
         >
           {blindedAt ? (
             <BlindedBubble

--- a/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble-ui.tsx
@@ -20,6 +20,7 @@ import {
 } from './elements'
 import BubblePayload from './bubble-payload'
 import BlindedBubble from './blinded'
+import Thanks from './thanks'
 
 const CHAT_CONTAINER_STYLES = {
   marginTop: 20,
@@ -54,7 +55,12 @@ function SentChatContainer({
   const [show, setShow] = useState<boolean>(true)
 
   return show ? (
-    <Container css={{ textAlign: 'right', ...CHAT_CONTAINER_STYLES }}>
+    <Container
+      css={{
+        textAlign: 'right',
+        ...CHAT_CONTAINER_STYLES,
+      }}
+    >
       {!createdAt ? (
         <SendingFailureHandlerContainer>
           <RetryButton
@@ -77,8 +83,6 @@ function SentChatContainer({
             <BubbleInfo
               unreadCount={unreadCount}
               date={createdAt}
-              thanks={thanks}
-              onThanksClick={onThanksClick}
               css={{ marginRight: 8, textAlign: 'right' }}
             />
           )}
@@ -86,6 +90,14 @@ function SentChatContainer({
       )}
 
       {children}
+      {thanks && onThanksClick ? (
+        <Thanks
+          count={thanks.count}
+          haveMine={thanks.haveMine}
+          onClick={onThanksClick}
+          css={{ position: 'absolute', right: 10, marginTop: 6 }}
+        />
+      ) : null}
     </Container>
   ) : null
 }
@@ -118,9 +130,16 @@ function ReceivedChatContainer({
           <BubbleInfo
             unreadCount={unreadCount}
             date={createdAt}
-            thanks={thanks}
-            onThanksClick={onThanksClick}
             css={{ marginLeft: 8, textAlign: 'left' }}
+          />
+        ) : null}
+
+        {thanks && onThanksClick ? (
+          <Thanks
+            count={thanks.count}
+            haveMine={thanks.haveMine}
+            onClick={onThanksClick}
+            css={{ marginTop: 6 }}
           />
         ) : null}
       </Container>

--- a/packages/chat/src/chat-bubble/chat-bubble.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble.tsx
@@ -99,11 +99,15 @@ const ChatBubble = ({
       blindedAt={message.blindedAt}
       blindedText={blindedText}
       thanks={message.reactions?.thanks}
-      onThanksClick={() => {
-        if (message.reactions?.thanks) {
-          onThanksClick?.(message.id, message.reactions.thanks.haveMine)
-        }
-      }}
+      onThanksClick={
+        onThanksClick
+          ? () => {
+              if (message.reactions?.thanks) {
+                onThanksClick?.(message.id, message.reactions.thanks.haveMine)
+              }
+            }
+          : undefined
+      }
       bubbleStyle={bubbleStyle}
     />
   )

--- a/packages/chat/src/chat-bubble/chat-bubble.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble.tsx
@@ -96,6 +96,7 @@ const ChatBubble = ({
       onCancel={onCancel}
       blindedAt={message.blindedAt}
       blindedText={blindedText}
+      thanks={message.reactions?.thanks}
       bubbleStyle={bubbleStyle}
     />
   )

--- a/packages/chat/src/chat-bubble/chat-bubble.tsx
+++ b/packages/chat/src/chat-bubble/chat-bubble.tsx
@@ -23,6 +23,7 @@ interface ChatBubbleProps {
   disableUnreadCount?: boolean
   onRetryButtonClick?: (message: MessageInterface) => void
   onRetryCancelButtonClick?: (message: MessageInterface) => void
+  onThanksClick?: (id: number, haveMyThanks: boolean) => void
   blindedText?: string
   bubbleStyle?: ChatBubbleStyle
 }
@@ -36,6 +37,7 @@ const ChatBubble = ({
   postMessageAction,
   onRetryButtonClick,
   onRetryCancelButtonClick,
+  onThanksClick,
   disableUnreadCount = false,
   blindedText,
   bubbleStyle,
@@ -97,6 +99,11 @@ const ChatBubble = ({
       blindedAt={message.blindedAt}
       blindedText={blindedText}
       thanks={message.reactions?.thanks}
+      onThanksClick={() => {
+        if (message.reactions?.thanks) {
+          onThanksClick?.(message.id, message.reactions.thanks.haveMine)
+        }
+      }}
       bubbleStyle={bubbleStyle}
     />
   )

--- a/packages/chat/src/chat-bubble/thanks.tsx
+++ b/packages/chat/src/chat-bubble/thanks.tsx
@@ -33,7 +33,7 @@ export default function Thanks({
   return (
     <ThanksButton haveMine={haveMine} onClick={() => onClick?.()} {...props}>
       <img
-        src="https://assets.triple-dev.titicaca-corp.com/images/ic_chat_thumbsup_on.svg"
+        src="https://assets.triple.guide/images/ic_chat_thumbsup_on.svg"
         alt="좋아요 아이콘"
         width={11}
         height={11}

--- a/packages/chat/src/chat-bubble/thanks.tsx
+++ b/packages/chat/src/chat-bubble/thanks.tsx
@@ -2,15 +2,22 @@ import { Button } from '@titicaca/core-elements'
 import styled from 'styled-components'
 
 const ThanksButton = styled(Button)<{ haveMine: boolean }>`
-  display: flex;
-  gap: 4px;
+  display: inline-flex;
+  gap: 3px;
+  height: 20px;
   align-items: center;
   background-color: ${({ haveMine }) =>
     haveMine ? 'var(--color-white)' : 'var(--color-gray50)'};
   color: ${({ haveMine }) => (haveMine ? '#1DBEB2' : 'var(--color-gray700)')};
-  ${({ haveMine }) => (haveMine ? 'border: 1px solid #1DBEB2' : '')};
-  padding: 3.5px 8px 4.5px;
-  font-weight: normal;
+  ${({ haveMine }) => (haveMine ? 'border: 1px solid #1DBEB2;' : '')}
+  padding: 3.5px 6px 4.5px 7px;
+  font-weight: ${({ haveMine }) => (haveMine ? '700' : '500')};
+  font-size: 10px;
+`
+
+const ThanksCount = styled.span`
+  font-size: 10px;
+  line-height: 11px;
 `
 
 export default function Thanks({
@@ -28,8 +35,10 @@ export default function Thanks({
       <img
         src="https://assets.triple-dev.titicaca-corp.com/images/ic_chat_thumbsup_on.svg"
         alt="좋아요 아이콘"
+        width={11}
+        height={11}
       />
-      {count === 0 ? null : count}
+      {count === 0 ? null : <ThanksCount>{count}</ThanksCount>}
     </ThanksButton>
   )
 }

--- a/packages/chat/src/chat-bubble/thanks.tsx
+++ b/packages/chat/src/chat-bubble/thanks.tsx
@@ -2,7 +2,7 @@ import { Button } from '@titicaca/core-elements'
 import styled from 'styled-components'
 
 const ThanksButton = styled(Button)<{ haveMine: boolean }>`
-  display: inline-flex;
+  display: flex;
   gap: 3px;
   height: 20px;
   align-items: center;

--- a/packages/chat/src/chat-bubble/thanks.tsx
+++ b/packages/chat/src/chat-bubble/thanks.tsx
@@ -1,0 +1,35 @@
+import { Button } from '@titicaca/core-elements'
+import styled from 'styled-components'
+
+const ThanksButton = styled(Button)<{ haveMine: boolean }>`
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  background-color: ${({ haveMine }) =>
+    haveMine ? 'var(--color-white)' : 'var(--color-gray50)'};
+  color: ${({ haveMine }) => (haveMine ? '#1DBEB2' : 'var(--color-gray700)')};
+  ${({ haveMine }) => (haveMine ? 'border: 1px solid #1DBEB2' : '')};
+  padding: 3.5px 8px 4.5px;
+  font-weight: normal;
+`
+
+export default function Thanks({
+  count,
+  haveMine,
+  onClick,
+  ...props
+}: {
+  count: number
+  haveMine: boolean
+  onClick?: () => void
+}) {
+  return (
+    <ThanksButton haveMine={haveMine} onClick={() => onClick?.()} {...props}>
+      <img
+        src="https://assets.triple-dev.titicaca-corp.com/images/ic_chat_thumbsup_on.svg"
+        alt="좋아요 아이콘"
+      />
+      {count === 0 ? null : count}
+    </ThanksButton>
+  )
+}

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -13,6 +13,7 @@ import {
   PostMessageType,
   ReactionType,
   RoomInterface,
+  RoomType,
   TextPayload,
   UpdateChatData,
   UserInterface,
@@ -329,7 +330,9 @@ export const Chat = ({
                   onRetryCancelButtonClick={onRetryCancel}
                   disableUnreadCount={disableUnreadCount}
                   blindedText={blindedText}
-                  onThanksClick={onThanksClick}
+                  onThanksClick={
+                    room.type === RoomType.EVENT ? onThanksClick : undefined
+                  }
                   bubbleStyle={bubbleStyle}
                 />
               </li>
@@ -349,7 +352,9 @@ export const Chat = ({
                 onRetryCancelButtonClick={onRetryCancel}
                 disableUnreadCount={disableUnreadCount}
                 blindedText={blindedText}
-                onThanksClick={onThanksClick}
+                onThanksClick={
+                  room.type === RoomType.EVENT ? onThanksClick : undefined
+                }
                 bubbleStyle={bubbleStyle}
               />
             </li>

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -55,7 +55,7 @@ export interface ChatProps {
   showFailToast?: (message: string) => void
   onRetryButtonClick?: () => void
   onRetryCancelButtonClick?: () => void
-
+  onThanksClick?: (id: number, haveMyThanks: boolean) => void
   updateChatData?: UpdateChatData
   disableUnreadCount?: boolean
   blindedText?: string
@@ -73,7 +73,6 @@ export const Chat = ({
   room,
   messages: initMessages,
   beforeSentMessages = [],
-
   postMessage,
   getMessages,
   getUnreadRoom,
@@ -81,6 +80,7 @@ export const Chat = ({
   showFailToast,
   onRetryButtonClick,
   onRetryCancelButtonClick,
+  onThanksClick,
   updateChatData,
   disableUnreadCount = false,
   blindedText,

--- a/packages/chat/src/chat/chat.tsx
+++ b/packages/chat/src/chat/chat.tsx
@@ -323,7 +323,7 @@ export const Chat = ({
             reactions: {
               thanks: {
                 count: thanksCount ? thanksCount - 1 : 0,
-                haveMine: true,
+                haveMine: false,
               },
             },
           },

--- a/packages/chat/src/chat/reducer.ts
+++ b/packages/chat/src/chat/reducer.ts
@@ -7,6 +7,7 @@ export enum ChatActions {
   POST, // 메시지 전송
   FAILED_TO_POST, // 메시지 전송 실패
   UPDATE, // 읽음 표시 업데이트
+  UPDATE_MESSAGE, // 메시지 하나 업데이트
   REMOVE_FROM_FAILED, // 전송 실패 메세지 재전송 또는 삭제
 }
 
@@ -46,6 +47,7 @@ export type ChatAction =
       action: ChatActions.UPDATE
       otherUnreadInfo: OtherUnreadInterface[]
     }
+  | { action: ChatActions.UPDATE_MESSAGE; message: MessageInterface }
   | { action: ChatActions.REMOVE_FROM_FAILED; message: MessageInterface }
 
 export const ChatReducer = (
@@ -101,7 +103,13 @@ export const ChatReducer = (
         ...state,
         otherUnreadInfo: action.otherUnreadInfo,
       }
-
+    case ChatActions.UPDATE_MESSAGE:
+      return {
+        ...state,
+        messages: state.messages.map((message) =>
+          message.id === action.message.id ? action.message : message,
+        ),
+      }
     case ChatActions.REMOVE_FROM_FAILED:
       return {
         ...state,

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -62,6 +62,7 @@ export interface RoomInterface {
 
 export type DisplayTargetAll = 'all'
 
+export type ReactionType = 'thanks'
 export interface MessageInterface {
   id: number
   roomId: string
@@ -72,6 +73,7 @@ export interface MessageInterface {
   alternative?: TextPayload | ImagePayload | RichPayload
   blindedAt?: string
   sender: UserInterface
+  reactions?: { [type in ReactionType]?: { count: number; haveMine: boolean } }
 }
 
 export interface UserInterface {

--- a/packages/chat/src/utils/constants.ts
+++ b/packages/chat/src/utils/constants.ts
@@ -123,7 +123,7 @@ export const CHAT_ARGS: ChatProps = {
   },
   room: {
     id: '6344c73a53749900140bca43',
-    type: RoomType.DEFAULT,
+    type: RoomType.DEFAULT, // RoomType.EVENT로 수정 시 좋아요 버튼을 확인할 수 있습니다.
     createdAt: '2022-10-11T01:30:34.519Z',
     name: '',
     isDirect: true,
@@ -211,6 +211,9 @@ export const CHAT_ARGS: ChatProps = {
     }
   },
   addReactions: async () => {
+    return { success: true }
+  },
+  removeReactions: async () => {
     return { success: true }
   },
 }

--- a/packages/chat/src/utils/constants.ts
+++ b/packages/chat/src/utils/constants.ts
@@ -92,6 +92,9 @@ export const CHAT_ARGS: ChatProps = {
             message: '',
           },
         },
+        reactions: {
+          thanks: { count: 0, haveMine: false },
+        },
       },
       {
         id: 5749,
@@ -206,5 +209,8 @@ export const CHAT_ARGS: ChatProps = {
         },
       ],
     }
+  },
+  addReactions: async () => {
+    return { success: true }
   },
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

이벤트챗에서 사용될 좋아요 기능을 추가합니다. [관련 위키](https://inpk.atlassian.net/wiki/spaces/SPC/pages/462717087)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

좋아요 버튼 추가
- 좋아요, 좋아요 취소 가능
- blind된 메세지에는 노출되지 않음

좋아요 기능은 이벤트챗에서만 사용되지만 챗의 종류에 상관없이 API에서 `reactions` 값을 넘겨주기 때문에 기본챗(파트너센터)의 메세지들에서 thanks를 undefined로 넘겨주려고 했습니다. 그러나 과거 메세지 fetch가 TF 내에서 일어나고 있어서 chat-web에서 undefined로 바꿔주기 + TF에서 undefined로 바꿔주기 모두 필요한 상황이었습니다. 현재 리팩토링도 진행되고 있기 때문에 당장은 좀 더 간단한 로직을 갖고가기 위해 `ChatBubble`에서 `ChatBubbleUI`로 넘겨줄 때 채팅방의 타입을 구분해 값을 넘겨주기로 하였습니다. 
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL
![image](https://github.com/titicacadev/triple-frontend/assets/43779313/43cf1083-3ca1-4bf6-9e63-13754d791954)

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
