### PR TITLE
[triple-document] 추천 일정의 '내 일정으로 담기' 로직을 수정합니다.

### DIFF
--- a/packages/triple-document/src/elements/itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react'
-import { useTranslation } from '@titicaca/next-i18next'
 import styled from 'styled-components'
 import {
   Container,
@@ -7,7 +6,6 @@ import {
   Text,
   FlexBox,
   FlexBoxItem,
-  Button,
 } from '@titicaca/core-elements'
 import type {
   TransportationType,
@@ -36,13 +34,13 @@ import {
   Cable,
   Plane,
   Ship,
-  Download,
 } from './itinerary/icons'
-import useHandleAddPoisToTrip from './itinerary/use-handle-add-pois-to-trip'
+import SaveToItinerary, { Geotag } from './itinerary/save-to-itinerary'
 
 interface Props {
   value: {
     itinerary: Itinerary
+    geotag?: Geotag
   }
 }
 
@@ -89,20 +87,13 @@ const Duration = styled(Container)`
   flex-shrink: 0;
 `
 
-const SaveToItineraryButton = styled(Button)`
-  > * {
-    vertical-align: middle;
-  }
-`
-
 export default function ItineraryElement({ value }: Props) {
   const { trackEvent } = useEventTrackingContext()
-  const { t } = useTranslation('common-web')
 
   const guestMode = useGuestMode()
   const { courses, regionId, poiIds, hasItineraries, hideAddButton } =
     useItinerary({ itinerary: value.itinerary, guestMode })
-  const addPoisToTrip = useHandleAddPoisToTrip(regionId || '')
+
   const navigate = useNavigate()
 
   const generatePoiClickHandler = useCallback(
@@ -141,15 +132,9 @@ export default function ItineraryElement({ value }: Props) {
     [navigate, regionId],
   )
 
-  const handleSaveToItinerary = useCallback(() => {
-    trackEvent({
-      ga: ['내일정으로담기_선택'],
-      fa: {
-        action: '내일정으로담기_선택',
-      },
-    })
-    addPoisToTrip(poiIds)
-  }, [poiIds, addPoisToTrip, trackEvent])
+  const itineraryGeotag =
+    value.geotag ||
+    (regionId ? { type: 'triple-region', id: regionId } : undefined)
 
   return (
     <Container
@@ -265,21 +250,12 @@ export default function ItineraryElement({ value }: Props) {
             )
           })}
         </Stack>
-        {hideAddButton || guestMode ? null : (
-          <SaveToItineraryButton
-            fluid
-            basic
-            bold
-            inverted
-            margin={{ top: 20 }}
-            onClick={handleSaveToItinerary}
+        {hideAddButton || guestMode || !itineraryGeotag ? null : (
+          <SaveToItinerary
+            poiIds={poiIds}
+            geotag={itineraryGeotag}
             disabled={!hasItineraries}
-          >
-            <Download />
-            <Text inline size={14} margin={{ left: 3 }} color="white">
-              {t(['nae-iljeongeuro-damgi', '내 일정으로 담기'])}
-            </Text>
-          </SaveToItineraryButton>
+          />
         )}
       </Container>
     </Container>

--- a/packages/triple-document/src/elements/itinerary/save-to-itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary/save-to-itinerary.tsx
@@ -1,0 +1,67 @@
+import { useEventTrackingContext } from '@titicaca/react-contexts'
+import { useCallback } from 'react'
+import { useTranslation } from '@titicaca/next-i18next'
+import styled from 'styled-components'
+import { Text, Button } from '@titicaca/core-elements'
+
+import useHandleAddPoisToTrip from '../itinerary/use-handle-add-pois-to-trip'
+
+import { Download } from './icons'
+
+export interface Geotag {
+  type: 'triple-region' | 'triple-zone'
+  id: string
+}
+
+const SaveToItineraryButton = styled(Button)`
+  > * {
+    vertical-align: middle;
+  }
+`
+
+export default function SaveToItinerary({
+  poiIds,
+  geotag,
+  disabled = false,
+}: {
+  poiIds: string[]
+  geotag: Geotag
+  disabled?: boolean
+}) {
+  const { trackEvent } = useEventTrackingContext()
+
+  const { t } = useTranslation('common-web')
+
+  const addPoisToTrip = useHandleAddPoisToTrip({
+    geotag,
+  })
+
+  const handleSaveToItinerary = useCallback(() => {
+    trackEvent({
+      ga: ['내일정으로담기_선택'],
+      fa: {
+        action: '내일정으로담기_선택',
+      },
+    })
+    if (geotag) {
+      addPoisToTrip(poiIds)
+    }
+  }, [geotag, poiIds, addPoisToTrip, trackEvent])
+
+  return (
+    <SaveToItineraryButton
+      fluid
+      basic
+      bold
+      inverted
+      margin={{ top: 20 }}
+      onClick={handleSaveToItinerary}
+      disabled={disabled}
+    >
+      <Download />
+      <Text inline size={14} margin={{ left: 3 }} color="white">
+        {t(['nae-iljeongeuro-damgi', '내 일정으로 담기'])}
+      </Text>
+    </SaveToItineraryButton>
+  )
+}

--- a/packages/triple-document/src/elements/itinerary/use-computed-itineraries.ts
+++ b/packages/triple-document/src/elements/itinerary/use-computed-itineraries.ts
@@ -51,7 +51,8 @@ export default function useItinerary({ itinerary, guestMode }: Props) {
 
   const hasItineraries = items.length > 0
   /** NOTE: 일정을 일정판에 저장하기 위해 regionId 를 특정하기 위한 로직 */
-  const regionId = items[0]?.poi.source?.regionId
+  const regionId = items.find((item) => item.poi.source?.regionId)?.poi.source
+    ?.regionId
 
   const poiIds = useMemo(() => items.map(({ poi }) => poi.id), [items])
 

--- a/packages/triple-document/src/elements/itinerary/use-handle-add-pois-to-trip.ts
+++ b/packages/triple-document/src/elements/itinerary/use-handle-add-pois-to-trip.ts
@@ -9,31 +9,54 @@ import { useNavigate } from '@titicaca/router'
 /**
  * TODO: hotels-web, content-web 일정추가 액션 중복코드
  */
-export default function useHandleAddPoiToTrip(regionId?: string) {
+
+interface Geotag {
+  type: 'triple-region' | 'triple-zone'
+  id: string
+}
+
+export default function useHandleAddPoiToTrip({ geotag }: { geotag: Geotag }) {
   const { appUrlScheme } = useEnv()
   const navigate = useNavigate()
 
   const handleFn = useCallback(
     (poiId: string | string[]) => {
-      const pois = Array.isArray(poiId) ? poiId.join(',') : poiId
+      const query = generateAddTripPlanQuery({ poiId, geotag })
 
       navigate(
         generateUrl({
           scheme: appUrlScheme,
           path: '/action/add_trip_plan',
-          query: qs.stringify({
-            region_id: regionId,
-            pois,
-          }),
+          query: qs.stringify(query),
         }),
       )
       return true
     },
-    [navigate, regionId, appUrlScheme],
+    [navigate, geotag, appUrlScheme],
   )
 
   return useAppCallback(
     TransitionType.AddPoisToTripSelect,
     useSessionCallback(handleFn),
   )
+}
+
+export function generateAddTripPlanQuery({
+  poiId,
+  geotag,
+}: {
+  poiId: string | string[]
+  geotag: Geotag
+}) {
+  const pois = Array.isArray(poiId) ? poiId.join(',') : poiId
+
+  const geotagQuery =
+    geotag.type === 'triple-region'
+      ? { region_id: geotag.id }
+      : { zone_id: geotag.id }
+
+  return {
+    ...geotagQuery,
+    pois,
+  }
 }

--- a/packages/triple-document/src/mocks/triple-document.itinerary.json
+++ b/packages/triple-document/src/mocks/triple-document.itinerary.json
@@ -31,6 +31,10 @@
         {
           "type": "itinerary",
           "value": {
+            "geotag": {
+              "type": "triple-region",
+              "id": "be72875a-8b3f-41ad-98d4-42b2e0939bea"
+            },
             "itinerary": {
               "day": 1,
               "items": [


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

기존에는 `내 일정으로 담기` 버튼 클릭 시에 추천일정에 포함된 첫번째 POI의 regionId 값을 앱으로 전달했습니다. 그러나 해당 값은 백엔드에서 강제 할당했던 값으로, `geotag`가 도입된 이후에는 강제 할당 로직을 실행하지 않아 `regionId` 값이 업데이트되지 않은 POI가 존재합니다. 이럴 경우, `내 일정으로 담기` 버튼을 클릭하더라도 아무런 동작이 취해지지 않는 현상이 발생합니다.

또한 `zone` 역시 앱으로 전달하는 것이 가능한데 해당 로직은 현재 빠져있습니다. 

`내 일정으로 담기` 기능을 정상적으로 실행하기 위해 로직을 수정했습니다. `Itinerary` element에 `geotag` prop을 추가해 `내 일정으로 담기` 버튼 클릭 시 해당 값을 우선적으로 참조합니다. 이 값이 없는 경우에는 추천 일정의 POI들을 참조합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- `Itinerary` element에 `geotag` prop 추가했습니다
- `geotag` prop이 없는 경우 POI 참조합니다
  - 기존에는 첫번째 POI의 값만 참고했지만, `regionId`를 찾지 못할 가능성을 낮추기 위해 `find` 메소드를 적용했습니다
- 앱으로 전달할 수 있는 리전/존의 값이 존재하는 경우에만 `내 일정으로 담기` 버튼을 노출합니다
  - `SaveToItinerary` 컴포넌트를 분리했습니다
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
- [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요?

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
