### PR TITLE
[v14] session-context 마이그레이션

### DIFF
--- a/packages/tds-widget/src/footer/company-info.tsx
+++ b/packages/tds-widget/src/footer/company-info.tsx
@@ -6,8 +6,12 @@ import {
   FlexBox,
   AccordionTitle,
 } from '@titicaca/tds-ui'
-import { useTrackEvent, useSessionAvailability } from '@titicaca/triple-web'
-import { useSessionControllers } from '@titicaca/react-contexts'
+import {
+  useTrackEvent,
+  useSessionAvailability,
+  useLogin,
+  useLogout,
+} from '@titicaca/triple-web'
 import { Dispatch, SetStateAction } from 'react'
 
 const MAX_PHONE_WIDTH = 360
@@ -84,7 +88,8 @@ export function CompanyInfo({
   setBusinessExpanded,
 }: CompanyInfoProps) {
   const sessionAvailable = useSessionAvailability()
-  const { login, logout } = useSessionControllers()
+  const login = useLogin()
+  const logout = useLogout()
   const trackEvent = useTrackEvent()
 
   return (

--- a/packages/tds-widget/src/review/reviews-shorten.stories.tsx
+++ b/packages/tds-widget/src/review/reviews-shorten.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { TransitionModal } from '@titicaca/modals'
-import { SessionContextProvider } from '@titicaca/react-contexts'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { authHandlers, handlers } from './mocks/reviews'
@@ -20,17 +19,6 @@ const meta: Meta<typeof ReviewsShorten> = {
         <Story />
         <TransitionModal deepLink="/" />
       </>
-    ),
-    (Story) => (
-      <SessionContextProvider
-        type="browser"
-        props={{
-          initialUser: { uid: 'random-uid' },
-          initialSessionAvailability: true,
-        }}
-      >
-        <Story />
-      </SessionContextProvider>
     ),
     (Story) => (
       <QueryClientProvider client={queryClient}>

--- a/packages/tds-widget/src/review/reviews.stories.tsx
+++ b/packages/tds-widget/src/review/reviews.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { TransitionModal } from '@titicaca/modals'
-import { SessionContextProvider } from '@titicaca/react-contexts'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { authHandlers, handlers } from './mocks/reviews'
@@ -20,17 +19,6 @@ const meta: Meta<typeof Reviews> = {
         <Story />
         <TransitionModal deepLink="/" />
       </>
-    ),
-    (Story) => (
-      <SessionContextProvider
-        type="browser"
-        props={{
-          initialUser: { uid: 'random-uid' },
-          initialSessionAvailability: true,
-        }}
-      >
-        <Story />
-      </SessionContextProvider>
     ),
     (Story) => (
       <QueryClientProvider client={queryClient}>

--- a/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
+++ b/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@titicaca/tds-ui'
 import styled from 'styled-components'
-import { useHashRouter, useSessionControllers } from '@titicaca/triple-web'
+import { useHashRouter, useLogin } from '@titicaca/triple-web'
 import {
   useUserVerification,
   VerificationType,
@@ -122,7 +122,7 @@ export function CouponDownloadButton({
     verificationType,
     forceVerification: false,
   })
-  const { login } = useSessionControllers()
+  const login = useLogin()
 
   const [needLogin, setNeedLogin] = useState(false)
   const timePassed = useDownloadTimePassed(enabledAt)
@@ -286,7 +286,7 @@ export function CouponGroupDownloadButton({
     verificationType,
     forceVerification: false,
   })
-  const { login } = useSessionControllers()
+  const login = useLogin()
 
   const [needLogin, setNeedLogin] = useState(false)
   const timePassed = useDownloadTimePassed(enabledAt)

--- a/packages/triple-web/src/hooks/session/use-login.ts
+++ b/packages/triple-web/src/hooks/session/use-login.ts
@@ -14,11 +14,11 @@ export function useLogin() {
   const env = useEnv()
 
   return useCallback(
-    (options: LoginOptions) => {
+    (options?: LoginOptions) => {
       if (clientApp) {
         handleClientApp(env.appUrlScheme)
       } else {
-        handleBrowser(options.returnUrl)
+        handleBrowser(options?.returnUrl)
       }
     },
     [clientApp, env.appUrlScheme],

--- a/packages/ui-flow/package.json
+++ b/packages/ui-flow/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@titicaca/fetcher": "workspace:*",
     "@titicaca/view-utilities": "workspace:*",
+    "@titicaca/triple-web": "workspace:*",
     "qs": "^6.11.2"
   },
   "devDependencies": {

--- a/packages/ui-flow/src/use-session-callback.test.tsx
+++ b/packages/ui-flow/src/use-session-callback.test.tsx
@@ -2,22 +2,28 @@ import { renderHook, act } from '@testing-library/react'
 import { useLoginCtaModal } from '@titicaca/modals'
 import {
   useSessionAvailability,
-  useSessionControllers,
-  useUriHash,
-} from '@titicaca/react-contexts'
+  useLogin,
+  useLogout,
+  useHashRouter,
+} from '@titicaca/triple-web'
 
 import { useSessionCallback } from './use-session-callback'
 
-jest.mock('@titicaca/react-contexts')
 jest.mock('@titicaca/modals')
+jest.mock('@titicaca/triple-web')
 
 describe('useSessionCallback', () => {
   beforeEach(() => {
     ;(
-      useSessionControllers as unknown as jest.MockedFunction<
-        () => Pick<ReturnType<typeof useSessionControllers>, 'login'>
+      useLogin as unknown as jest.MockedFunction<
+        () => ReturnType<typeof useLogin>
       >
-    ).mockImplementation(() => ({ login: jest.fn() }))
+    ).mockImplementation(() => jest.fn())
+    ;(
+      useLogout as unknown as jest.MockedFunction<
+        () => ReturnType<typeof useLogout>
+      >
+    ).mockImplementation(() => jest.fn())
     ;(
       useLoginCtaModal as unknown as jest.MockedFunction<
         () => Pick<ReturnType<typeof useLoginCtaModal>, 'show'>
@@ -35,7 +41,7 @@ describe('useSessionCallback', () => {
     it('returns undefined value', () => {
       const { result } = renderHook(() => {
         const doAction = useSessionCallback(() => 'login')
-        const uriHash = useUriHash()
+        const { uriHash } = useHashRouter()
 
         return { uriHash, doAction }
       })
@@ -50,7 +56,7 @@ describe('useSessionCallback', () => {
           returnValue: 'fallback',
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any)
-        const uriHash = useUriHash()
+        const { uriHash } = useHashRouter()
 
         return { uriHash, doAction }
       })
@@ -69,7 +75,7 @@ describe('useSessionCallback', () => {
     it('returns the return value of fn', () => {
       const { result } = renderHook(() => {
         const doAction = useSessionCallback(() => 'login')
-        const uriHash = useUriHash()
+        const { uriHash } = useHashRouter()
 
         return { uriHash, doAction }
       })

--- a/packages/ui-flow/src/use-session-callback.ts
+++ b/packages/ui-flow/src/use-session-callback.ts
@@ -1,9 +1,6 @@
 import { useCallback } from 'react'
 import { useLoginCtaModal } from '@titicaca/modals'
-import {
-  useSessionAvailability,
-  useSessionControllers,
-} from '@titicaca/react-contexts'
+import { useSessionAvailability, useLogin } from '@titicaca/triple-web'
 
 /**
  * sessionId가 있는 환경에서만 주어진 콜백을 실행하는 함수를 반환하는 훅
@@ -30,7 +27,7 @@ export function useSessionCallback<T extends (...args: any[]) => any>(
     | []
 ): (...args: Parameters<T>) => ReturnType<T> | boolean | void {
   const sessionAvailable = useSessionAvailability()
-  const { login } = useSessionControllers()
+  const login = useLogin()
   const { show } = useLoginCtaModal()
 
   return useCallback(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,6 +845,9 @@ importers:
       '@titicaca/fetcher':
         specifier: workspace:*
         version: link:../fetcher
+      '@titicaca/triple-web':
+        specifier: workspace:*
+        version: link:../triple-web
       '@titicaca/view-utilities':
         specifier: workspace:*
         version: link:../view-utilities
@@ -855,9 +858,6 @@ importers:
       '@titicaca/react-triple-client-interfaces':
         specifier: workspace:*
         version: link:../react-triple-client-interfaces
-      '@titicaca/triple-web':
-        specifier: workspace:*
-        version: link:../triple-web
       '@types/qs':
         specifier: ^6.9.9
         version: 6.9.9


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

기존 `react-contexts`의 `session` 코드를 `triple-web`의 `session` 코드로 변경합니다.

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

### `useSessionControllers`를 `useLogin`, `useLogout`으로 분리
```tsx
// AS-IS
const { login, logout } = useSessionControllers()

/// TO-BE
const login = useLogin()
const logout = useLogout()
```

### import path 변경
`@titicaca/react-contexts` -> `@titicaca/triple-web`

### 스토리북 코드
Session decorator를 제거했습니다.
- 추후에 decorator를 한번에 정리할 예정입니다.

### 의존성 설치
`@titicaca/ui-flow`에 `@titicaca/triple-web`을 설치했습니다.

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
