### PR TITLE
[v14] useClientAppActions import path 수정

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -45,7 +45,6 @@
     "qs": "^6.11.2"
   },
   "devDependencies": {
-    "@titicaca/react-triple-client-interfaces": "workspace:*",
     "@titicaca/triple-web": "workspace:*",
     "@types/qs": "^6.9.9",
     "next": "^13.4.13",
@@ -53,7 +52,6 @@
     "styled-components": "^5.3.11"
   },
   "peerDependencies": {
-    "@titicaca/react-triple-client-interfaces": "*",
     "@titicaca/triple-web": "*",
     "next": "^13.0",
     "react": "^18.0",

--- a/packages/router/src/navigate/use-navigate.test.ts
+++ b/packages/router/src/navigate/use-navigate.test.ts
@@ -17,7 +17,6 @@ jest.mock('@titicaca/view-utilities', () => ({
   ...jest.requireActual('@titicaca/view-utilities'),
   checkIfRoutable: jest.fn(),
 }))
-jest.mock('@titicaca/react-triple-client-interfaces')
 
 const webUrlBase = mockWebUrlBase()
 const routablePath = mockRoutablePath()

--- a/packages/standard-action-handler/package.json
+++ b/packages/standard-action-handler/package.json
@@ -48,7 +48,6 @@
   "devDependencies": {
     "@titicaca/i18n": "workspace:*",
     "@titicaca/triple-web": "workspace:*",
-    "@titicaca/react-triple-client-interfaces": "workspace:*",
     "@types/qs": "^6.9.9",
     "i18next": "^23.7.6",
     "react": "^18.2.0"
@@ -56,7 +55,6 @@
   "peerDependencies": {
     "@titicaca/i18n": "*",
     "@titicaca/triple-web": "*",
-    "@titicaca/react-triple-client-interfaces": "*",
     "i18next": "*",
     "react": "^18.0",
     "styled-components": "^5.3.9"

--- a/packages/tds-widget/package.json
+++ b/packages/tds-widget/package.json
@@ -67,7 +67,6 @@
     "@graphql-codegen/typescript-generic-sdk": "^3.1.0",
     "@graphql-codegen/typescript-operations": "4.0.1",
     "@titicaca/i18n": "workspace:*",
-    "@titicaca/react-triple-client-interfaces": "workspace:*",
     "@titicaca/triple-web": "workspace:*",
     "@titicaca/tds-theme": "workspace:*",
     "@types/qs": "^6.9.8",
@@ -83,7 +82,6 @@
   "peerDependencies": {
     "@titicaca/i18n": "*",
     "@titicaca/triple-web": "*",
-    "@titicaca/react-triple-client-interfaces": "*",
     "@titicaca/tds-theme": "*",
     "i18next": "*",
     "next": "^13.4.13",

--- a/packages/tds-widget/src/poi-detail/detail-header-v2/index.test.tsx
+++ b/packages/tds-widget/src/poi-detail/detail-header-v2/index.test.tsx
@@ -8,7 +8,6 @@ import {
   ClientAppName,
 } from '@titicaca/triple-web'
 
-jest.mock('@titicaca/react-triple-client-interfaces')
 jest.mock('@titicaca/triple-web')
 jest.mock('@titicaca/tds-ui', () => ({
   ...jest.requireActual('@titicaca/tds-ui'),

--- a/packages/tds-widget/src/poi-detail/detail-header/index.test.tsx
+++ b/packages/tds-widget/src/poi-detail/detail-header/index.test.tsx
@@ -8,7 +8,6 @@ import {
   ClientAppName,
 } from '@titicaca/triple-web'
 
-jest.mock('@titicaca/react-triple-client-interfaces')
 jest.mock('@titicaca/triple-web')
 jest.mock('@titicaca/tds-ui', () => ({
   ...jest.requireActual('@titicaca/tds-ui'),

--- a/packages/tds-widget/src/replies/list/index.tsx
+++ b/packages/tds-widget/src/replies/list/index.tsx
@@ -1,7 +1,6 @@
 import { Container, HR1, List, Text, Confirm } from '@titicaca/tds-ui'
 import { useTranslation } from 'react-i18next'
-import { useHashRouter } from '@titicaca/triple-web'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
+import { useHashRouter, useClientAppActions } from '@titicaca/triple-web'
 
 import { Reply as ReplyType } from '../types'
 import { useRepliesContext } from '../context'
@@ -36,7 +35,7 @@ export default function ReplyList({
     initializeEditingMessage,
   } = useRepliesContext()
 
-  const { showToast } = useTripleClientActions()
+  const { showToast } = useClientAppActions()
 
   const description = mentioningUserName
     ? t('답글을 삭제하시겠습니까?')

--- a/packages/tds-widget/src/review/components/filter-context.tsx
+++ b/packages/tds-widget/src/review/components/filter-context.tsx
@@ -7,8 +7,7 @@ import {
   useContext,
   useEffect,
 } from 'react'
-import { useTrackEvent } from '@titicaca/triple-web'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
+import { useClientAppActions, useTrackEvent } from '@titicaca/triple-web'
 
 interface FilterValues {
   isRecentTrip: boolean
@@ -35,7 +34,7 @@ export function FilterProvider({
   const [isMediaCollection, setIsMediaCollection] = useState(initialMediaFilter)
 
   const trackEvent = useTrackEvent()
-  const { broadcastMessage, subscribe, unsubscribe } = useTripleClientActions()
+  const { broadcastMessage, subscribe, unsubscribe } = useClientAppActions()
 
   const handleRecentTripChange = useCallback(() => {
     setIsRecentTrip((prevState) => !prevState)

--- a/packages/tds-widget/src/review/components/infinite-list/infinite-list.tsx
+++ b/packages/tds-widget/src/review/components/infinite-list/infinite-list.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { List, Spinner } from '@titicaca/tds-ui'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 import { StaticIntersectionObserver } from '@titicaca/intersection-observer'
+import { useClientAppActions } from '@titicaca/triple-web'
 
 import { useDescriptions, useMyReview } from '../../services'
 import { BaseReviewFragment } from '../../data/graphql'
@@ -46,7 +46,7 @@ export function InfiniteList({
     undefined,
   )
   const { subscribeLikedChangeEvent, unsubscribeLikedChangeEvent } =
-    useTripleClientActions()
+    useClientAppActions()
 
   const { data: myReviewData } = useMyReview({
     resourceId,

--- a/packages/tds-widget/src/review/components/my-review-action-sheet.tsx
+++ b/packages/tds-widget/src/review/components/my-review-action-sheet.tsx
@@ -1,7 +1,10 @@
 import { ActionSheet, ActionSheetItem, Confirm } from '@titicaca/tds-ui'
 import { useTranslation } from 'react-i18next'
-import { useEnv, useHashRouter } from '@titicaca/triple-web'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
+import {
+  useClientAppActions,
+  useEnv,
+  useHashRouter,
+} from '@titicaca/triple-web'
 import qs from 'qs'
 
 import { useDeleteReviewMutation } from '../services'
@@ -30,7 +33,7 @@ export function MyReviewActionSheet({
 
   const { appUrlScheme } = useEnv()
   const { uriHash, addUriHash, removeUriHash } = useHashRouter()
-  const { notifyReviewDeleted } = useTripleClientActions()
+  const { notifyReviewDeleted } = useClientAppActions()
 
   const { mutate } = useDeleteReviewMutation()
 

--- a/packages/tds-widget/src/review/components/review-element/index.tsx
+++ b/packages/tds-widget/src/review/components/review-element/index.tsx
@@ -8,8 +8,8 @@ import {
   useSessionCallback,
   useClientAppCallback,
   useClientApp,
+  useClientAppActions,
 } from '@titicaca/triple-web'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 import { Timestamp } from '@titicaca/view-utilities'
 import * as CSS from 'csstype'
 import moment from 'moment'
@@ -115,7 +115,7 @@ export function ReviewElement({
   const trackEvent = useTrackEvent()
   const { addUriHash } = useHashRouter()
   const app = useClientApp()
-  const { showToast } = useTripleClientActions()
+  const { showToast } = useClientAppActions()
   const { navigateReviewDetail, navigateUserDetail } = useClientActions()
 
   const { mutate: likeReview } = useLikeReviewMutation()

--- a/packages/tds-widget/src/review/components/reviews-shorten.tsx
+++ b/packages/tds-widget/src/review/components/reviews-shorten.tsx
@@ -2,8 +2,8 @@ import { ComponentType, useEffect } from 'react'
 import styled from 'styled-components'
 import { FlexBox, Section, Text } from '@titicaca/tds-ui'
 import { useTranslation } from 'react-i18next'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 import { formatNumber } from '@titicaca/view-utilities'
+import { useClientAppActions } from '@titicaca/triple-web'
 
 import { useReviewCount } from '../services'
 
@@ -103,7 +103,7 @@ function ReviewsShortenComponent({
   const { t } = useTranslation('triple-frontend')
 
   const { subscribeReviewUpdateEvent, unsubscribeReviewUpdateEvent } =
-    useTripleClientActions()
+    useClientAppActions()
 
   const { data: reviewsCountData, refetch: refetchReviewsCount } =
     useReviewCount(

--- a/packages/tds-widget/src/review/components/reviews.tsx
+++ b/packages/tds-widget/src/review/components/reviews.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { FlexBox, Section, Container, Text } from '@titicaca/tds-ui'
 import { formatNumber } from '@titicaca/view-utilities'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
+import { useClientAppActions } from '@titicaca/triple-web'
 
 import { useReviewCount } from '../services'
 
@@ -107,7 +107,7 @@ function ReviewsComponent({
   const { t } = useTranslation('triple-frontend')
 
   const { subscribeReviewUpdateEvent, unsubscribeReviewUpdateEvent } =
-    useTripleClientActions()
+    useClientAppActions()
 
   const { data: reviewsCountData, refetch: refetchReviewsCount } =
     useReviewCount(

--- a/packages/tds-widget/src/review/components/shorten-list/reviews-list.tsx
+++ b/packages/tds-widget/src/review/components/shorten-list/reviews-list.tsx
@@ -1,6 +1,6 @@
 import { List, Spinner } from '@titicaca/tds-ui'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 import { useEffect, useMemo, useState } from 'react'
+import { useClientAppActions } from '@titicaca/triple-web'
 
 import { BaseReviewFragment } from '../../data/graphql'
 import { useDescriptions, useMyReview } from '../../services'
@@ -43,7 +43,7 @@ export function ReviewsList({
     undefined,
   )
   const { subscribeLikedChangeEvent, unsubscribeLikedChangeEvent } =
-    useTripleClientActions()
+    useClientAppActions()
 
   const { data: myReviewData } = useMyReview({
     resourceId,

--- a/packages/tds-widget/src/review/components/sorting-context.tsx
+++ b/packages/tds-widget/src/review/components/sorting-context.tsx
@@ -7,9 +7,8 @@ import {
   useState,
   useEffect,
 } from 'react'
-import { useTrackEvent } from '@titicaca/triple-web'
+import { useClientAppActions, useTrackEvent } from '@titicaca/triple-web'
 import { useTranslation } from 'react-i18next'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 
 import { useReviewFilters } from './filter-context'
 
@@ -59,7 +58,7 @@ export function SortingOptionsProvider({
   const { t } = useTranslation('triple-frontend')
   const trackEvent = useTrackEvent()
   const { isRecentTrip } = useReviewFilters()
-  const { broadcastMessage, subscribe, unsubscribe } = useTripleClientActions()
+  const { broadcastMessage, subscribe, unsubscribe } = useClientAppActions()
 
   const defaultOptions = [
     { key: 'recommendation' as const, text: t('추천순') },

--- a/packages/tds-widget/src/review/services/use-client-actions.tsx
+++ b/packages/tds-widget/src/review/services/use-client-actions.tsx
@@ -1,9 +1,8 @@
 import { useMemo } from 'react'
 import qs from 'qs'
-import { useEnv } from '@titicaca/triple-web'
+import { useClientAppActions, useEnv } from '@titicaca/triple-web'
 import { useNavigate } from '@titicaca/router'
 import { ImageMeta } from '@titicaca/type-definitions'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 
 import { writeReview } from '../utils'
 import type { SortingType, SortingOption } from '../components/sorting-context'
@@ -11,7 +10,7 @@ import type { SortingType, SortingOption } from '../components/sorting-context'
 export function useClientActions() {
   const { appUrlScheme } = useEnv()
   const { navigate } = useNavigate()
-  const { getWindowId } = useTripleClientActions()
+  const { getWindowId } = useClientAppActions()
 
   return useMemo(() => {
     return {

--- a/packages/tds-widget/src/review/services/use-reviews.ts
+++ b/packages/tds-widget/src/review/services/use-reviews.ts
@@ -1,10 +1,10 @@
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 import {
   InfiniteData,
   useMutation,
   useQuery,
   useQueryClient,
 } from 'react-query'
+import { useClientAppActions } from '@titicaca/triple-web'
 
 import {
   BaseReviewFragment,
@@ -52,7 +52,7 @@ export function useMyReview(params: GetMyReviewQueryVariables) {
 }
 
 export function useLikeReviewMutation() {
-  const { notifyReviewLiked } = useTripleClientActions()
+  const { notifyReviewLiked } = useClientAppActions()
   const queryClient = useQueryClient()
 
   return useMutation(
@@ -147,7 +147,7 @@ export function useLikeReviewMutation() {
 }
 
 export function useUnlikeReviewMutation() {
-  const { notifyReviewUnliked } = useTripleClientActions()
+  const { notifyReviewUnliked } = useClientAppActions()
   const queryClient = useQueryClient()
 
   return useMutation(
@@ -241,7 +241,7 @@ export function useUnlikeReviewMutation() {
 }
 
 export function useDeleteReviewMutation() {
-  const { notifyReviewDeleted } = useTripleClientActions()
+  const { notifyReviewDeleted } = useClientAppActions()
   const queryClient = useQueryClient()
 
   return useMutation(

--- a/packages/tds-widget/src/scrap/use-scrap.ts
+++ b/packages/tds-widget/src/scrap/use-scrap.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
+import { useClientAppActions } from '@titicaca/triple-web'
 
 import type { ScrapProps, Target } from './types'
 import { useScrapsReducer } from './use-reducer'
@@ -23,7 +23,7 @@ export function useScrap({
     notifyUnscraped,
     subscribeScrapedChangeEvent,
     unsubscribeScrapedChangeEvent,
-  } = useTripleClientActions()
+  } = useClientAppActions()
   const { scraps, updating, dispatch } = useScrapsReducer({ initialScraps })
 
   const deriveCurrentStateAndCount = useCallback(

--- a/packages/tds-widget/src/user-verification/verified-message.spec.ts
+++ b/packages/tds-widget/src/user-verification/verified-message.spec.ts
@@ -1,6 +1,10 @@
 import { renderHook } from '@testing-library/react'
-import { ClientAppName, TestWrapper, useEnv } from '@titicaca/triple-web'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
+import {
+  ClientAppName,
+  TestWrapper,
+  useClientAppActions,
+  useEnv,
+} from '@titicaca/triple-web'
 
 import {
   useSendVerifiedMessage,
@@ -8,7 +12,6 @@ import {
 } from './verified-message'
 
 jest.mock('@titicaca/triple-web')
-jest.mock('@titicaca/react-triple-client-interfaces')
 
 afterEach(() => {
   jest.clearAllMocks()
@@ -24,9 +27,7 @@ describe('useSendVerifiedMessage', () => {
   it('should call broadcastMessage if it is running on triple client', () => {
     const broadcastMessage = jest.fn()
     ;(
-      useTripleClientActions as jest.MockedFunction<
-        typeof useTripleClientActions
-      >
+      useClientAppActions as jest.MockedFunction<typeof useClientAppActions>
     ).mockReturnValue({
       broadcastMessage,
     })
@@ -87,9 +88,7 @@ describe('useVerifiedMessageListener', () => {
     >['0']
 
     ;(
-      useTripleClientActions as jest.MockedFunction<
-        typeof useTripleClientActions
-      >
+      useClientAppActions as jest.MockedFunction<typeof useClientAppActions>
     ).mockReturnValue({
       subscribe,
       unsubscribe,

--- a/packages/tds-widget/src/user-verification/verified-message.ts
+++ b/packages/tds-widget/src/user-verification/verified-message.ts
@@ -1,5 +1,4 @@
-import { useClientApp, useEnv } from '@titicaca/triple-web'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
+import { useClientApp, useClientAppActions, useEnv } from '@titicaca/triple-web'
 import { useCallback, useEffect } from 'react'
 
 /**
@@ -14,7 +13,7 @@ export interface VerifiedMessage {
 export function useSendVerifiedMessage() {
   const { webUrlBase } = useEnv()
   const app = useClientApp()
-  const { broadcastMessage } = useTripleClientActions()
+  const { broadcastMessage } = useClientAppActions()
 
   const sendVerifiedMessage = useCallback(
     (message: VerifiedMessage) => {
@@ -42,7 +41,7 @@ export function useVerifiedMessageListener(
   handleVerifiedMessage: (message: VerifiedMessage) => void,
 ) {
   const app = useClientApp()
-  const { subscribe, unsubscribe } = useTripleClientActions()
+  const { subscribe, unsubscribe } = useClientAppActions()
 
   useEffect(() => {
     if (!app) {

--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -57,7 +57,6 @@
   "devDependencies": {
     "@titicaca/i18n": "workspace:*",
     "@titicaca/triple-web": "workspace:*",
-    "@titicaca/react-triple-client-interfaces": "workspace:*",
     "@types/qs": "^6.9.9",
     "i18next": "^23.7.6",
     "next": "^13.4.13",
@@ -68,7 +67,6 @@
   "peerDependencies": {
     "@titicaca/i18n": "*",
     "@titicaca/triple-web": "*",
-    "@titicaca/react-triple-client-interfaces": "*",
     "i18next": "*",
     "next": "^13.0",
     "react": "^18.0",

--- a/packages/triple-header/package.json
+++ b/packages/triple-header/package.json
@@ -48,14 +48,12 @@
   },
   "devDependencies": {
     "@titicaca/triple-web": "workspace:*",
-    "@titicaca/react-triple-client-interfaces": "workspace:*",
     "next": "^13.4.13",
     "react": "^18.2.0",
     "styled-components": "^5.3.11"
   },
   "peerDependencies": {
     "@titicaca/triple-web": "*",
-    "@titicaca/react-triple-client-interfaces": "*",
     "next": "^13.0",
     "react": "^18.0",
     "styled-components": "^5.3.9"

--- a/packages/triple-web/src/hooks/client-app/index.ts
+++ b/packages/triple-web/src/hooks/client-app/index.ts
@@ -1,3 +1,4 @@
+export * from './use-client-app-actions'
 export * from './use-client-app-callback'
 export * from './use-client-app'
 export * from './use-feature-flag'

--- a/packages/ui-flow/package.json
+++ b/packages/ui-flow/package.json
@@ -51,14 +51,12 @@
   },
   "devDependencies": {
     "@titicaca/triple-web": "workspace:*",
-    "@titicaca/react-triple-client-interfaces": "workspace:*",
     "@types/qs": "^6.9.9",
     "next": "^13.4.13",
     "react": "^18.2.0"
   },
   "peerDependencies": {
     "@titicaca/triple-web": "*",
-    "@titicaca/react-triple-client-interfaces": "*",
     "next": "^13.0",
     "react": "^18.0"
   }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

useClientAppActions import path 수정

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- useClientAppActions import path 수정
- react-triple-client-interfaces 흔적 제거