### PR TITLE
댓글 작성, 삭제 handle function prop을 추가합니다

### DIFF
--- a/packages/replies/src/register.tsx
+++ b/packages/replies/src/register.tsx
@@ -29,12 +29,14 @@ function Register(
     placeholders,
     onReplyAdd,
     onReplyEdit,
+    onCompleteReplyAdd,
   }: {
     resourceId: string
     resourceType: ResourceType
     placeholders?: Placeholders
     onReplyAdd: (response: Reply) => void
     onReplyEdit: (response: Reply) => void
+    onCompleteReplyAdd?: (reply: Reply) => void
   },
   ref: ForwardedRef<TextAreaHandle>,
 ) {
@@ -69,6 +71,7 @@ function Register(
       onReplyEdit(response)
     } else {
       onReplyAdd(response)
+      onCompleteReplyAdd?.(response)
     }
 
     initializeEditingMessage()

--- a/packages/replies/src/replies.stories.tsx
+++ b/packages/replies/src/replies.stories.tsx
@@ -1,10 +1,50 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { SessionContextProvider } from '@titicaca/react-contexts'
+import { rest } from 'msw'
 
 import Replies from './replies'
 
 export default {
   title: 'replies / Replies',
   component: Replies,
+  parameters: {
+    msw: {
+      handlers: [
+        rest.post(
+          '/api/reply/messages?contentFormat=plaintext',
+          async (req, res, ctx) => {
+            const newReply = await req.json()
+            return res(
+              ctx.json({
+                id: 'new reply',
+                parentId: undefined,
+                blinded: false,
+                deleted: false,
+                isMine: true,
+                childrenCount: 0,
+                createdAt: new Date(2024, 1, 1).toString(),
+                updatedAt: new Date(2024, 1, 1).toString(),
+                reactions: {},
+                content: { text: newReply.content },
+                children: [],
+                writer: {
+                  href: '',
+                  name: '트리플',
+                  profileImage: '',
+                  badges: [],
+                },
+                actionSpecifications: {
+                  delete: false,
+                  reaction: false,
+                  report: false,
+                },
+              }),
+            )
+          },
+        ),
+      ],
+    },
+  },
   argTypes: {
     resourceId: {
       type: 'string',
@@ -37,6 +77,19 @@ export default {
       required: false,
     },
   },
+  decorators: [
+    (Story) => (
+      <SessionContextProvider
+        type="browser"
+        props={{
+          initialUser: undefined,
+          initialSessionAvailability: true,
+        }}
+      >
+        <Story />
+      </SessionContextProvider>
+    ),
+  ],
 } as Meta<typeof Replies>
 
 export const Basic: StoryObj<typeof Replies> = {

--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -40,6 +40,7 @@ function Replies({
   size = 10,
   initialSize,
   onCompleteReplyAdd,
+  onCompleteReplyDelete,
   ...props
 }: {
   /**
@@ -63,6 +64,7 @@ function Replies({
   size?: number
   initialSize?: number
   onCompleteReplyAdd?: (reply: Reply) => void
+  onCompleteReplyDelete?: (reply: Reply) => void
 }) {
   const [replies, setReplies] = useState<Reply[]>([])
 
@@ -84,6 +86,7 @@ function Replies({
       .filter(Boolean) as Reply[]
 
     setReplies(deletedReplies)
+    onCompleteReplyDelete?.(response)
   }
 
   const handleReplyEdit = (response: Reply): void => {

--- a/packages/replies/src/replies.tsx
+++ b/packages/replies/src/replies.tsx
@@ -39,6 +39,7 @@ function Replies({
   isFormFixed,
   size = 10,
   initialSize,
+  onCompleteReplyAdd,
   ...props
 }: {
   /**
@@ -61,6 +62,7 @@ function Replies({
    */
   size?: number
   initialSize?: number
+  onCompleteReplyAdd?: (reply: Reply) => void
 }) {
   const [replies, setReplies] = useState<Reply[]>([])
 
@@ -216,6 +218,7 @@ function Replies({
           placeholders={placeholders}
           onReplyAdd={handleReplyAdd}
           onReplyEdit={handleReplyEdit}
+          onCompleteReplyAdd={onCompleteReplyAdd}
         />
       </InputContainer>
     </RepliesProvider>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

유저가 댓글을 작성하고 삭제할 때 해당 이벤트를 외부에서 알 수 있도록 함수를 추가합니다. 
[관련 스레드](https://interpark.slack.com/archives/C05ERUV2603/p1703652133870889)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- `onCompleteReplyAdd`, `onCompleteReplyDelete` 함수 prop 추가
- 스토리북에서 댓글 작성 기능을 테스트할 수 있도록 수정
  - 댓글 작성은 `Session`이 available해야하기 때문에 `SessionContextProvider`를 override
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
