### PR TITLE
[v14] 스토리북 코드 수정

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
-import { ClientAppName, TripleWeb } from '../packages/triple-web'
+import {
+  ClientAppName,
+  EventTrackingProvider,
+  TripleWeb,
+} from '../packages/triple-web'
 import { defaultTheme, GlobalStyle } from '../packages/tds-theme/src'
 import { TripleClientMetadataProvider } from '../packages/react-triple-client-interfaces/src'
 import { ThemeProvider } from 'styled-components'
+import i18n from './i18next'
 
 export function themeDecorator(Story) {
   return (
@@ -36,6 +41,10 @@ export function tripleWebProviderDecorator(Story) {
         afOnelinkId: '',
         afOnelinkPid: '',
         afOnelinkSubdomain: '',
+      }}
+      i18nProvider={{
+        i18n: i18n,
+        lang: 'ko',
       }}
       sessionProvider={{
         user: null,

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-  EnvProvider,
-  HistoryProvider,
-  SessionContextProvider,
-} from '../packages/react-contexts/src'
-import { TripleWeb } from '../packages/triple-web'
+import { ClientAppName, TripleWeb } from '../packages/triple-web'
 import { defaultTheme, GlobalStyle } from '../packages/tds-theme/src'
 import { TripleClientMetadataProvider } from '../packages/react-triple-client-interfaces/src'
 import { ThemeProvider } from 'styled-components'
@@ -18,54 +13,33 @@ export function themeDecorator(Story) {
   )
 }
 
-export function envProviderDecorator(Story) {
-  return (
-    <EnvProvider
-      appUrlScheme="dev-soto"
-      webUrlBase="https://triple-dev.titicaca-corp.com"
-      authBasePath="MOCK_AUTH_BASE_PATH"
-      facebookAppId=""
-      defaultPageTitle=""
-      defaultPageDescription=""
-      googleMapsApiKey="AIzaSyDuSWU_yBwuQzeyRFcTqhyifqNX_8oaXI4"
-      afOnelinkId=""
-      afOnelinkPid=""
-      afOnelinkSubdomain=""
-    >
-      <Story />
-    </EnvProvider>
-  )
-}
-
-export function historyProviderDecorator(Story) {
-  return (
-    <HistoryProvider
-      isPublic={false}
-      isAndroid={false}
-      transitionModalHash="transition.general"
-    >
-      <Story />
-    </HistoryProvider>
-  )
-}
-
-export function sessionContextProviderDecorator(Story) {
-  return (
-    <SessionContextProvider
-      type="browser"
-      props={{
-        initialUser: undefined,
-        initialSessionAvailability: false,
-      }}
-    >
-      <Story />
-    </SessionContextProvider>
-  )
-}
-
-export function userAgentProviderDecorator(Story) {
+export function tripleWebProviderDecorator(Story) {
   return (
     <TripleWeb
+      clientAppProvider={{
+        metadata: {
+          name: ClientAppName.iOS,
+          version: '6.5.0',
+        },
+        device: {
+          autoplay: 'always',
+          networkType: 'wifi',
+        },
+      }}
+      envProvider={{
+        appUrlScheme: 'dev-soto',
+        webUrlBase: 'https://triple-dev.titicaca-corp.com',
+        facebookAppId: '',
+        defaultPageTitle: '',
+        defaultPageDescription: '',
+        googleMapsApiKey: 'AIzaSyDuSWU_yBwuQzeyRFcTqhyifqNX_8oaXI4',
+        afOnelinkId: '',
+        afOnelinkPid: '',
+        afOnelinkSubdomain: '',
+      }}
+      sessionProvider={{
+        user: null,
+      }}
       userAgentProvider={{
         ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148;Triple-iOS/6.5.0',
         browser: { name: 'WebKit', version: '605.1.15', major: '605' },
@@ -73,6 +47,7 @@ export function userAgentProviderDecorator(Story) {
         os: { name: 'iOS', version: '13.3.1' },
         device: { vendor: 'Apple', model: 'iPhone', type: 'mobile' },
         cpu: { architecture: undefined },
+        isMobile: true,
       }}
     >
       <Story />

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,9 +1,5 @@
 import React from 'react'
-import {
-  ClientAppName,
-  EventTrackingProvider,
-  TripleWeb,
-} from '../packages/triple-web'
+import { ClientAppName, TripleWeb } from '../packages/triple-web'
 import { defaultTheme, GlobalStyle } from '../packages/tds-theme/src'
 import { TripleClientMetadataProvider } from '../packages/react-triple-client-interfaces/src'
 import { ThemeProvider } from 'styled-components'
@@ -47,7 +43,9 @@ export function tripleWebProviderDecorator(Story) {
         lang: 'ko',
       }}
       sessionProvider={{
-        user: null,
+        user: {
+          id: 'FA1243567',
+        },
       }}
       userAgentProvider={{
         ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148;Triple-iOS/6.5.0',

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,6 +14,18 @@ const config: StorybookConfig = {
     '@storybook/addon-essentials',
     '@storybook/addon-onboarding',
     'storybook-react-i18next',
+    {
+      name: 'storybook-addon-swc',
+      options: {
+        swcLoaderOptions: {
+          jsc: {
+            experimental: {
+              plugins: [['@swc/plugin-styled-components', {}]],
+            },
+          },
+        },
+      },
+    },
   ],
   typescript: {
     reactDocgenTypescriptOptions: {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -23,9 +23,6 @@ const config: StorybookConfig = {
   framework: {
     name: '@storybook/nextjs',
     options: {
-      builder: {
-        useSWC: true,
-      },
       fastRefresh: true,
       strictMode: true,
     },

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,11 +3,8 @@ import { initialize, mswLoader } from 'msw-storybook-addon'
 import { mockDateDecorator } from 'storybook-mock-date-decorator'
 import {
   themeDecorator,
+  tripleWebProviderDecorator,
   tripleClientMetadataDecorator,
-  userAgentProviderDecorator,
-  historyProviderDecorator,
-  sessionContextProviderDecorator,
-  envProviderDecorator,
 } from './decorators'
 import i18n from './i18next'
 
@@ -26,11 +23,8 @@ const preview: Preview = {
   decorators: [
     mockDateDecorator,
     themeDecorator,
+    tripleWebProviderDecorator,
     tripleClientMetadataDecorator,
-    userAgentProviderDecorator,
-    historyProviderDecorator,
-    sessionContextProviderDecorator,
-    envProviderDecorator,
   ],
   globals: {
     locale: 'ko',

--- a/.swcrc
+++ b/.swcrc
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/swcrc",
   "module": {
-    "type": "commonjs"
+    "type": "es6"
   },
   "sourceMaps": true,
   "jsc": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-i18next": "13.5.0",
     "rimraf": "^5.0.5",
     "storybook": "^7.5.3",
+    "storybook-addon-swc": "^1.2.0",
     "storybook-mock-date-decorator": "^1.0.1",
     "storybook-react-i18next": "^2.0.9",
     "styled-components": "^5.3.11",

--- a/packages/react-triple-client-interfaces/src/app-bridge/index.ts
+++ b/packages/react-triple-client-interfaces/src/app-bridge/index.ts
@@ -1,5 +1,2 @@
-export {
-  AppSpecificLinkProps,
-  appSpecificLinkOptions,
-} from './app-specific-link-options'
+export * from './app-specific-link-options'
 export * from './use-triple-client-navigate'

--- a/packages/tds-ui/src/components/accordion/accordion.stories.tsx
+++ b/packages/tds-ui/src/components/accordion/accordion.stories.tsx
@@ -8,7 +8,7 @@ import { AccordionFolded } from './accordion-folded'
 import { AccordionTitle } from './accordion-title'
 
 export default {
-  title: 'core-elements / Accordion',
+  title: 'tds-ui / Accordion',
   component: Accordion,
   subcomponents: {
     AccordionContent,

--- a/packages/tds-ui/src/components/button/button.stories.tsx
+++ b/packages/tds-ui/src/components/button/button.stories.tsx
@@ -6,7 +6,7 @@ import { ButtonGroup } from './button-group'
 import { ButtonIcon } from './button-icon'
 
 export default {
-  title: 'core-elements / Button',
+  title: 'tds-ui / Button',
   component: Button,
   subcomponents: {
     ButtonContainer,

--- a/packages/tds-ui/src/components/carousel/carousel.stories.tsx
+++ b/packages/tds-ui/src/components/carousel/carousel.stories.tsx
@@ -4,7 +4,7 @@ import { Carousel } from './carousel'
 import IMAGES from './mocks/carousel.sample.json'
 
 const meta: Meta<typeof Carousel> = {
-  title: 'core-elements / Carousel / default',
+  title: 'tds-ui / Carousel / default',
   component: Carousel,
 }
 

--- a/packages/tds-ui/src/components/carousel/flicking-carousel.stories.tsx
+++ b/packages/tds-ui/src/components/carousel/flicking-carousel.stories.tsx
@@ -19,7 +19,7 @@ const FlickingScrollButton = styled.button<{
 `
 
 const meta: Meta<typeof FlickingCarousel> = {
-  title: 'core-elements / Carousel / FlickingCarousel',
+  title: 'tds-ui / Carousel / FlickingCarousel',
   component: FlickingCarousel,
 }
 

--- a/packages/tds-ui/src/components/checkbox-group/checkbox-group.stories.tsx
+++ b/packages/tds-ui/src/components/checkbox-group/checkbox-group.stories.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from '../checkbox'
 import { CheckboxGroup } from './checkbox-group'
 
 export default {
-  title: 'core-elements / CheckboxGroup',
+  title: 'tds-ui / CheckboxGroup',
   component: CheckboxGroup,
 } as Meta<typeof CheckboxGroup>
 

--- a/packages/tds-ui/src/components/checkbox/checkbox-base.stories.tsx
+++ b/packages/tds-ui/src/components/checkbox/checkbox-base.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryFn } from '@storybook/react'
 import { CheckboxBase } from './checkbox-base'
 
 export default {
-  title: 'core-elements / CheckboxBase',
+  title: 'tds-ui / CheckboxBase',
   component: CheckboxBase,
 } as Meta<typeof CheckboxBase>
 

--- a/packages/tds-ui/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/tds-ui/src/components/checkbox/checkbox.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Checkbox } from './checkbox'
 
 export default {
-  title: 'core-elements / Checkbox',
+  title: 'tds-ui / Checkbox',
   component: Checkbox,
 } as Meta<typeof Checkbox>
 

--- a/packages/tds-ui/src/components/confirm-selector/confirm-selector.stories.tsx
+++ b/packages/tds-ui/src/components/confirm-selector/confirm-selector.stories.tsx
@@ -3,7 +3,7 @@ import type { StoryFn, Meta } from '@storybook/react'
 import { ConfirmSelector } from './confirm-selector'
 
 export default {
-  title: 'core-elements / ConfirmSelector',
+  title: 'tds-ui / ConfirmSelector',
   component: ConfirmSelector,
 } as Meta<typeof ConfirmSelector>
 

--- a/packages/tds-ui/src/components/container/container.stories.tsx
+++ b/packages/tds-ui/src/components/container/container.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta } from '@storybook/react'
 import { Container } from './container'
 
 export default {
-  title: 'core-elements / Container',
+  title: 'tds-ui / Container',
   component: Container,
 } as Meta
 

--- a/packages/tds-ui/src/components/drawer/drawer.stories.tsx
+++ b/packages/tds-ui/src/components/drawer/drawer.stories.tsx
@@ -7,7 +7,7 @@ import { Text } from '../text'
 import { Drawer } from './drawer'
 
 export default {
-  title: 'core-elements / Drawer',
+  title: 'tds-ui / Drawer',
   component: Drawer,
 } as Meta
 

--- a/packages/tds-ui/src/components/fieldset/fieldset.stories.tsx
+++ b/packages/tds-ui/src/components/fieldset/fieldset.stories.tsx
@@ -5,7 +5,7 @@ import { FieldsetLegend } from './fieldset-legend'
 import { useFieldset } from './use-fieldset'
 
 export default {
-  title: 'core-elements / Fieldset',
+  title: 'tds-ui / Fieldset',
   component: Fieldset,
 } as Meta<typeof Fieldset>
 

--- a/packages/tds-ui/src/components/flex-box/flex-box.stories.tsx
+++ b/packages/tds-ui/src/components/flex-box/flex-box.stories.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { FlexBox, FlexBoxItem } from '../flex-box'
 
 export default {
-  title: 'core-elements / FlexBox',
+  title: 'tds-ui / FlexBox',
   components: FlexBox,
   subcomponents: {
     FlexBoxItem,

--- a/packages/tds-ui/src/components/form-field/form-field.stories.tsx
+++ b/packages/tds-ui/src/components/form-field/form-field.stories.tsx
@@ -7,7 +7,7 @@ import { FormFieldHelp } from './form-field-help'
 import { FormFieldLabel } from './form-field-label'
 
 export default {
-  title: 'core-elements / FormField',
+  title: 'tds-ui / FormField',
   component: FormField,
 } as Meta<typeof FormField>
 

--- a/packages/tds-ui/src/components/gender-selector/gender-selector.stories.tsx
+++ b/packages/tds-ui/src/components/gender-selector/gender-selector.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { GenderSelector } from './gender-selector'
 
 export default {
-  title: 'core-elements / GenderSelector',
+  title: 'tds-ui / GenderSelector',
   component: GenderSelector,
 } as Meta<typeof GenderSelector>
 

--- a/packages/tds-ui/src/components/input/input.stories.tsx
+++ b/packages/tds-ui/src/components/input/input.stories.tsx
@@ -5,7 +5,7 @@ import { List } from '../list'
 import { Input } from './input'
 
 export default {
-  title: 'core-elements / Input',
+  title: 'tds-ui / Input',
   component: Input,
 } as Meta<typeof Input>
 

--- a/packages/tds-ui/src/components/label/label.stories.tsx
+++ b/packages/tds-ui/src/components/label/label.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Label } from './label'
 
 export default {
-  title: 'core-elements / Label',
+  title: 'tds-ui / Label',
   component: Label,
 } as Meta
 

--- a/packages/tds-ui/src/components/list/list.stories.tsx
+++ b/packages/tds-ui/src/components/list/list.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { List } from './list'
 
 export default {
-  title: 'core-elements / List',
+  title: 'tds-ui / List',
   component: List,
 } as Meta<typeof List>
 

--- a/packages/tds-ui/src/components/long-clickable/long-clickable.stories.tsx
+++ b/packages/tds-ui/src/components/long-clickable/long-clickable.stories.tsx
@@ -4,7 +4,7 @@ import { HR1 } from '../hr'
 import { longClickable } from './long-clickable'
 
 export default {
-  title: 'core-elements / longClickable',
+  title: 'tds-ui / longClickable',
   component: longClickable,
 }
 

--- a/packages/tds-ui/src/components/navbar/navbar.stories.tsx
+++ b/packages/tds-ui/src/components/navbar/navbar.stories.tsx
@@ -24,7 +24,7 @@ const Toc = styled.div`
 // ] as const
 
 export default {
-  title: 'core-elements / Navbar',
+  title: 'tds-ui / Navbar',
 }
 
 export function twoButtons() {

--- a/packages/tds-ui/src/components/numeric-spinner/numeric-spinner.stories.tsx
+++ b/packages/tds-ui/src/components/numeric-spinner/numeric-spinner.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { NumericSpinner } from './numeric-spinner'
 
 export default {
-  title: 'core-elements / NumericSpinner',
+  title: 'tds-ui / NumericSpinner',
   component: NumericSpinner,
 } as Meta<typeof NumericSpinner>
 

--- a/packages/tds-ui/src/components/radio-group/radio-group.stories.tsx
+++ b/packages/tds-ui/src/components/radio-group/radio-group.stories.tsx
@@ -6,7 +6,7 @@ import { Radio } from '../radio/radio'
 import { RadioGroup } from './radio-group'
 
 export default {
-  title: 'core-elements / RadioGroup',
+  title: 'tds-ui / RadioGroup',
   component: RadioGroup,
 } as Meta<typeof RadioGroup>
 

--- a/packages/tds-ui/src/components/radio/radio.stories.tsx
+++ b/packages/tds-ui/src/components/radio/radio.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { Radio } from './radio'
 
 export default {
-  title: 'core-elements / Radio',
+  title: 'tds-ui / Radio',
   component: Radio,
 } as Meta<typeof Radio>
 

--- a/packages/tds-ui/src/components/rating/rating.stories.tsx
+++ b/packages/tds-ui/src/components/rating/rating.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryFn, StoryObj } from '@storybook/react'
 import { Rating } from './rating'
 
 export default {
-  title: 'core-elements / Rating',
+  title: 'tds-ui / Rating',
   component: Rating,
 } as Meta<typeof Rating>
 

--- a/packages/tds-ui/src/components/section/section.stories.tsx
+++ b/packages/tds-ui/src/components/section/section.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Section, SectionProps } from './section'
 
 export default {
-  title: 'core-elements / Section',
+  title: 'tds-ui / Section',
   component: Section,
 } as Meta
 

--- a/packages/tds-ui/src/components/segment/segment.stories.mdx
+++ b/packages/tds-ui/src/components/segment/segment.stories.mdx
@@ -3,7 +3,7 @@ import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
 import { Card } from '../card'
 import { Container } from '../container'
 
-<Meta title="Core-Elements / Card" component={Card} />
+<Meta title="tds-ui / Card" component={Card} />
 
 # Card
 

--- a/packages/tds-ui/src/components/select/select.stories.tsx
+++ b/packages/tds-ui/src/components/select/select.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Select } from './select'
 
 export default {
-  title: 'core-elements / Select',
+  title: 'tds-ui / Select',
   component: Select,
 } as Meta<typeof Select>
 

--- a/packages/tds-ui/src/components/skeleton/skeleton.stories.tsx
+++ b/packages/tds-ui/src/components/skeleton/skeleton.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from './skeleton'
 
 export default {
-  title: 'core-elements / Skeleton',
+  title: 'tds-ui / Skeleton',
 }
 
 export function BaseSkeleton() {

--- a/packages/tds-ui/src/components/spinner/spinner.stories.tsx
+++ b/packages/tds-ui/src/components/spinner/spinner.stories.tsx
@@ -2,7 +2,7 @@ import { RollingSpinner } from './rolling-spinner'
 import { Spinner } from './spinner'
 
 export default {
-  title: 'core-elements / Spinner',
+  title: 'tds-ui / Spinner',
 }
 
 export function BaseSpinner() {

--- a/packages/tds-ui/src/components/stack/stack.stories.tsx
+++ b/packages/tds-ui/src/components/stack/stack.stories.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { Stack } from './stack'
 
 export default {
-  title: 'core-elements / Stack',
+  title: 'tds-ui / Stack',
   component: Stack,
 } as Meta<typeof Stack>
 

--- a/packages/tds-ui/src/components/sticky-header/sticky-header.stories.tsx
+++ b/packages/tds-ui/src/components/sticky-header/sticky-header.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { StickyHeader } from './sticky-header'
 
 export default {
-  title: 'core-elements / StickyHeader',
+  title: 'tds-ui / StickyHeader',
   component: StickyHeader,
 } as Meta
 

--- a/packages/tds-ui/src/components/table/table.stories.tsx
+++ b/packages/tds-ui/src/components/table/table.stories.tsx
@@ -3,7 +3,7 @@ import SAMPLE from '../../mocks/table.sample.json'
 import { Table, TableProps } from './table'
 
 export default {
-  title: 'core-elements / Table',
+  title: 'tds-ui / Table',
   component: Table,
 }
 

--- a/packages/tds-ui/src/components/tabs/tabs.stories.tsx
+++ b/packages/tds-ui/src/components/tabs/tabs.stories.tsx
@@ -7,7 +7,7 @@ import { Tab } from './tab'
 import { TabPanel } from './tab-panel'
 
 export default {
-  title: 'core-elements / Tabs',
+  title: 'tds-ui / Tabs',
   component: Tabs,
   subcomponents: {
     TabList,

--- a/packages/tds-ui/src/components/textarea/textarea.stories.tsx
+++ b/packages/tds-ui/src/components/textarea/textarea.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Textarea } from './textarea'
 
 export default {
-  title: 'core-elements / Textarea',
+  title: 'tds-ui / Textarea',
   component: Textarea,
 } as Meta<typeof Textarea>
 

--- a/packages/tds-ui/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/tds-ui/src/components/tooltip/tooltip.stories.tsx
@@ -6,7 +6,7 @@ import { Navbar } from '../navbar'
 import { Tooltip } from './tooltip'
 
 export default {
-  title: 'core-elements / Tooltip',
+  title: 'tds-ui / Tooltip',
   component: Tooltip,
 } as Meta
 

--- a/packages/tds-widget/src/app-banner/app-banner.stories.tsx
+++ b/packages/tds-widget/src/app-banner/app-banner.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import AppBanner from '.'
+import { AppBanner } from './app-banner'
 
 export default {
   title: 'app-banner / AppBanner',

--- a/packages/tds-widget/src/booking-completion/booking-completion.stories.tsx
+++ b/packages/tds-widget/src/booking-completion/booking-completion.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import { BookingCompletion } from '.'
 
 export default {
   title: 'booking-completion / Booking Complete',
   component: BookingCompletion,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta
 
 export const Basic: StoryObj<typeof BookingCompletion> = {

--- a/packages/tds-widget/src/booking-completion/booking-completion.stories.tsx
+++ b/packages/tds-widget/src/booking-completion/booking-completion.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import BookingCompletion from '.'
+import { BookingCompletion } from '.'
 
 export default {
   title: 'booking-completion / Booking Complete',

--- a/packages/tds-widget/src/directions-finder/directions-finder.stories.tsx
+++ b/packages/tds-widget/src/directions-finder/directions-finder.stories.tsx
@@ -1,13 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import DirectionsFinder from '.'
+import { DirectionButtons } from './direction-buttons'
 
 export default {
-  title: 'directions-finder / DirectionsFinder',
-  component: DirectionsFinder,
-} as Meta<typeof DirectionsFinder>
+  title: 'directions-finder / DirectionButtons',
+  component: DirectionButtons,
+} as Meta<typeof DirectionButtons>
 
-export const Basic: StoryObj<typeof DirectionsFinder> = {
+export const Basic: StoryObj<typeof DirectionButtons> = {
   args: {
     primaryName: '도쿄 디즈니 랜드',
     localName: '東京ディズニーランド',

--- a/packages/tds-widget/src/directions-finder/directions-finder.stories.tsx
+++ b/packages/tds-widget/src/directions-finder/directions-finder.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import { DirectionButtons } from './direction-buttons'
 
 export default {
   title: 'directions-finder / DirectionButtons',
   component: DirectionButtons,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta<typeof DirectionButtons>
 
 export const Basic: StoryObj<typeof DirectionButtons> = {

--- a/packages/tds-widget/src/footer/award-footer.stories.tsx
+++ b/packages/tds-widget/src/footer/award-footer.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import { AwardFooter } from './award-footer'
 
 export default {
   title: 'footer / AwardFooter',
   component: AwardFooter,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta<typeof AwardFooter>
 
 export const Basic: StoryObj<typeof AwardFooter> = {}

--- a/packages/tds-widget/src/footer/footer.stories.tsx
+++ b/packages/tds-widget/src/footer/footer.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import Footer from './default-footer'
 
 export default {
   title: 'footer / Footer',
   component: Footer,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta<typeof Footer>
 
 export const Basic: StoryObj<typeof Footer> = {}

--- a/packages/tds-widget/src/listing-filter/listing-filter-expanding-filter-entry.stories.tsx
+++ b/packages/tds-widget/src/listing-filter/listing-filter-expanding-filter-entry.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import ListingFilter from './listing-filter'
+import { ListingFilter } from './listing-filter'
 
 export default {
   title: 'listing-filter / ListingFilter.ExpandingFilterEntry',

--- a/packages/tds-widget/src/listing-filter/listing-filter-filter-entry.stories.tsx
+++ b/packages/tds-widget/src/listing-filter/listing-filter-filter-entry.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import ListingFilter from './listing-filter'
+import { ListingFilter } from './listing-filter'
 
 export default {
   title: 'listing-filter / ListingFilter.FilterEntry',

--- a/packages/tds-widget/src/listing-filter/listing-filter-primary-filter-entry.stories.tsx
+++ b/packages/tds-widget/src/listing-filter/listing-filter-primary-filter-entry.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import ListingFilter from './listing-filter'
+import { ListingFilter } from './listing-filter'
 
 export default {
   title: 'listing-filter / ListingFilter.PrimaryFilterEntry',

--- a/packages/tds-widget/src/listing-filter/listing-filter.stories.tsx
+++ b/packages/tds-widget/src/listing-filter/listing-filter.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import ListingFilter from './listing-filter'
+import { ListingFilter } from './listing-filter'
 
 export default {
   title: 'listing-filter / ListingFilter',

--- a/packages/tds-widget/src/location-properties/location-properties.stories.tsx
+++ b/packages/tds-widget/src/location-properties/location-properties.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import LocationProperties from './location-properties'
+import { LocationProperties } from './location-properties'
 
 export default {
   title: 'Location-Properties / LocationProperties',

--- a/packages/tds-widget/src/location-properties/location-properties.stories.tsx
+++ b/packages/tds-widget/src/location-properties/location-properties.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import { LocationProperties } from './location-properties'
 
 export default {
   title: 'Location-Properties / LocationProperties',
   component: LocationProperties,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta<typeof LocationProperties>
 
 export const Basic: StoryObj<typeof LocationProperties> = {

--- a/packages/tds-widget/src/nearby-pois/nearby-pois.stories.tsx
+++ b/packages/tds-widget/src/nearby-pois/nearby-pois.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import { NearbyPois } from './nearby-pois'
 
 export default {
   title: 'Nearby-Pois / NearbyPois',
   component: NearbyPois,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta<typeof NearbyPois>
 
 // TODO: 서버에 데이터가 없어서 mocking 해야 할 듯

--- a/packages/tds-widget/src/nearby-pois/nearby-pois.stories.tsx
+++ b/packages/tds-widget/src/nearby-pois/nearby-pois.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import NearbyPois from './nearby-pois'
+import { NearbyPois } from './nearby-pois'
 
 export default {
   title: 'Nearby-Pois / NearbyPois',

--- a/packages/tds-widget/src/poi-detail/detail-header-v2.stories.tsx
+++ b/packages/tds-widget/src/poi-detail/detail-header-v2.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import DetailHeaderV2 from './detail-header-v2'
 
 export default {
   title: 'poi-detail / DetailHeader V2',
   component: DetailHeaderV2,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta<typeof DetailHeaderV2>
 
 export const Basic: StoryObj<typeof DetailHeaderV2> = {

--- a/packages/tds-widget/src/poi-detail/detail-header.stories.tsx
+++ b/packages/tds-widget/src/poi-detail/detail-header.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import DetailHeader from './detail-header'
 
 export default {
   title: 'poi-detail / DetailHeader',
   component: DetailHeader,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta
 
 export const Basic: StoryObj<typeof DetailHeader> = {

--- a/packages/tds-widget/src/poi-detail/index.ts
+++ b/packages/tds-widget/src/poi-detail/index.ts
@@ -3,7 +3,7 @@ export { default as DetailHeader } from './detail-header'
 export { default as ImageCarousel } from './image-carousel'
 export {
   ImageCarouselProvider,
-  ImageCarouselProviderProps,
+  type ImageCarouselProviderProps,
   useImageCarousel,
 } from './image-carousel/provider'
 export { default as RecommendedArticles } from './recommended-articles'

--- a/packages/tds-widget/src/poi-detail/recommended-articles.stories.tsx
+++ b/packages/tds-widget/src/poi-detail/recommended-articles.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { rest } from 'msw'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import RECOMMNEDED_ARTICLES from './mocks/recommended-articles.json'
 import INVENTORY_ITEMS from './mocks/inventory-item.json'
@@ -8,6 +9,13 @@ import RecommendedArticles from './recommended-articles/recommended-articles'
 const meta: Meta<typeof RecommendedArticles> = {
   title: 'poi-detail / RecommendedArticles',
   component: RecommendedArticles,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 }
 
 export default meta

--- a/packages/tds-widget/src/poi-list-elements/extended-poi-list-element.tsx
+++ b/packages/tds-widget/src/poi-list-elements/extended-poi-list-element.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useScrap } from '../scrap'
 import {
   ExtendedResourceListElement,
-  ResourceListElementProps,
+  type ResourceListElementProps,
 } from '../resource-list-elements'
 
 import { POI_IMAGE_PLACEHOLDERS } from './constants'

--- a/packages/tds-widget/src/poi-list-elements/poi-card-element.stories.tsx
+++ b/packages/tds-widget/src/poi-list-elements/poi-card-element.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import PoiCardElement from './poi-card-element'
 
 export default {
   title: 'poi-list-elements / PoiCardElement',
   component: PoiCardElement,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta<typeof PoiCardElement>
 
 export const Hotel: StoryObj<typeof PoiCardElement> = {

--- a/packages/tds-widget/src/poi-list-elements/poi-carousel-element.stories.tsx
+++ b/packages/tds-widget/src/poi-list-elements/poi-carousel-element.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import PoiCarouselElement from './carousel-element'
 import POIS from './mocks/pois.sample.json'
@@ -6,6 +7,13 @@ import POIS from './mocks/pois.sample.json'
 export default {
   title: 'poi-list-elements / PoiCarouselElement',
   component: PoiCarouselElement,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta<typeof PoiCarouselElement>
 
 const [POI] = POIS

--- a/packages/tds-widget/src/poi-list-elements/poi-list-element.stories.tsx
+++ b/packages/tds-widget/src/poi-list-elements/poi-list-element.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import HOTELS from './mocks/hotels.sample.json'
 import POIS from './mocks/pois.sample.json'
@@ -7,6 +8,13 @@ import { PoiListElement } from './poi-list-element'
 export default {
   title: 'poi-list-elements / PoiList',
   component: PoiListElement,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta<typeof PoiListElement>
 
 const [POI] = POIS

--- a/packages/tds-widget/src/public-header/public-header.stories.tsx
+++ b/packages/tds-widget/src/public-header/public-header.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryFn, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import { PublicHeader } from './public-header'
 
 export default {
   title: 'public-header / PublicHeader',
   component: PublicHeader,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
   argTypes: {
     category: {
       control: { type: 'select' },

--- a/packages/tds-widget/src/recommended-contents/recommended-contents.stories.tsx
+++ b/packages/tds-widget/src/recommended-contents/recommended-contents.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { contents } from './mocks/recommended-contents.sample.json'
-import RecommendedContents from './recommended-contents'
+import { RecommendedContents } from './recommended-contents'
 
 export default {
   title: 'recommended-contents / RecommendedContents',

--- a/packages/tds-widget/src/replies/replies.stories.tsx
+++ b/packages/tds-widget/src/replies/replies.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import Replies from './replies'
 
 export default {
   title: 'replies / Replies',
   component: Replies,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
   argTypes: {
     resourceId: {
       type: 'string',

--- a/packages/tds-widget/src/resource-list-elements/extended-resource-list-element.stories.tsx
+++ b/packages/tds-widget/src/resource-list-elements/extended-resource-list-element.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react'
 import { Container } from '@titicaca/tds-ui'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import Pricing from '../pricing'
 import { ScrapButtonMask } from '../scrap-button'
@@ -9,6 +10,13 @@ import ExtendedResourceListElement from './extended-resource-list-element'
 const meta: Meta<typeof ExtendedResourceListElement> = {
   title: 'resource-list-element / extended-resource-list-element',
   component: ExtendedResourceListElement,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 }
 
 const defaultArgs = {

--- a/packages/tds-widget/src/resource-list-elements/index.ts
+++ b/packages/tds-widget/src/resource-list-elements/index.ts
@@ -4,5 +4,5 @@ export { default as ResourceListElementStats } from './resource-list-element-sta
 
 export {
   default as ExtendedResourceListElement,
-  ResourceListElementProps,
+  type ResourceListElementProps,
 } from './extended-resource-list-element'

--- a/packages/tds-widget/src/review/review-element.stories.tsx
+++ b/packages/tds-widget/src/review/review-element.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { QueryClient, QueryClientProvider } from 'react-query'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import { ReviewElement } from './components/review-element'
 import duoImagesData from './mocks/review-element.duo-images.json'
@@ -23,6 +24,11 @@ const meta: Meta<typeof ReviewElement> = {
       <QueryClientProvider client={queryClient}>
         <Story />
       </QueryClientProvider>
+    ),
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
     ),
   ],
 }

--- a/packages/tds-widget/src/review/reviews-placeholder.stories.tsx
+++ b/packages/tds-widget/src/review/reviews-placeholder.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import { ReviewsPlaceholder } from './components/review-placeholder-with-rating'
 
 const meta: Meta<typeof ReviewsPlaceholder> = {
   title: 'Review / Review Placeholder',
   component: ReviewsPlaceholder,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 }
 
 export default meta

--- a/packages/tds-widget/src/review/reviews-shorten.stories.tsx
+++ b/packages/tds-widget/src/review/reviews-shorten.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { EventTrackingProvider, TransitionModal } from '@titicaca/triple-web'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { authHandlers, handlers } from './mocks/reviews'
@@ -14,12 +14,6 @@ const meta: Meta<typeof ReviewsShorten> = {
   title: 'Review / ReviewsShorten',
   component: ReviewsShorten,
   decorators: [
-    (Story) => (
-      <>
-        <Story />
-        <TransitionModal />
-      </>
-    ),
     (Story) => (
       <QueryClientProvider client={queryClient}>
         <Story />

--- a/packages/tds-widget/src/review/reviews-shorten.stories.tsx
+++ b/packages/tds-widget/src/review/reviews-shorten.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { TransitionModal } from '@titicaca/triple-web'
+import { EventTrackingProvider, TransitionModal } from '@titicaca/triple-web'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { authHandlers, handlers } from './mocks/reviews'
@@ -31,6 +31,12 @@ const meta: Meta<typeof ReviewsShorten> = {
           <Story />
         </SortingOptionsProvider>
       </FilterProvider>
+    ),
+
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
     ),
   ],
 }

--- a/packages/tds-widget/src/review/reviews-shorten.stories.tsx
+++ b/packages/tds-widget/src/review/reviews-shorten.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof ReviewsShorten> = {
     (Story) => (
       <>
         <Story />
-        <TransitionModal deepLink="/" />
+        <TransitionModal />
       </>
     ),
     (Story) => (

--- a/packages/tds-widget/src/review/reviews.stories.tsx
+++ b/packages/tds-widget/src/review/reviews.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof Reviews> = {
     (Story) => (
       <>
         <Story />
-        <TransitionModal deepLink="/" />
+        <TransitionModal />
       </>
     ),
     (Story) => (

--- a/packages/tds-widget/src/review/reviews.stories.tsx
+++ b/packages/tds-widget/src/review/reviews.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { TransitionModal } from '@titicaca/triple-web'
+import { EventTrackingProvider, TransitionModal } from '@titicaca/triple-web'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { authHandlers, handlers } from './mocks/reviews'
@@ -31,6 +31,12 @@ const meta: Meta<typeof Reviews> = {
           <Story />
         </SortingOptionsProvider>
       </FilterProvider>
+    ),
+
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
     ),
   ],
 }

--- a/packages/tds-widget/src/review/reviews.stories.tsx
+++ b/packages/tds-widget/src/review/reviews.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { EventTrackingProvider, TransitionModal } from '@titicaca/triple-web'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 import { QueryClient, QueryClientProvider } from 'react-query'
 
 import { authHandlers, handlers } from './mocks/reviews'
@@ -14,12 +14,6 @@ const meta: Meta<typeof Reviews> = {
   title: 'Review / Reviews',
   component: Reviews,
   decorators: [
-    (Story) => (
-      <>
-        <Story />
-        <TransitionModal />
-      </>
-    ),
     (Story) => (
       <QueryClientProvider client={queryClient}>
         <Story />

--- a/packages/tds-widget/src/scrap-button/outline-scrap-button.stories.tsx
+++ b/packages/tds-widget/src/scrap-button/outline-scrap-button.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import { OutlineScrapButton } from '.'
 
 const meta: Meta<typeof OutlineScrapButton> = {
   title: 'ScrapButton / OutlineScrapButton',
   component: OutlineScrapButton,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 }
 
 export default meta

--- a/packages/tds-widget/src/scrap-button/overlay-scrap-button.stories.tsx
+++ b/packages/tds-widget/src/scrap-button/overlay-scrap-button.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import { OverlayScrapButton } from '.'
 
 const meta: Meta<typeof OverlayScrapButton> = {
   title: 'ScrapButton / OverlayScrapButton',
   component: OverlayScrapButton,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 }
 
 export default meta

--- a/packages/tds-widget/src/search/search.stories.tsx
+++ b/packages/tds-widget/src/search/search.stories.tsx
@@ -1,33 +1,33 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import Search from './search'
+import { FullScreenSearchView } from './search'
 
 export default {
   title: 'search / Search',
-  component: Search,
-} as Meta<typeof Search>
+  component: FullScreenSearchView,
+} as Meta<typeof FullScreenSearchView>
 
-export const Basic: StoryObj<typeof Search> = {
+export const Basic: StoryObj<typeof FullScreenSearchView> = {
   args: {
     placeholder: '“항공권 예약” 도시이름으로 검색',
   },
 }
 
-export const Borderless: StoryObj<typeof Search> = {
+export const Borderless: StoryObj<typeof FullScreenSearchView> = {
   args: {
     ...Basic.args,
     borderless: true,
   },
 }
 
-export const DefaultKeyword: StoryObj<typeof Search> = {
+export const DefaultKeyword: StoryObj<typeof FullScreenSearchView> = {
   args: {
     ...Basic.args,
     defaultKeyword: '제주',
   },
 }
 
-export const Controlled: StoryObj<typeof Search> = {
+export const Controlled: StoryObj<typeof FullScreenSearchView> = {
   args: {
     ...Basic.args,
     keyword: '인천',

--- a/packages/tds-widget/src/social-reviews/social-reviews.stories.tsx
+++ b/packages/tds-widget/src/social-reviews/social-reviews.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import SocialReviews from './social-review'
 
 export default {
   title: 'Social-Reviews / SocialReviews',
   component: SocialReviews,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta<typeof SocialReviews>
 
 export const Basic: StoryObj<typeof SocialReviews> = {

--- a/packages/triple-document/src/elements/coupon/modals.tsx
+++ b/packages/triple-document/src/elements/coupon/modals.tsx
@@ -114,7 +114,7 @@ export function CouponModal({ identifier }: { identifier: string }) {
       </Text>
 
       <Modal.Actions>
-        <Modal.Action color="gray" onClick={back}>
+        <Modal.Action color="gray" onClick={() => removeUriHash()}>
           {t('취소')}
         </Modal.Action>
         <Modal.Action

--- a/packages/triple-document/src/pois.stories.tsx
+++ b/packages/triple-document/src/pois.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import POIS from './mocks/pois.sample.json'
 import HOTEL from './mocks/hotel.sample.json'
@@ -9,6 +10,13 @@ const { pois: Pois } = ELEMENTS
 export default {
   title: 'triple-document / POI',
   component: Pois,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta
 
 export function Normal() {

--- a/packages/triple-document/src/tna-slot.stories.tsx
+++ b/packages/triple-document/src/tna-slot.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta } from '@storybook/react'
 import { rest } from 'msw'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import ELEMENTS from './elements'
 import SLOTS from './mocks/slots.sample.json'
@@ -9,6 +10,13 @@ const { tnaProducts: TnaProducts } = ELEMENTS
 export default {
   title: 'triple-document / T&A Slot',
   component: TnaProducts,
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta
 
 export function InTripleDocument() {

--- a/packages/triple-document/src/triple-document.stories.tsx
+++ b/packages/triple-document/src/triple-document.stories.tsx
@@ -3,6 +3,7 @@ import { Container } from '@titicaca/tds-ui'
 import { useScrollToAnchor } from '@titicaca/react-hooks'
 import { rest } from 'msw'
 import { useEffect } from 'react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import ELEMENTS from './elements'
 import MOCK_EMBEDDED from './mocks/triple-document.embedded.json'
@@ -27,6 +28,13 @@ const {
 
 export default {
   title: 'triple-document / TripleDocument',
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta
 
 export const Sample: StoryObj<typeof TripleDocument> = {

--- a/packages/triple-email-document/src/components/index.ts
+++ b/packages/triple-email-document/src/components/index.ts
@@ -1,1 +1,1 @@
-export { default as EmailPreview, PreviewDocument } from './preview'
+export { default as EmailPreview, type PreviewDocument } from './preview'

--- a/packages/triple-header/src/triple-header.stories.tsx
+++ b/packages/triple-header/src/triple-header.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta } from '@storybook/react'
+import { EventTrackingProvider } from '@titicaca/triple-web'
 
 import SAMPLE from './mocks/triple-header.sample.json'
 import TripleHeader from './triple-header'
@@ -6,6 +7,13 @@ import { TripleHeader as TripleHeaderProps } from './types'
 
 export default {
   title: 'triple-header / TripleHeader',
+  decorators: [
+    (Story) => (
+      <EventTrackingProvider page={{ path: '/', label: 'test' }} utm={{}}>
+        <Story />
+      </EventTrackingProvider>
+    ),
+  ],
 } as Meta<typeof TripleHeader>
 
 export function Sample() {

--- a/packages/triple-web/src/components/event-tracking-provider.tsx
+++ b/packages/triple-web/src/components/event-tracking-provider.tsx
@@ -20,7 +20,9 @@ export function EventTrackingProvider({
   const { user } = useSession()
 
   useEffect(() => {
-    setUserId(firebaseAnalytics, user?.uid ?? null)
+    if (firebaseAnalytics) {
+      setUserId(firebaseAnalytics, user?.uid ?? null)
+    }
   }, [user?.uid])
 
   useEffect(() => {

--- a/packages/triple-web/src/contexts/client-app.ts
+++ b/packages/triple-web/src/contexts/client-app.ts
@@ -1,17 +1,7 @@
-import { createContext, useContext } from 'react'
+import { createContext } from 'react'
 
 import { ClientAppValue } from '../types'
 
 export const ClientAppContext = createContext<ClientAppValue | undefined>(
   undefined,
 )
-
-export function useClientApp() {
-  const context = useContext(ClientAppContext)
-
-  if (context === undefined) {
-    throw new Error('ClientAppContext가 없습니다.')
-  }
-
-  return context
-}

--- a/packages/triple-web/src/contexts/session.tsx
+++ b/packages/triple-web/src/contexts/session.tsx
@@ -3,7 +3,6 @@ import {
   PropsWithChildren,
   SetStateAction,
   createContext,
-  useContext,
   useState,
 } from 'react'
 
@@ -15,16 +14,6 @@ export const SessionStateContext = createContext<SessionValue | undefined>(
 export const SessionUpdaterContext = createContext<
   Dispatch<SetStateAction<SessionValue>> | undefined
 >(undefined)
-
-export function useSession() {
-  const context = useContext(SessionStateContext)
-
-  if (context === undefined) {
-    throw new Error('SessionContext가 없습니다.')
-  }
-
-  return context
-}
 
 export interface SessionProviderProps extends PropsWithChildren {
   initialSession: SessionValue

--- a/packages/triple-web/src/contexts/user-agent.tsx
+++ b/packages/triple-web/src/contexts/user-agent.tsx
@@ -1,17 +1,7 @@
-import { createContext, useContext } from 'react'
+import { createContext } from 'react'
 
 import { type UserAgentValue } from '../types'
 
 export const UserAgentContext = createContext<UserAgentValue | undefined>(
   undefined,
 )
-
-export function useUserAgent() {
-  const context = useContext(UserAgentContext)
-
-  if (context === undefined) {
-    throw new Error('UserAgentContext가 없습니다.')
-  }
-
-  return context
-}

--- a/packages/triple-web/src/hooks/client-app/use-client-app.ts
+++ b/packages/triple-web/src/hooks/client-app/use-client-app.ts
@@ -1,1 +1,13 @@
-export { useClientApp } from '../../contexts'
+import { useContext } from 'react'
+
+import { ClientAppContext } from '../../contexts'
+
+export function useClientApp() {
+  const context = useContext(ClientAppContext)
+
+  if (context === undefined) {
+    throw new Error('ClientAppContext가 없습니다.')
+  }
+
+  return context
+}

--- a/packages/triple-web/src/hooks/client-app/use-feature-flag.ts
+++ b/packages/triple-web/src/hooks/client-app/use-feature-flag.ts
@@ -1,6 +1,6 @@
 import * as semver from 'semver'
 
-import { useClientApp } from '../../contexts'
+import { useClientApp } from './use-client-app'
 
 type Operator = 'lt' | 'lte' | 'gt' | 'gte'
 

--- a/packages/triple-web/src/hooks/session/use-session.ts
+++ b/packages/triple-web/src/hooks/session/use-session.ts
@@ -1,1 +1,13 @@
-export { useSession } from '../../contexts'
+import { useContext } from 'react'
+
+import { SessionStateContext } from '../../contexts'
+
+export function useSession() {
+  const context = useContext(SessionStateContext)
+
+  if (context === undefined) {
+    throw new Error('SessionContext가 없습니다.')
+  }
+
+  return context
+}

--- a/packages/triple-web/src/hooks/user-agent/use-user-agent.ts
+++ b/packages/triple-web/src/hooks/user-agent/use-user-agent.ts
@@ -1,1 +1,13 @@
-export { useUserAgent } from '../../contexts'
+import { useContext } from 'react'
+
+import { UserAgentContext } from '../../contexts'
+
+export function useUserAgent() {
+  const context = useContext(UserAgentContext)
+
+  if (context === undefined) {
+    throw new Error('UserAgentContext가 없습니다.')
+  }
+
+  return context
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       storybook:
         specifier: ^7.5.3
         version: 7.6.4
+      storybook-addon-swc:
+        specifier: ^1.2.0
+        version: 1.2.0(@swc/core@1.3.99)(webpack@5.88.1)
       storybook-mock-date-decorator:
         specifier: ^1.0.1
         version: 1.0.1(react-dom@18.2.0)(react@18.2.0)
@@ -19559,6 +19562,25 @@ packages:
     resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
     dev: true
 
+  /storybook-addon-swc@1.2.0(@swc/core@1.3.99)(webpack@5.88.1):
+    resolution: {integrity: sha512-PEpxhAH+407KTcVDC7uUH4S26qtuBDC/JlZI3NqFYu0Tm2uCBf56On+13lK4iE3Iz8FORl4aSXo2RricJ/UhPQ==}
+    peerDependencies:
+      '@swc/core': ^1.2.152
+      terser-webpack-plugin: ^4.0.0 || ^5.0.0
+      webpack: ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      terser-webpack-plugin:
+        optional: true
+      webpack:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.2
+      '@swc/core': 1.3.99
+      deepmerge: 4.3.1
+      swc-loader: 0.1.16(@swc/core@1.3.99)(webpack@5.88.1)
+      webpack: 5.88.1(@swc/core@1.3.99)(esbuild@0.18.20)
+    dev: true
+
   /storybook-i18n@2.0.13(@storybook/components@7.6.4)(@storybook/manager-api@7.6.4)(@storybook/preview-api@7.6.4)(@storybook/types@7.6.4)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-p0VPL5QiHdeS3W9BvV7UnuTKw7Mj1HWLW67LK0EOoh5fpSQIchu7byfrUUe1RbCF1gT0gOOhdNuTSXMoVVoTDw==}
     peerDependencies:
@@ -20025,6 +20047,16 @@ packages:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
     dependencies:
       tslib: 2.6.2
+    dev: true
+
+  /swc-loader@0.1.16(@swc/core@1.3.99)(webpack@5.88.1):
+    resolution: {integrity: sha512-NKIm8aJjK/z/yfzk+v7YGwJMjBKaLaUs9ZKI2zoaIGKAjtkwjO92ZLI0fiTZuwzRqVLQl/29fBdSgFCBzquR0w==}
+    peerDependencies:
+      '@swc/core': ^1.2.147
+      webpack: '>=2'
+    dependencies:
+      '@swc/core': 1.3.99
+      webpack: 5.88.1(@swc/core@1.3.99)(esbuild@0.18.20)
     dev: true
 
   /swc-loader@0.2.3(@swc/core@1.3.99)(webpack@5.88.1):

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,62 +4,23 @@
     "baseUrl": ".",
     "paths": {
       "@titicaca/ab-experiments": ["./packages/ab-experiments/src"],
-      "@titicaca/action-sheet": ["./packages/action-sheet/src"],
-      "@titicaca/ad-banners": ["./packages/ad-banners/src"],
-      "@titicaca/app-banner": ["./packages/app-banner/src"],
-      "@titicaca/app-installation-cta": ["./packages/app-installation-cta/src"],
-      "@titicaca/author": ["./packages/author/src"],
-      "@titicaca/booking-completion": ["./packages/booking-completion/src"],
-      "@titicaca/carousel": ["./packages/carousel/src"],
-      "@titicaca/chat": ["./packages/chat/src"],
       "@titicaca/constants": ["./packages/constants/src"],
-      "@titicaca/content-sharing": ["./packages/content-sharing/src"],
-      "@titicaca/core-elements": ["./packages/core-elements/src"],
-      "@titicaca/date-picker": ["./packages/date-picker/src"],
-      "@titicaca/directions-finder": ["./packages/directions-finder/src"],
-      "@titicaca/drawer-button": ["./packages/drawer-button/src"],
       "@titicaca/fetcher": ["./packages/fetcher/src"],
-      "@titicaca/footer": ["./packages/footer/src"],
-      "@titicaca/hub-form": ["./packages/hub-form/src"],
       "@titicaca/i18n": ["./packages/i18n/src"],
-      "@titicaca/image-carousel": ["./packages/image-carousel/src"],
       "@titicaca/intersection-observer": [
         "./packages/intersection-observer/src"
       ],
-      "@titicaca/listing-filter": ["./packages/listing-filter/src"],
-      "@titicaca/location-properties": ["./packages/location-properties/src"],
-      "@titicaca/map": ["./packages/map/src"],
       "@titicaca/meta-tags": ["./packages/meta-tags/src"],
-      "@titicaca/modals": ["./packages/modals/src"],
-      "@titicaca/nearby-pois": ["./packages/nearby-pois/src"],
-      "@titicaca/poi-detail": ["./packages/poi-detail/src"],
-      "@titicaca/poi-list-elements": ["./packages/poi-list-elements/src"],
-      "@titicaca/popup": ["./packages/popup/src"],
-      "@titicaca/pricing": ["./packages/pricing/src"],
-      "@titicaca/public-header": ["./packages/public-header/src"],
-      "@titicaca/react-contexts": ["./packages/react-contexts/src"],
       "@titicaca/react-hooks": ["./packages/react-hooks/src"],
       "@titicaca/react-triple-client-interfaces": [
         "./packages/react-triple-client-interfaces/src"
       ],
-      "@titicaca/recommended-contents": ["./packages/recommended-contents/src"],
-      "@titicaca/replies": ["./packages/replies/src"],
-      "@titicaca/resource-list-element": [
-        "./packages/resource-list-element/src"
-      ],
-      "@titicaca/review": ["./packages/review/src"],
       "@titicaca/router": ["./packages/router/src"],
-      "@titicaca/scrap-button": ["./packages/scrap-button/src"],
       "@titicaca/scroll-spy": ["./packages/scroll-spy/src"],
       "@titicaca/scroll-to-element": ["./packages/scroll-to-element/src"],
-      "@titicaca/search": ["./packages/search/src"],
-      "@titicaca/slider": ["./packages/slider/src"],
-      "@titicaca/social-reviews": ["./packages/social-reviews/src"],
       "@titicaca/standard-action-handler": [
         "./packages/standard-action-handler/src"
       ],
-      "@titicaca/static-map": ["./packages/static-map/src"],
-      "@titicaca/static-page-contents": ["./packages/static-page-contents/src"],
       "@titicaca/tds-theme": ["./packages/tds-theme/src"],
       "@titicaca/tds-ui": ["./packages/tds-ui/src"],
       "@titicaca/tds-widget": ["./packages/tds-widget/src"],
@@ -72,11 +33,17 @@
       ],
       "@titicaca/triple-header": ["./packages/triple-header/src"],
       "@titicaca/triple-media": ["./packages/triple-media/src"],
+      "@titicaca/triple-web-binding-nextjs-pages": [
+        "./packages/triple-web-binding-nextjs-pages"
+      ],
+      "@titicaca/triple-web-binding-nextjs": [
+        "./packages/triple-web-binding-nextjs"
+      ],
+      "@titicaca/triple-web-utils": ["./packages/triple-web-utils"],
+      "@titicaca/triple-web": ["./packages/triple-web"],
       "@titicaca/type-definitions": ["./packages/type-definitions/src"],
       "@titicaca/ui-flow": ["./packages/ui-flow/src"],
-      "@titicaca/user-verification": ["./packages/user-verification/src"],
-      "@titicaca/view-utilities": ["./packages/view-utilities/src"],
-      "@titicaca/web-storage": ["./packages/web-storage/src"]
+      "@titicaca/view-utilities": ["./packages/view-utilities/src"]
     }
   },
   "include": ["global.d.ts", "**/*.ts", "**/*.tsx"],

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -33,14 +33,12 @@
       ],
       "@titicaca/triple-header": ["./packages/triple-header/src"],
       "@titicaca/triple-media": ["./packages/triple-media/src"],
-      "@titicaca/triple-web-binding-nextjs-pages": [
-        "./packages/triple-web-binding-nextjs-pages"
-      ],
-      "@titicaca/triple-web-binding-nextjs": [
-        "./packages/triple-web-binding-nextjs"
-      ],
-      "@titicaca/triple-web-utils": ["./packages/triple-web-utils"],
       "@titicaca/triple-web": ["./packages/triple-web"],
+      "@titicaca/triple-web-nextjs-pages": [
+        "./packages/triple-web-nextjs-pages"
+      ],
+      "@titicaca/triple-web-nextjs": ["./packages/triple-web-nextjs"],
+      "@titicaca/triple-web-utils": ["./packages/triple-web-utils"],
       "@titicaca/type-definitions": ["./packages/type-definitions/src"],
       "@titicaca/ui-flow": ["./packages/ui-flow/src"],
       "@titicaca/view-utilities": ["./packages/view-utilities/src"]


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

스토리북 관련 코드를 수정합니다.

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

### `storybook decorator` 수정
- 공통으로 분류되는 TripleWeb을 Root에 정의하고, EventTracking과 관련된 부분은 스토리 파일에 정의했습니다.
- react-contexts 관련 로직을 제거했습니다.

### tsconfig.test.json 수정

- 패키지명 변경으로 인해 전반적으로 수정했습니다.

### storybook-addon-swc 설치

- 기존에 css props가 적용이 안되고 있어서 이 부분도 추가 설정해줬습니다. 

### firebase 관련 로직 수정

- firebase app을 찾을 수 없어 스토리북이 깨지는 이슈를 수정했습니다.
- firebase 인스턴스가 있을 때에만 함수를 실행하도록 변경했습니다.

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 추후 계획

- storybook version 7 형식으로 전환
- tds-ui / tds-widget 스토리북 보완