### PR TITLE
[Chat Refactor] MessagesReducer의 액션을 추가하고 타입을 수정합니다.

### DIFF
--- a/packages/chat/src/chat/messages-reducer.ts
+++ b/packages/chat/src/chat/messages-reducer.ts
@@ -14,7 +14,7 @@ export enum MessagesActions {
 export interface MessageBase<Id = string> {
   id: Id
   createdAt?: string
-  parentMessage?: MessageBase<Id>
+  parentMessage?: MessageBase<Id> | null
 }
 
 export interface MessagesState<Message extends MessageBase<Id>, Id = string> {
@@ -56,15 +56,15 @@ export type MessagesAction<Message extends MessageBase<Id>, Id = string> =
     }
   | {
       action: MessagesActions.PENDING
-      message: Message
+      message: Omit<Message, 'createdAt'>
     }
   | {
       action: MessagesActions.FAIL
-      message: Message
+      message: Omit<Message, 'createdAt'>
     }
   | {
       action: MessagesActions.REMOVE
-      message: Message
+      message: Omit<Message, 'createdAt'>
     }
 
 function MessagesReducer<Message extends MessageBase<Id>, Id = string>(

--- a/packages/chat/src/chat/messages-reducer.ts
+++ b/packages/chat/src/chat/messages-reducer.ts
@@ -9,6 +9,8 @@ export enum MessagesActions {
   PENDING = 'PENDING', // 메세지 전송 응답 대기
   FAIL = 'FAIL', // 메시지 전송 실패
   REMOVE = 'REMOVE', // 전송 실패 메세지 삭제
+  HAS_PREV = 'HAS_PREV', // 이전 메세지 페이지네이션 플래그 설정
+  HAS_NEXT = 'HAS_NEXT', // 다음 메세지 페이지네이션 플래그 설정
 }
 
 export interface MessageBase<Id = string> {
@@ -66,6 +68,14 @@ export type MessagesAction<Message extends MessageBase<Id>, Id = string> =
       action: MessagesActions.REMOVE
       message: Omit<Message, 'createdAt'>
     }
+  | {
+      action: MessagesActions.HAS_PREV
+      hasPrevMessage: boolean
+    }
+  | {
+      action: MessagesActions.HAS_NEXT
+      hasNextMessage: boolean
+    }
 
 function MessagesReducer<Message extends MessageBase<Id>, Id = string>(
   state: MessagesState<Message, Id>,
@@ -92,7 +102,6 @@ function MessagesReducer<Message extends MessageBase<Id>, Id = string>(
           state.messages,
           action.messages,
         ),
-        hasNextMessage: action.messages.length > 0,
       }
 
     case MessagesActions.UPDATE:
@@ -152,6 +161,18 @@ function MessagesReducer<Message extends MessageBase<Id>, Id = string>(
         failedMessages: state.failedMessages.filter(
           (message) => message.id !== action.message.id,
         ),
+      }
+
+    case MessagesActions.HAS_PREV:
+      return {
+        ...state,
+        hasPrevMessage: action.hasPrevMessage,
+      }
+
+    case MessagesActions.HAS_NEXT:
+      return {
+        ...state,
+        hasNextMessage: action.hasNextMessage,
       }
 
     default:


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- messagesReducer에 hasPrevMessage, hasNextMessage를 설정할 수 있는 액션을 추가합니다.
- messagesReducer에 PENDING, FAILED, REMOVE 액션에 들어가는 메세지 타입을 수정합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

