### PR TITLE
[directions-finder] grab 호출 버튼에 Intersecting Observer를 추가합니다.

### DIFF
--- a/packages/directions-finder/package.json
+++ b/packages/directions-finder/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@titicaca/i18n": "workspace:*",
+    "@titicaca/intersection-observer": "workspace:*",
     "@titicaca/next-i18next": "13.8.5",
     "@titicaca/react-contexts": "workspace:*",
     "@titicaca/react-triple-client-interfaces": "workspace:*",

--- a/packages/directions-finder/src/direction-buttons.tsx
+++ b/packages/directions-finder/src/direction-buttons.tsx
@@ -8,6 +8,7 @@ import {
 } from '@titicaca/react-contexts'
 import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 import { Button, ButtonGroup, Container } from '@titicaca/core-elements'
+import { StaticIntersectionObserver } from '@titicaca/intersection-observer'
 
 import AskToTheLocal from './ask-to-the-local'
 import { HASH_ASK_TO_LOCALS_POPUP } from './constants'
@@ -25,6 +26,7 @@ function DirectionButtons({
   phoneNumber,
   isDomestic = false,
   onCallGrabButtonClick,
+  onCallGrabButtonIntersecting,
 }: {
   onDirectionsClick: () => void
   primaryName: string
@@ -33,6 +35,7 @@ function DirectionButtons({
   phoneNumber?: string
   isDomestic?: boolean
   onCallGrabButtonClick?: () => void
+  onCallGrabButtonIntersecting?: (entry: IntersectionObserverEntry) => void
 }) {
   const { t } = useTranslation('common-web')
 
@@ -66,15 +69,19 @@ function DirectionButtons({
         {hasLineBreak ? <LinkBreak /> : null}
 
         {onCallGrabButtonClick ? (
-          <Button
-            basic
-            inverted
-            color="blue"
-            size="small"
-            onClick={onCallGrabButtonClick}
+          <StaticIntersectionObserver
+            onChange={(entry) => onCallGrabButtonIntersecting?.(entry)}
           >
-            {t(['grab-hocul', 'Grab 호출'])}
-          </Button>
+            <Button
+              basic
+              inverted
+              color="blue"
+              size="small"
+              onClick={onCallGrabButtonClick}
+            >
+              {t(['grab-hocul', 'Grab 호출'])}
+            </Button>
+          </StaticIntersectionObserver>
         ) : null}
 
         <Button

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,6 +541,9 @@ importers:
       '@titicaca/i18n':
         specifier: workspace:*
         version: link:../i18n
+      '@titicaca/intersection-observer':
+        specifier: workspace:*
+        version: link:../intersection-observer
       '@titicaca/next-i18next':
         specifier: 13.8.5
         version: 13.8.5(i18next@22.5.1)(next@13.4.13)(react-i18next@12.3.1)(react@18.2.0)


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
grab 호출 버튼에 Intersecting Observer를 추가하고 onCallGrabButtonIntersecting props를 추가합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
