### PR TITLE
[v14] history-context의 openWindow를 router의 navigate으로 이동합니다.

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -40,20 +40,21 @@
     ]
   },
   "dependencies": {
+    "@titicaca/triple-web-to-native-interfaces": "1.9.0",
     "@titicaca/view-utilities": "workspace:*",
     "qs": "^6.11.2"
   },
   "devDependencies": {
-    "@titicaca/triple-web": "workspace:*",
     "@titicaca/react-triple-client-interfaces": "workspace:*",
+    "@titicaca/triple-web": "workspace:*",
     "@types/qs": "^6.9.9",
     "next": "^13.4.13",
     "react": "^18.2.0",
     "styled-components": "^5.3.11"
   },
   "peerDependencies": {
-    "@titicaca/triple-web": "*",
     "@titicaca/react-triple-client-interfaces": "*",
+    "@titicaca/triple-web": "*",
     "next": "^13.0",
     "react": "^18.0",
     "styled-components": "^5.3.9"

--- a/packages/router/src/navigate/index.test.ts
+++ b/packages/router/src/navigate/index.test.ts
@@ -39,7 +39,9 @@ describe('브라우저', () => {
       const changeLocationHref = jest.fn()
 
       const {
-        result: { current: navigate },
+        result: {
+          current: { navigate },
+        },
       } = renderHook(useNavigate, { initialProps: { changeLocationHref } })
 
       navigate(href)
@@ -61,7 +63,9 @@ describe('브라우저', () => {
       const changeLocationHref = jest.fn()
 
       const {
-        result: { current: navigate },
+        result: {
+          current: { navigate },
+        },
       } = renderHook(useNavigate, { initialProps: { changeLocationHref } })
       navigate(href)
 
@@ -75,7 +79,9 @@ describe('브라우저', () => {
     const changeLocationHref = jest.fn()
 
     const {
-      result: { current: navigate },
+      result: {
+        current: { navigate },
+      },
     } = renderHook(useNavigate, { initialProps: { changeLocationHref } })
 
     navigate(`/inlink?path=${encodeURIComponent(routablePath)}`)
@@ -105,7 +111,9 @@ describe('앱', () => {
       const changeLocationHref = jest.fn()
 
       const {
-        result: { current: navigate },
+        result: {
+          current: { navigate },
+        },
       } = renderHook(useNavigate, { initialProps: { changeLocationHref } })
 
       navigate(href)
@@ -124,7 +132,9 @@ describe('앱', () => {
     const changeLocationHref = jest.fn()
 
     const {
-      result: { current: navigate },
+      result: {
+        current: { navigate },
+      },
     } = renderHook(useNavigate, { initialProps: { changeLocationHref } })
 
     navigate(href)
@@ -140,7 +150,9 @@ describe('앱', () => {
     const changeLocationHref = jest.fn()
 
     const {
-      result: { current: navigate },
+      result: {
+        current: { navigate },
+      },
     } = renderHook(useNavigate, { initialProps: { changeLocationHref } })
 
     navigate(href)

--- a/packages/router/src/navigate/index.ts
+++ b/packages/router/src/navigate/index.ts
@@ -9,6 +9,7 @@ import {
   useSessionAvailability,
   useLoginCtaModal,
   useTransitionModal,
+  TransitionType,
 } from '@titicaca/triple-web'
 import {
   OutlinkOptions,
@@ -21,8 +22,12 @@ import qs from 'qs'
 import canonizeTargetAddress from './canonization'
 
 export function useNavigate({
+  transitionType = TransitionType.General,
   changeLocationHref = defaultChangeLocationHref,
-}: { changeLocationHref?: (href: string) => void } = {}) {
+}: {
+  changeLocationHref?: (href: string) => void
+  transitionType?: TransitionType
+} = {}) {
   const { webUrlBase, appUrlScheme } = useEnv()
   const sessionAvailable = useSessionAvailability()
   const { show: showTransitionModal } = useTransitionModal()
@@ -43,7 +48,7 @@ export function useNavigate({
         return
       }
 
-      showTransitionModal()
+      showTransitionModal(transitionType)
     },
     [changeLocationHref, showTransitionModal, webUrlBase],
   )

--- a/packages/standard-action-handler/src/hook.ts
+++ b/packages/standard-action-handler/src/hook.ts
@@ -3,7 +3,7 @@ import { useNavigate, useExternalRouter } from '@titicaca/router'
 import { initialize } from './index'
 
 export function useStandardActionHandler() {
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
   const routeExternally = useExternalRouter()
 
   return initialize({ navigate, routeExternally })

--- a/packages/tds-widget/src/ad-banner/content-details-banner.tsx
+++ b/packages/tds-widget/src/ad-banner/content-details-banner.tsx
@@ -55,7 +55,7 @@ function isPropsForInventoryApi(
 function useAdBannerProps(props: AdBannersProps) {
   const { latitude, longitude } = useGeolocation()
   const trackEvent = useTrackEvent()
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
 
   if (isPropsForInventoryApi(props)) {
     const { onBannersFetch, onBannerIntersect, onBannerClick } = props

--- a/packages/tds-widget/src/ad-banner/list-top-banners.tsx
+++ b/packages/tds-widget/src/ad-banner/list-top-banners.tsx
@@ -62,7 +62,7 @@ function isPropsForInventoryApi(
 function useAdBannerProps(props: AdBannersProps) {
   const { latitude, longitude } = useGeolocation()
   const trackEvent = useTrackEvent()
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
 
   if (isPropsForInventoryApi(props)) {
     const { onBannersFetch, onBannerIntersect, onBannerClick } = props

--- a/packages/tds-widget/src/booking-completion/index.tsx
+++ b/packages/tds-widget/src/booking-completion/index.tsx
@@ -78,7 +78,7 @@ export function BookingCompletion({
   const { t } = useTranslation('triple-frontend')
 
   const regionName = region?.names.ko || region?.names.en
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
 
   const handleMoveToRegion = useAppCallback(
     TransitionType.General,

--- a/packages/tds-widget/src/nearby-pois/poi-entry.tsx
+++ b/packages/tds-widget/src/nearby-pois/poi-entry.tsx
@@ -25,7 +25,7 @@ export default function PoiEntry({
   optimized?: boolean
 }) {
   const trackEvent = useTrackEvent()
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
 
   const handleIntersectionChange = useCallback(
     ({ isIntersecting }: { isIntersecting: boolean }) => {

--- a/packages/tds-widget/src/replies/list/reply.tsx
+++ b/packages/tds-widget/src/replies/list/reply.tsx
@@ -92,7 +92,7 @@ export default function Reply({
   const { setEditingMessage } = useRepliesContext()
   const { addUriHash, removeUriHash } = useHashRouter()
   const { asyncBack } = useIsomorphicNavigation()
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
   const likeReactionCount = likeReaction?.count
 
   const handleMoreClick = useCallback(
@@ -431,7 +431,7 @@ function Content({
 
   const [unfolded, setUnfolded] = useState(false)
   const foldedPosition = findFoldedPosition(5, text)
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
 
   const handleMentiondUserNameClick = useAppCallback(
     TransitionType.General,

--- a/packages/tds-widget/src/replies/reply.test.tsx
+++ b/packages/tds-widget/src/replies/reply.test.tsx
@@ -23,7 +23,7 @@ beforeEach(() => {
       () => ReturnType<typeof useNavigate>
     >
   ).mockImplementation(() => {
-    return () => {}
+    return { navigate: () => {}, openWindow: () => {} }
   })
   ;(
     useAppCallback as unknown as jest.MockedFunction<typeof useAppCallback>

--- a/packages/tds-widget/src/review/services/use-client-actions.tsx
+++ b/packages/tds-widget/src/review/services/use-client-actions.tsx
@@ -10,7 +10,7 @@ import type { SortingType, SortingOption } from '../components/sorting-context'
 
 export function useClientActions() {
   const { appUrlScheme } = useEnv()
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
   const { getWindowId } = useTripleClientActions()
 
   return useMemo(() => {

--- a/packages/tds-widget/src/social-reviews/social-review.tsx
+++ b/packages/tds-widget/src/social-reviews/social-review.tsx
@@ -25,7 +25,7 @@ function SocialReviews({
   const { t } = useTranslation('triple-frontend')
 
   const trackEvent = useTrackEvent()
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
 
   if (!socialReviews || socialReviews.length === 0) {
     return null

--- a/packages/triple-document/src/elements/coupon/modals.tsx
+++ b/packages/triple-document/src/elements/coupon/modals.tsx
@@ -42,7 +42,7 @@ const CouponIcon = styled.img`
 export function CouponModal({ identifier }: { identifier: string }) {
   const { t } = useTranslation('triple-frontend')
   const { uriHash, removeUriHash } = useHashRouter()
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
 
   const modalHash = uriHash.replace(`${identifier}.`, '')
 

--- a/packages/triple-document/src/elements/itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary.tsx
@@ -103,7 +103,7 @@ export default function ItineraryElement({ value }: Props) {
   const { courses, regionId, poiIds, hasItineraries, hideAddButton } =
     useItinerary({ itinerary: value.itinerary, guestMode })
   const addPoisToTrip = useHandleAddPoisToTrip(regionId || '')
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
 
   const generatePoiClickHandler = useCallback(
     ({

--- a/packages/triple-document/src/elements/itinerary/use-handle-add-pois-to-trip.ts
+++ b/packages/triple-document/src/elements/itinerary/use-handle-add-pois-to-trip.ts
@@ -10,7 +10,7 @@ import { useNavigate } from '@titicaca/router'
  */
 export default function useHandleAddPoiToTrip(regionId?: string) {
   const { appUrlScheme } = useEnv()
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
 
   const handleFn = useCallback(
     (poiId: string | string[]) => {

--- a/packages/triple-document/src/elements/tna/slot.tsx
+++ b/packages/triple-document/src/elements/tna/slot.tsx
@@ -20,7 +20,7 @@ export function Slot({
   const { t } = useTranslation('triple-frontend')
   const { colors } = useTheme()
   const trackEvent = useTrackEvent()
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
 
   const [showMore, setShowMore] = useState(false)
 

--- a/packages/triple-document/src/triple-document.tsx
+++ b/packages/triple-document/src/triple-document.tsx
@@ -43,7 +43,7 @@ export function TripleDocument({
 } & TripleDocumentContext) {
   const trackEventWithMetadata = useTrackEventWithMetadata()
   const trackResourceEvent = useEventResourceTracker()
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
   const routeExternally = useExternalRouter()
 
   const handleAction = useMemo(

--- a/packages/triple-header/src/frame/frame.tsx
+++ b/packages/triple-header/src/frame/frame.tsx
@@ -47,7 +47,7 @@ export function Frame({
   const heightRatio = calculateFrameRatio(height)
 
   const trackEventWithMetadata = useTrackEventWithMetadata()
-  const navigate = useNavigate()
+  const { navigate } = useNavigate()
   const routeExternally = useExternalRouter()
 
   const handleAction = useMemo(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
 
   packages/router:
     dependencies:
+      '@titicaca/triple-web-to-native-interfaces':
+        specifier: 1.9.0
+        version: 1.9.0
       '@titicaca/view-utilities':
         specifier: workspace:*
         version: link:../view-utilities


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
기존 history-context의 openWindow를 router의 navigate로 이동합니다.
기존의 useNavigate는 사용시 디스트럭쳐링이 필요하게 됩니다.
(https://github.com/titicacadev/triple-frontend/pull/3027 에서 이동했습니다.)
```tsx
// before
const navigate = useNavigate()

// after
const { navigate, openWindow } = useNavigate()
```
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

