### PR TITLE
[v14] useDeviceContext를 useGeolocation과 useClientApp로 대체합니다.

### DIFF
--- a/packages/tds-widget/src/ad-banner/content-details-banner.tsx
+++ b/packages/tds-widget/src/ad-banner/content-details-banner.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { MarginPadding } from '@titicaca/tds-ui'
-import { useDeviceContext, useTrackEvent } from '@titicaca/triple-web'
+import { useGeolocation, useTrackEvent } from '@titicaca/triple-web'
 import { useNavigate } from '@titicaca/router'
 
 import {
@@ -53,7 +53,7 @@ function isPropsForInventoryApi(
 }
 
 function useAdBannerProps(props: AdBannersProps) {
-  const { latitude, longitude } = useDeviceContext()
+  const { latitude, longitude } = useGeolocation()
   const trackEvent = useTrackEvent()
   const navigate = useNavigate()
 

--- a/packages/tds-widget/src/ad-banner/list-top-banners.tsx
+++ b/packages/tds-widget/src/ad-banner/list-top-banners.tsx
@@ -1,6 +1,6 @@
 import { FC, useState, useEffect } from 'react'
 import { MarginPadding } from '@titicaca/tds-ui'
-import { useDeviceContext, useTrackEvent } from '@titicaca/triple-web'
+import { useGeolocation, useTrackEvent } from '@titicaca/triple-web'
 import { useNavigate } from '@titicaca/router'
 
 import {
@@ -60,7 +60,7 @@ function isPropsForInventoryApi(
 }
 
 function useAdBannerProps(props: AdBannersProps) {
-  const { latitude, longitude } = useDeviceContext()
+  const { latitude, longitude } = useGeolocation()
   const trackEvent = useTrackEvent()
   const navigate = useNavigate()
 

--- a/packages/tds-widget/src/image-carousel/video-content.tsx
+++ b/packages/tds-widget/src/image-carousel/video-content.tsx
@@ -2,7 +2,7 @@ import { Container } from '@titicaca/tds-ui'
 import { FrameRatioAndSizes, GlobalSizes } from '@titicaca/type-definitions'
 import { MouseEventHandler, ReactNode, useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { useDeviceContext } from '@titicaca/react-contexts'
+import { useClientApp } from '@titicaca/triple-web'
 import { useIntersection } from '@titicaca/intersection-observer'
 
 import { CarouselImageMeta } from './types'
@@ -95,14 +95,12 @@ function VideoContent({
   const { ref, isIntersecting } = useIntersection<HTMLVideoElement>({
     threshold: 0.5,
   })
-
-  const {
-    deviceState: { autoplay, networkType },
-  } = useDeviceContext()
+  const clientApp = useClientApp()
 
   const [videoAutoplay, setVideoAutoPlay] = useState(
-    autoplay === 'always' ||
-      (autoplay === 'wifi_only' && networkType === 'wifi'),
+    clientApp?.device.autoplay === 'always' ||
+      (clientApp?.device.autoplay === 'wifi_only' &&
+        clientApp?.device.networkType === 'wifi'),
   )
 
   useEffect(() => {

--- a/packages/tds-widget/src/review/components/review-element/media/video.tsx
+++ b/packages/tds-widget/src/review/components/review-element/media/video.tsx
@@ -1,8 +1,8 @@
+import { useEffect, useState } from 'react'
 import { ImageMeta } from '@titicaca/type-definitions'
 import { Container } from '@titicaca/tds-ui'
 import { useIntersection } from '@titicaca/intersection-observer'
-import { useEffect, useState } from 'react'
-import { useDeviceContext } from '@titicaca/react-contexts'
+import { useClientApp } from '@titicaca/triple-web'
 import styled from 'styled-components'
 
 interface Props {
@@ -62,13 +62,12 @@ function Video({ medium }: Props) {
     threshold: 0.5,
   })
 
-  const {
-    deviceState: { autoplay, networkType },
-  } = useDeviceContext()
+  const clientApp = useClientApp()
 
   const [videoAutoplay, setVideoAutoPlay] = useState(
-    autoplay === 'always' ||
-      (autoplay === 'wifi_only' && networkType === 'wifi'),
+    clientApp?.device.autoplay === 'always' ||
+      (clientApp?.device.autoplay === 'wifi_only' &&
+        clientApp?.device.networkType === 'wifi'),
   )
 
   useEffect(() => {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

`DeviceContext`를 `useGeolocation`과 `useClientApp`로 대체합니다.
