### PR TITLE
[react-contexts] 틱톡 pixel 이벤트를 추가합니다.

### DIFF
--- a/packages/react-contexts/src/event-tracking-context/event-metadata-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-metadata-context.tsx
@@ -4,7 +4,8 @@ import { useEventTrackingContext } from './event-tracking-context'
 import {
   FirebaseAnalyticsParams,
   GoogleAnalyticsParams,
-  PixelParams,
+  FacebookPixelParams,
+  TiktokPixelEvent,
 } from './types'
 
 interface EventMetadataContext {
@@ -41,12 +42,14 @@ export function useEventTrackerWithMetadata() {
   return (params: {
     ga?: GoogleAnalyticsParams
     fa?: Partial<FirebaseAnalyticsParams>
-    pixel?: PixelParams
+    pixel?: FacebookPixelParams
+    tiktokPixel?: TiktokPixelEvent
   }) => {
     trackEvent({
       ga: getGoogleAnalyticsWithMetadata(params.ga, eventMetadata),
       fa: getFirebaseAnalyticsWithMetadata(params.fa, eventMetadata),
-      pixel: getPixelWithMetadata(params.pixel, eventMetadata),
+      pixel: getFacebookPixelWithMetadata(params.pixel, eventMetadata),
+      tiktokPixel: params.tiktokPixel,
     })
   }
 }
@@ -86,8 +89,8 @@ function getGoogleAnalyticsWithMetadata(
   return ga
 }
 
-function getPixelWithMetadata(
-  pixel?: PixelParams,
+function getFacebookPixelWithMetadata(
+  pixel?: FacebookPixelParams,
   eventMetaContext?: EventMetadataContext,
 ) {
   if (!pixel) {

--- a/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
@@ -29,6 +29,9 @@ import {
   FirebaseAnalyticsParams,
   GoogleAnalyticsParams,
   FacebookPixelParams,
+  TiktokPixelEvent,
+  TiktokPixelEventType,
+  TiktokPixelEventParams,
 } from './types'
 
 const NOOP = () => {}
@@ -49,6 +52,10 @@ export interface EventTrackingContextValue {
      * 그리고 type을 생략하면 맞춤 이벤트를 사용합니다.
      */
     pixel?: FacebookPixelParams
+    /**
+     * tiktok pixel 이벤트 파라미터
+     */
+    tiktokPixel?: TiktokPixelEvent
   }) => void
   /**
    * 하나의 파라미터로 GA, FA 이벤트를 기록합니다.
@@ -149,6 +156,7 @@ declare global {
       action: string,
       payload?: { [key: string]: unknown },
     ) => void
+    ttq?: (type: TiktokPixelEventType, params?: TiktokPixelEventParams) => void
   }
 }
 

--- a/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
@@ -213,7 +213,7 @@ export function EventTrackingProvider({
   )
 
   const trackEvent: EventTrackingContextValue['trackEvent'] = useCallback(
-    ({ ga, fa, pixel }) => {
+    ({ ga, fa, pixel, tiktokPixel }) => {
       try {
         if (window.ga && ga) {
           const [action, label] = ga
@@ -224,6 +224,10 @@ export function EventTrackingProvider({
           const { type = 'trackCustom', action, payload } = pixel
 
           window.fbq(type, action, { pageLabel, ...payload })
+        }
+
+        if (window.ttq && tiktokPixel) {
+          window.ttq(tiktokPixel.type, tiktokPixel.params)
         }
 
         const firebaseAnalyticsWebInstance = getFirebaseAnalyticsWebInstance()

--- a/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
+++ b/packages/react-contexts/src/event-tracking-context/event-tracking-context.tsx
@@ -28,7 +28,7 @@ import { useUser } from '../session-context'
 import {
   FirebaseAnalyticsParams,
   GoogleAnalyticsParams,
-  PixelParams,
+  FacebookPixelParams,
 } from './types'
 
 const NOOP = () => {}
@@ -48,7 +48,7 @@ export interface EventTrackingContextValue {
      * type을 "track"으로 설정하면 주어진 action만 사용할 수 있습니다.
      * 그리고 type을 생략하면 맞춤 이벤트를 사용합니다.
      */
-    pixel?: PixelParams
+    pixel?: FacebookPixelParams
   }) => void
   /**
    * 하나의 파라미터로 GA, FA 이벤트를 기록합니다.

--- a/packages/react-contexts/src/event-tracking-context/types.ts
+++ b/packages/react-contexts/src/event-tracking-context/types.ts
@@ -86,5 +86,5 @@ export interface TiktokPixelEventParams {
 
 export interface TiktokPixelEvent {
   type: TiktokPixelEventType
-  params: TiktokPixelEventParams
+  params?: TiktokPixelEventParams
 }

--- a/packages/react-contexts/src/event-tracking-context/types.ts
+++ b/packages/react-contexts/src/event-tracking-context/types.ts
@@ -6,16 +6,16 @@ export interface FirebaseAnalyticsParams {
 
 export type GoogleAnalyticsParams = (string | undefined)[]
 
-interface PixelPayload {
+interface FacebookPixelPayload {
   [key: string]: unknown
 }
 
 /**
- * Pixel 표준 이벤트입니다.
+ * Facebook Pixel 표준 이벤트입니다.
  *
  * ref: https://www.facebook.com/business/help/402791146561655?id=1205376682832142
  */
-interface PixelStandardEvent {
+interface FacebookPixelStandardEvent {
   type: 'track'
   action:
     | 'AddPaymentInfo'
@@ -35,16 +35,16 @@ interface PixelStandardEvent {
     | 'SubmitApplication'
     | 'Subscribe'
     | 'ViewContent'
-  payload?: PixelPayload
+  payload?: FacebookPixelPayload
 }
 
-interface PixelCustomEvent {
+interface FacebookPixelCustomEvent {
   type: 'trackCustom'
   action: string
-  payload?: PixelPayload
+  payload?: FacebookPixelPayload
 }
 
-export type PixelParams =
-  | PixelStandardEvent
-  | PixelCustomEvent
-  | (Omit<PixelCustomEvent, 'type'> & { type?: never })
+export type FacebookPixelParams =
+  | FacebookPixelStandardEvent
+  | FacebookPixelCustomEvent
+  | (Omit<FacebookPixelCustomEvent, 'type'> & { type?: never })

--- a/packages/react-contexts/src/event-tracking-context/types.ts
+++ b/packages/react-contexts/src/event-tracking-context/types.ts
@@ -48,3 +48,43 @@ export type FacebookPixelParams =
   | FacebookPixelStandardEvent
   | FacebookPixelCustomEvent
   | (Omit<FacebookPixelCustomEvent, 'type'> & { type?: never })
+
+/**
+ * Tiktok Pixel 이벤트입니다.
+ *
+ * ref: https://ads.tiktok.com/gateway/docs/index?identify_key=2b9b4278e47b275f36e7c39a4af4ba067d088e031d5f5fe45d381559ac89ba48&language=ENGLISH&doc_id=1701890973258754#item-link-Install%20event%20code
+ */
+export type TiktokPixelEventType =
+  | 'AddPaymentInfo'
+  | 'AddToCart'
+  | 'AddToWishlist'
+  | 'ClickButton'
+  | 'CompletePayment'
+  | 'CompleteRegistration'
+  | 'Contact'
+  | 'Download'
+  | 'InitiateCheckout'
+  | 'PlaceAnOrder'
+  | 'Search'
+  | 'SubmitForm'
+  | 'Subscribe'
+  | 'ViewContent'
+
+export interface TiktokPixelEventParams {
+  content_type?: string
+  contents?: {
+    content_id?: string
+    content_name?: string
+    content_category?: string
+    price?: string
+    quantity?: number
+    brand?: string
+  }[]
+  currency?: string // ISO 4217
+  value?: number // total price of the order
+}
+
+export interface TiktokPixelEvent {
+  type: TiktokPixelEventType
+  params: TiktokPixelEventParams
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- 틱톡 픽셀 이벤트를 EventTrackingContext에 추가합니다.
  - [틱톡 픽셀 api 문서](https://ads.tiktok.com/gateway/docs/index?identify_key=2b9b4278e47b275f36e7c39a4af4ba067d088e031d5f5fe45d381559ac89ba48&language=ENGLISH&doc_id=1701890973258754#item-link-Track%20an%20event%20based%20on%20page%20load) 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 논의사항
v14에는 기존 pixel 항목이 facebookPixel로 변경될 예정입니다.
