### PR TITLE
ExtendedResourceListElement에 badge 영역 추가

### DIFF
--- a/packages/resource-list-element/src/extended-resource-list-element.stories.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.stories.tsx
@@ -78,3 +78,15 @@ export const Advertisement = {
     isAdvertisement: true,
   },
 }
+
+export const Badge = {
+  render: Template,
+
+  args: {
+    ...defaultArgs,
+    badge: {
+      icon: 'https://assets.triple.guide/images/seoulcon/default/ic_spot.svg',
+      text: '즉시확정',
+    },
+  },
+}

--- a/packages/resource-list-element/src/extended-resource-list-element.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.tsx
@@ -1,6 +1,6 @@
 import { MouseEventHandler, PropsWithChildren } from 'react'
 import { useTranslation } from '@titicaca/next-i18next'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { OverlayScrapButton } from '@titicaca/scrap-button'
 import {
   Container,
@@ -38,6 +38,10 @@ export type ResourceListElementProps<R extends ResourceMeta> = {
     color?: LabelColor
     emphasized?: boolean
   }[]
+  badge?: {
+    text: string
+    icon?: string
+  }
   scrapsCount?: number
   reviewsCount?: number
   reviewsRating?: number
@@ -60,6 +64,29 @@ const LabelContainer = styled.div`
   bottom: 20px;
 `
 
+const Badge = styled.div<{ icon?: string }>`
+  padding: 0 5px;
+  border-radius: 4px;
+  border: 1px solid var(--color-gray100);
+  display: inline-block;
+
+  ${({ icon }) =>
+    icon &&
+    css`
+      &::before {
+        content: '';
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        margin-right: 3px;
+        background-image: url(${icon});
+        background-size: 10px;
+        background-position: center;
+        background-repeat: no-repeat;
+      }
+    `};
+`
+
 function ExtendedResourceListElement<R extends ResourceMeta>({
   resource,
   scrapResource,
@@ -72,6 +99,7 @@ function ExtendedResourceListElement<R extends ResourceMeta>({
   distanceSuffix = 'm',
   note,
   tags,
+  badge,
   scrapsCount,
   reviewsCount,
   reviewsRating,
@@ -165,6 +193,16 @@ function ExtendedResourceListElement<R extends ResourceMeta>({
                   {note}
                 </Text>
               ) : null}
+            </Container>
+          ) : null}
+
+          {badge ? (
+            <Container css={{ margin: '7px 0 0' }}>
+              <Badge icon={badge.icon}>
+                <Text bold size={12} lineHeight="24px">
+                  {badge.text}
+                </Text>
+              </Badge>
             </Container>
           ) : null}
         </Container>

--- a/packages/resource-list-element/src/extended-resource-list-element.tsx
+++ b/packages/resource-list-element/src/extended-resource-list-element.tsx
@@ -199,7 +199,7 @@ function ExtendedResourceListElement<R extends ResourceMeta>({
           {badge ? (
             <Container css={{ margin: '7px 0 0' }}>
               <Badge icon={badge.icon}>
-                <Text bold size={12} lineHeight="24px">
+                <Text bold inline size={12} lineHeight="24px">
                   {badge.text}
                 </Text>
               </Badge>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

- `ExtendedResourceListElement`에 `badge` 영역을 추가합니다. 

## 스크린샷 & URL
https://triple-dev.titicaca-corp.com/tna/products?from=hub&type=CITY&cityId=d-f1bc8e2c-6a91-4660-a0fe-f604895c88e5&categoryIds=9120

![스크린샷 2023-12-08 오후 4 34 50](https://github.com/titicacadev/triple-frontend/assets/133629020/d9291eb2-7c09-40d0-80c4-4c04eab07247)


