### PR TITLE
[INTHOTEL-383] react context push 함수 반환타입 Promise 로 수정

### DIFF
--- a/packages/react-contexts/src/history-context/history-context.tsx
+++ b/packages/react-contexts/src/history-context/history-context.tsx
@@ -40,10 +40,7 @@ interface NavigateFunctionConfig {
 
 interface HistoryContextValue {
   uriHash: UriHash
-  push: (
-    hash: string,
-    config?: NavigateFunctionConfig,
-  ) => Promise<boolean> | void
+  push: (hash: string, config?: NavigateFunctionConfig) => Promise<boolean>
   replace: (hash: string, config?: NavigateFunctionConfig) => void
   back: () => void
   /**
@@ -79,7 +76,9 @@ const UriHashContext = createContext<UriHash>('')
 const HistoryFunctionsContext = createContext<
   Omit<HistoryContextValue, 'uriHash'>
 >({
-  push: NOOP,
+  push: () => {
+    return new Promise((resolve) => resolve(true))
+  },
   replace: NOOP,
   back: NOOP,
   navigate: NOOP,

--- a/packages/react-contexts/src/history-context/history-context.tsx
+++ b/packages/react-contexts/src/history-context/history-context.tsx
@@ -40,7 +40,10 @@ interface NavigateFunctionConfig {
 
 interface HistoryContextValue {
   uriHash: UriHash
-  push: (hash: string, config?: NavigateFunctionConfig) => Promise<boolean>
+  push: (
+    hash: string,
+    config?: NavigateFunctionConfig,
+  ) => Promise<boolean> | void
   replace: (hash: string, config?: NavigateFunctionConfig) => void
   back: () => void
   /**

--- a/packages/react-contexts/src/history-context/history-context.tsx
+++ b/packages/react-contexts/src/history-context/history-context.tsx
@@ -40,7 +40,7 @@ interface NavigateFunctionConfig {
 
 interface HistoryContextValue {
   uriHash: UriHash
-  push: (hash: string, config?: NavigateFunctionConfig) => void
+  push: (hash: string, config?: NavigateFunctionConfig) => Promise<boolean>
   replace: (hash: string, config?: NavigateFunctionConfig) => void
   back: () => void
   /**


### PR DESCRIPTION
## PR 설명
react context push 함수 반환타입 Promise 로 수정

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
https://inpk.atlassian.net/browse/INTHOTEL-383
위 버그 해결 중 push 함수를 await 하여야 하는데, 기존에 push 함수가 Promise 리턴함에도 불구하고 void 리턴으로 타입이 되어있어 수정한 건입니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
