### PR TITLE
[chat] 부모 메세지 UI를 추가합니다

### DIFF
--- a/packages/chat/src/bubble-container/bubble-container.stories.tsx
+++ b/packages/chat/src/bubble-container/bubble-container.stories.tsx
@@ -65,7 +65,7 @@ export const ReceivedBubbleContainer = {
         type: 'boolean',
       },
     },
-    profile: {
+    user: {
       control: {
         type: 'object',
       },
@@ -76,12 +76,12 @@ export const ReceivedBubbleContainer = {
     createdAt: new Date(2022, 10, 1).toISOString(),
     unreadCount: null,
     showInfo: true,
-    profile: {
-      imageUrl:
+    user: {
+      photo:
         'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
       name: '테스트계정',
       userId: 'test',
-      unregister: false,
+      unregistered: false,
     },
   },
 }

--- a/packages/chat/src/bubble-container/bubble-container.tsx
+++ b/packages/chat/src/bubble-container/bubble-container.tsx
@@ -2,6 +2,7 @@ import { PropsWithChildren } from 'react'
 import { Container } from '@titicaca/core-elements'
 
 import { DEFAULT_MESSAGE_ID_PREFIX } from '../chat/constants'
+import { DEFAULT_MAX_USERNAME_LENGTH, formatUsername } from '../utils/profile'
 
 import { BubbleInfo } from './bubble-info'
 import {
@@ -132,11 +133,25 @@ function ReceivedBubbleContainer({
       css={{ ...CHAT_CONTAINER_STYLES }}
       {...props}
     >
-      {showProfile ? <ProfileImage src={user?.photo} /> : null}
-      <Container css={{ marginLeft: 40 }}>
+      {showProfile ? (
+        <ProfileImage
+          src={
+            user && !user.unregistered && user.photo
+              ? user.photo
+              : 'https://assets.triple.guide/images/ico-default-profile.svg'
+          }
+        />
+      ) : null}
+      <Container css={{ marginLeft: 50 }}>
         {showProfile ? (
-          <ProfileName alpha={0.7} margin={{ bottom: 5 }}>
-            {user?.name || ''}
+          <ProfileName size="mini" alpha={0.8} margin={{ bottom: 5 }}>
+            {user
+              ? formatUsername({
+                  name: user?.name,
+                  unregistered: user?.unregistered,
+                  maxLength: DEFAULT_MAX_USERNAME_LENGTH,
+                })
+              : ''}
           </ProfileName>
         ) : null}
 

--- a/packages/chat/src/bubble/altered.tsx
+++ b/packages/chat/src/bubble/altered.tsx
@@ -2,7 +2,7 @@ import { FlexBox } from '@titicaca/core-elements'
 
 import ExclamationMarkIcon from '../icons/ExclamationMarkIcon'
 
-import { Bubble } from './bubble'
+import Bubble from './bubble'
 import { BlindedBubbleProp } from './type'
 
 export default function AlteredBubble({

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -13,6 +13,7 @@ import {
 import { ProductBubble } from './product'
 import AlteredBubble from './altered'
 import { ALTERNATIVE_TEXT_MESSAGE } from './constants'
+import { ParentMessageUIProp } from './parent/parent-ui'
 
 export const BubbleTypeArray = ['text', 'images', 'rich', 'product'] as const
 
@@ -20,11 +21,12 @@ export type BubbleType = (typeof BubbleTypeArray)[number]
 
 interface BubbleUIPropBase {
   type: BubbleType
+  parentMessage?: ParentMessageUIProp
 }
 
 export interface TextBubbleUIProp extends BubbleUIPropBase {
   type: 'text'
-  value: Pick<TextBubbleProp, 'message' | 'parentMessage'>
+  value: Pick<TextBubbleProp, 'message'>
 }
 
 export interface ImageBubbleUIProp extends BubbleUIPropBase {
@@ -54,6 +56,7 @@ export type BubbleUIProps = (
   deleted?: boolean
   unfriended?: boolean
   alternativeText?: string
+  parentMessage?: ParentMessageUIProp
   onBubbleClick?: BubbleProp['onClick']
   onImageBubbleClick?: ImageBubbleProp['onClick']
   onBubbleLongPress?: BubbleProp['onLongPress']

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -24,7 +24,7 @@ interface BubbleUIPropBase {
 
 export interface TextBubbleUIProp extends BubbleUIPropBase {
   type: 'text'
-  value: Pick<TextBubbleProp, 'message'>
+  value: Pick<TextBubbleProp, 'message' | 'parentMessage'>
 }
 
 export interface ImageBubbleUIProp extends BubbleUIPropBase {

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -21,7 +21,7 @@ export type BubbleType = (typeof BubbleTypeArray)[number]
 
 interface BubbleUIPropBase {
   type: BubbleType
-  parentMessage?: ParentMessageUIProp
+  parentMessage?: ParentMessageUIProp | null
 }
 
 export interface TextBubbleUIProp extends BubbleUIPropBase {

--- a/packages/chat/src/bubble/bubble.stories.tsx
+++ b/packages/chat/src/bubble/bubble.stories.tsx
@@ -1,3 +1,5 @@
+import { ScrollProvider } from '../chat'
+
 import {
   ImageBubbleProp,
   ProductBubbleProp,
@@ -12,7 +14,11 @@ export default {
 }
 
 export const Text = {
-  render: (args: TextBubbleProp) => <TextBubble {...args} />,
+  render: (args: TextBubbleProp) => (
+    <ScrollProvider>
+      <TextBubble {...args} />
+    </ScrollProvider>
+  ),
   argTypes: {
     message: {
       type: 'text',
@@ -31,6 +37,16 @@ export const Text = {
     message: '안녕하세요',
     my: true,
     id: 'text_bubble',
+    parentMessage: {
+      id: 'parent_message',
+      type: 'text',
+      blinded: false,
+      value: { message: '안녕하세요' },
+      sender: {
+        name: '트리플',
+        unregistered: false,
+      },
+    },
   },
 }
 

--- a/packages/chat/src/bubble/bubble.stories.tsx
+++ b/packages/chat/src/bubble/bubble.stories.tsx
@@ -6,6 +6,7 @@ import {
   RichBubbleProp,
   TextBubbleProp,
 } from './type'
+import AlteredBubble from './altered'
 
 import { ImageBubble, ProductBubble, RichBubble, TextBubble } from './index'
 
@@ -113,5 +114,16 @@ export const Image = {
       },
     ],
     appUrlScheme: '',
+  },
+}
+
+export const Altered = {
+  render: (args: React.ComponentProps<typeof AlteredBubble>) => (
+    <AlteredBubble {...args} />
+  ),
+  args: {
+    my: true,
+    alternativeText: '관리자에 의해 가려진 메세지입니다.',
+    textColor: 'gray',
   },
 }

--- a/packages/chat/src/bubble/bubble.stories.tsx
+++ b/packages/chat/src/bubble/bubble.stories.tsx
@@ -11,14 +11,17 @@ import { ImageBubble, ProductBubble, RichBubble, TextBubble } from './index'
 
 export default {
   title: 'chat / Bubble',
+  decorators: [
+    (Story) => (
+      <ScrollProvider>
+        <Story />
+      </ScrollProvider>
+    ),
+  ],
 }
 
 export const Text = {
-  render: (args: TextBubbleProp) => (
-    <ScrollProvider>
-      <TextBubble {...args} />
-    </ScrollProvider>
-  ),
+  render: (args: TextBubbleProp) => <TextBubble {...args} />,
   argTypes: {
     message: {
       type: 'text',

--- a/packages/chat/src/bubble/bubble.stories.tsx
+++ b/packages/chat/src/bubble/bubble.stories.tsx
@@ -46,7 +46,7 @@ export const Text = {
       blinded: false,
       value: { message: '안녕하세요' },
       sender: {
-        name: '트리플',
+        profile: { name: '트리플' },
         unregistered: false,
       },
     },

--- a/packages/chat/src/bubble/bubble.tsx
+++ b/packages/chat/src/bubble/bubble.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from 'react'
 import { useLongPress } from 'use-long-press'
 
 import { BubbleCSSProp, BubbleProp } from './type'
+import ParentMessageUI, { ParentMessageUIProp } from './parent/parent-ui'
 
 const StyledBubble = styled(Text).attrs({
   textAlign: 'left',
@@ -29,7 +30,7 @@ const StyledBubble = styled(Text).attrs({
   `}
 `
 
-export function Bubble({
+export function BaseBubble({
   id,
   onClick,
   onLongPress,
@@ -50,5 +51,18 @@ export function Bubble({
     <StyledBubble onClick={(e) => onClick?.(e, id)} {...props} {...bind()}>
       {children}
     </StyledBubble>
+  )
+}
+
+export default function BubbleWithParentMessage({
+  parentMessage,
+  children,
+  ...props
+}: PropsWithChildren<BubbleProp> & { parentMessage?: ParentMessageUIProp }) {
+  return (
+    <BaseBubble {...props}>
+      {parentMessage ? <ParentMessageUI {...parentMessage} /> : null}
+      {children}
+    </BaseBubble>
   )
 }

--- a/packages/chat/src/bubble/parent/parent-message.tsx
+++ b/packages/chat/src/bubble/parent/parent-message.tsx
@@ -1,6 +1,6 @@
 import { Container, Text, FlexBox } from '@titicaca/core-elements'
 import { MouseEventHandler } from 'react'
-import styled from 'styled-components'
+import styled, { CSSProp } from 'styled-components'
 
 import { useScroll } from '../../chat/scroll-context'
 
@@ -20,37 +20,37 @@ interface ParentMessageType {
   titleColor?: string
   previewTextColor?: string
   onClick?: MouseEventHandler
+  css?: CSSProp
 }
+
+const ParentMessageContainer = styled(FlexBox)`
+  padding: 8px 11px;
+  margin-bottom: 11px;
+  align-items: center;
+  background-color: var(--color-white);
+`
 
 export default function ParentMessage({
   id,
   senderName,
   previewImageUrl,
   text,
-  backgroundColor,
   titleColor,
   previewTextColor,
   onClick,
+  css,
 }: ParentMessageType) {
   const { scrollToMessage } = useScroll()
 
   return (
-    <FlexBox
+    <ParentMessageContainer
       onClick={(e) => {
         scrollToMessage(id)
         onClick?.(e)
       }}
       flex
       borderRadius={13}
-      css={{
-        paddingLeft: 11,
-        paddingRight: 11,
-        paddingTop: 8,
-        paddingBottom: 8,
-        marginBottom: 11,
-        backgroundColor: backgroundColor || 'var(--color-white)',
-        alignItems: 'center',
-      }}
+      css={css}
     >
       {previewImageUrl ? <PreviewImage src={previewImageUrl} /> : null}
       <Container>
@@ -79,6 +79,6 @@ export default function ParentMessage({
           {text}
         </Text>
       </Container>
-    </FlexBox>
+    </ParentMessageContainer>
   )
 }

--- a/packages/chat/src/bubble/parent/parent-message.tsx
+++ b/packages/chat/src/bubble/parent/parent-message.tsx
@@ -16,19 +16,11 @@ interface ParentMessageType {
   senderName: string
   previewImageUrl?: string
   text: string
-  backgroundColor?: string
   titleColor?: string
   previewTextColor?: string
   onClick?: MouseEventHandler
   css?: CSSProp
 }
-
-const ParentMessageContainer = styled(FlexBox)`
-  padding: 8px 11px;
-  margin-bottom: 11px;
-  align-items: center;
-  background-color: var(--color-white);
-`
 
 export default function ParentMessage({
   id,
@@ -38,19 +30,25 @@ export default function ParentMessage({
   titleColor,
   previewTextColor,
   onClick,
-  css,
+  ...props
 }: ParentMessageType) {
   const { scrollToMessage } = useScroll()
 
   return (
-    <ParentMessageContainer
+    <FlexBox
       onClick={(e) => {
         scrollToMessage(id)
         onClick?.(e)
       }}
       flex
       borderRadius={13}
-      css={css}
+      css={{
+        padding: '8px 11px',
+        marginBottom: 11,
+        alignItems: 'center',
+        backgroundColor: 'var(--color-white)',
+      }}
+      {...props}
     >
       {previewImageUrl ? <PreviewImage src={previewImageUrl} /> : null}
       <Container>
@@ -79,6 +77,6 @@ export default function ParentMessage({
           {text}
         </Text>
       </Container>
-    </ParentMessageContainer>
+    </FlexBox>
   )
 }

--- a/packages/chat/src/bubble/parent/parent-message.tsx
+++ b/packages/chat/src/bubble/parent/parent-message.tsx
@@ -1,0 +1,84 @@
+import { Container, Text, FlexBox } from '@titicaca/core-elements'
+import { MouseEventHandler } from 'react'
+import styled from 'styled-components'
+
+import { useScroll } from '../../chat/scroll-context'
+
+const PreviewImage = styled.img`
+  margin-right: 10px;
+  width: 34px;
+  height: 34px;
+  object-fit: 'cover';
+`
+
+interface ParentMessageType {
+  id: string
+  senderName: string
+  previewImageUrl?: string
+  text: string
+  backgroundColor?: string
+  titleColor?: string
+  previewTextColor?: string
+  onClick?: MouseEventHandler
+}
+
+export default function ParentMessage({
+  id,
+  senderName,
+  previewImageUrl,
+  text,
+  backgroundColor,
+  titleColor,
+  previewTextColor,
+  onClick,
+}: ParentMessageType) {
+  const { scrollToMessage } = useScroll()
+
+  return (
+    <FlexBox
+      onClick={(e) => {
+        scrollToMessage(id)
+        onClick?.(e)
+      }}
+      flex
+      borderRadius={13}
+      css={{
+        paddingLeft: 11,
+        paddingRight: 11,
+        paddingTop: 8,
+        paddingBottom: 8,
+        marginBottom: 11,
+        backgroundColor: backgroundColor || 'var(--color-white)',
+        alignItems: 'center',
+      }}
+    >
+      {previewImageUrl ? <PreviewImage src={previewImageUrl} /> : null}
+      <Container>
+        <Text
+          css={{
+            color: titleColor,
+            fontSize: 12,
+            fontWeight: 500,
+          }}
+        >
+          {senderName}님에게 답장
+        </Text>
+        <Text
+          margin={{ top: 2, bottom: 1 }}
+          color={previewTextColor}
+          size={12}
+          css={{
+            display: '-webkit-box',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            opacity: '0.7',
+            '-webkit-box-orient': 'vertical',
+            '-webkit-line-clamp': '1',
+          }}
+        >
+          {text}
+        </Text>
+      </Container>
+    </FlexBox>
+  )
+}

--- a/packages/chat/src/bubble/parent/parent-ui.tsx
+++ b/packages/chat/src/bubble/parent/parent-ui.tsx
@@ -6,21 +6,21 @@ import {
 
 import ParentMessage from './parent-message'
 
-export interface TextParentMessage {
+interface ParentMessageInterface {
   id: string
+  sender: { name: string; unregistered: boolean }
+}
+export interface TextParentMessage extends ParentMessageInterface {
   type: 'text'
   value: {
     message: string
-    sender: { name: string; unregistered: boolean }
   }
 }
 
-export interface ImageParentMessage {
-  id: string
+export interface ImageParentMessage extends ParentMessageInterface {
   type: 'image'
   value: {
     images: MetaDataInterface[]
-    sender: { name: string; unregistered: boolean }
   }
 }
 
@@ -33,9 +33,8 @@ export default function ParentMessageUI({
   type,
   value,
   blinded,
+  sender,
 }: ParentMessageUIProp) {
-  const { sender } = value
-
   const senderName = formatUsername({
     name: sender.name,
     unregistered: sender.unregistered,

--- a/packages/chat/src/bubble/parent/parent-ui.tsx
+++ b/packages/chat/src/bubble/parent/parent-ui.tsx
@@ -1,3 +1,5 @@
+import { CSSProp } from 'styled-components'
+
 import { MetaDataInterface, UserInterface } from '../../types'
 import {
   DEFAULT_MAX_USERNAME_LENGTH,
@@ -26,6 +28,7 @@ export interface ImageParentMessage extends ParentMessageInterface {
 
 export type ParentMessageUIProp = (TextParentMessage | ImageParentMessage) & {
   blinded: boolean
+  css?: CSSProp
 }
 
 export default function ParentMessageUI({
@@ -34,6 +37,7 @@ export default function ParentMessageUI({
   value,
   blinded,
   sender,
+  ...props
 }: ParentMessageUIProp) {
   const senderName = formatUsername({
     name: sender.profile.name,
@@ -47,13 +51,19 @@ export default function ParentMessageUI({
         id={id}
         text="삭제된 메세지입니다."
         senderName={senderName}
+        {...props}
       />
     )
   }
 
   if (type === 'text') {
     return (
-      <ParentMessage id={id} senderName={senderName} text={value.message} />
+      <ParentMessage
+        id={id}
+        senderName={senderName}
+        text={value.message}
+        {...props}
+      />
     )
   } else {
     return (
@@ -62,6 +72,7 @@ export default function ParentMessageUI({
         senderName={senderName}
         text="사진"
         previewImageUrl={value.images[0]?.sizes.large.url}
+        {...props}
       />
     )
   }

--- a/packages/chat/src/bubble/parent/parent-ui.tsx
+++ b/packages/chat/src/bubble/parent/parent-ui.tsx
@@ -1,4 +1,4 @@
-import { MetaDataInterface } from '../../types'
+import { MetaDataInterface, UserInterface } from '../../types'
 import {
   DEFAULT_MAX_USERNAME_LENGTH,
   formatUsername,
@@ -8,7 +8,7 @@ import ParentMessage from './parent-message'
 
 interface ParentMessageInterface {
   id: string
-  sender: { name: string; unregistered: boolean }
+  sender: UserInterface
 }
 export interface TextParentMessage extends ParentMessageInterface {
   type: 'text'
@@ -36,7 +36,7 @@ export default function ParentMessageUI({
   sender,
 }: ParentMessageUIProp) {
   const senderName = formatUsername({
-    name: sender.name,
+    name: sender.profile.name,
     unregistered: sender.unregistered,
     maxLength: DEFAULT_MAX_USERNAME_LENGTH,
   })

--- a/packages/chat/src/bubble/parent/parent-ui.tsx
+++ b/packages/chat/src/bubble/parent/parent-ui.tsx
@@ -28,7 +28,7 @@ export interface ImageParentMessage extends ParentMessageInterface {
 
 export type ParentMessageUIProp = (TextParentMessage | ImageParentMessage) & {
   blinded: boolean
-  css?: CSSProp
+  style?: { css?: CSSProp; titleColor?: string; previewTextColor?: string }
 }
 
 export default function ParentMessageUI({
@@ -37,7 +37,7 @@ export default function ParentMessageUI({
   value,
   blinded,
   sender,
-  ...props
+  style,
 }: ParentMessageUIProp) {
   const senderName = formatUsername({
     name: sender.profile.name,
@@ -51,7 +51,9 @@ export default function ParentMessageUI({
         id={id}
         text="삭제된 메세지입니다."
         senderName={senderName}
-        {...props}
+        previewTextColor={style?.previewTextColor}
+        titleColor={style?.titleColor}
+        css={style?.css}
       />
     )
   }
@@ -62,7 +64,9 @@ export default function ParentMessageUI({
         id={id}
         senderName={senderName}
         text={value.message}
-        {...props}
+        previewTextColor={style?.previewTextColor}
+        titleColor={style?.titleColor}
+        css={style?.css}
       />
     )
   } else {
@@ -72,7 +76,9 @@ export default function ParentMessageUI({
         senderName={senderName}
         text="사진"
         previewImageUrl={value.images[0]?.sizes.large.url}
-        {...props}
+        previewTextColor={style?.previewTextColor}
+        titleColor={style?.titleColor}
+        css={style?.css}
       />
     )
   }

--- a/packages/chat/src/bubble/parent/parent-ui.tsx
+++ b/packages/chat/src/bubble/parent/parent-ui.tsx
@@ -1,0 +1,69 @@
+import { MetaDataInterface } from '../../types'
+import {
+  DEFAULT_MAX_USERNAME_LENGTH,
+  formatUsername,
+} from '../../utils/profile'
+
+import ParentMessage from './parent-message'
+
+export interface TextParentMessage {
+  id: string
+  type: 'text'
+  value: {
+    message: string
+    sender: { name: string; unregistered: boolean }
+  }
+}
+
+export interface ImageParentMessage {
+  id: string
+  type: 'image'
+  value: {
+    images: MetaDataInterface[]
+    sender: { name: string; unregistered: boolean }
+  }
+}
+
+export type ParentMessageUIProp = (TextParentMessage | ImageParentMessage) & {
+  blinded: boolean
+}
+
+export default function ParentMessageUI({
+  id,
+  type,
+  value,
+  blinded,
+}: ParentMessageUIProp) {
+  const { sender } = value
+
+  const senderName = formatUsername({
+    name: sender.name,
+    unregistered: sender.unregistered,
+    maxLength: DEFAULT_MAX_USERNAME_LENGTH,
+  })
+
+  if (blinded) {
+    return (
+      <ParentMessage
+        id={id}
+        text="삭제된 메세지입니다."
+        senderName={senderName}
+      />
+    )
+  }
+
+  if (type === 'text') {
+    return (
+      <ParentMessage id={id} senderName={senderName} text={value.message} />
+    )
+  } else {
+    return (
+      <ParentMessage
+        id={id}
+        senderName={senderName}
+        text="사진"
+        previewImageUrl={value.images[0]?.sizes.large.url}
+      />
+    )
+  }
+}

--- a/packages/chat/src/bubble/parent/parent.stories.tsx
+++ b/packages/chat/src/bubble/parent/parent.stories.tsx
@@ -39,7 +39,7 @@ export const Image = {
   args: {
     id: 'parent-message',
     type: 'image',
-    sender: { name: '트리플', unregistered: false },
+    sender: { profile: { name: '트리플', photo: '' }, unregistered: false },
     value: {
       images: [
         {
@@ -70,7 +70,7 @@ export const Text = {
   args: {
     id: 'parent-message',
     type: 'text',
-    sender: { name: '트리플', unregistered: false },
+    sender: { profile: { name: '트리플' }, unregistered: false },
     value: {
       message: '반가워요',
     },

--- a/packages/chat/src/bubble/parent/parent.stories.tsx
+++ b/packages/chat/src/bubble/parent/parent.stories.tsx
@@ -1,0 +1,79 @@
+import { StoryFn } from '@storybook/react'
+
+import { Bubble } from '../bubble'
+import { TextItem } from '../item'
+import { ScrollProvider } from '../../chat'
+
+import ParentMessage from './parent-message'
+import ParentMessageUI, { ParentMessageUIProp } from './parent-ui'
+
+const Template: StoryFn<ParentMessageUIProp> = (args) => (
+  <ScrollProvider>
+    <Bubble id="bubble" my={false}>
+      <ParentMessageUI {...args} />
+      <TextItem text="안녕하세요" />
+    </Bubble>
+  </ScrollProvider>
+)
+export default {
+  title: 'chat / BubbleWithParent',
+  component: ParentMessage,
+  render: Template,
+  argTypes: {
+    id: {
+      type: 'text',
+      required: true,
+    },
+    value: {
+      type: 'object',
+      required: true,
+    },
+    blinded: {
+      type: 'boolean',
+      required: true,
+    },
+  },
+}
+
+export const Image = {
+  args: {
+    id: 'parent-message',
+    type: 'image',
+    value: {
+      sender: { name: '트리플', unregistered: false },
+      images: [
+        {
+          cloudinaryBucket: 'triple-dev',
+          cloudinaryId: 'cloudinary',
+          id: 'image',
+          type: 'image',
+          width: 1125,
+          height: 2436,
+          sizes: {
+            full: {
+              url: 'https://res.cloudinary.com/triple-entry/image/upload/w_1024,h_1024,c_limit,f_auto/07f5ed9c-1102-4ec0-b07c-7b1b098311b2.jpg',
+            },
+            large: {
+              url: 'https://res.cloudinary.com/triple-entry/image/upload/w_1024,h_1024,c_limit,f_auto/07f5ed9c-1102-4ec0-b07c-7b1b098311b2.jpg',
+            },
+            smallSquare: {
+              url: 'https://res.cloudinary.com/triple-entry/image/upload/w_1024,h_1024,c_limit,f_auto/07f5ed9c-1102-4ec0-b07c-7b1b098311b2.jpg',
+            },
+          },
+        },
+      ],
+    },
+  },
+}
+
+export const Text = {
+  args: {
+    id: 'parent-message',
+    type: 'text',
+    value: {
+      sender: { name: '트리플', unregistered: false },
+      message: '반가워요',
+    },
+    blinded: false,
+  },
+}

--- a/packages/chat/src/bubble/parent/parent.stories.tsx
+++ b/packages/chat/src/bubble/parent/parent.stories.tsx
@@ -39,8 +39,8 @@ export const Image = {
   args: {
     id: 'parent-message',
     type: 'image',
+    sender: { name: '트리플', unregistered: false },
     value: {
-      sender: { name: '트리플', unregistered: false },
       images: [
         {
           cloudinaryBucket: 'triple-dev',
@@ -70,8 +70,8 @@ export const Text = {
   args: {
     id: 'parent-message',
     type: 'text',
+    sender: { name: '트리플', unregistered: false },
     value: {
-      sender: { name: '트리플', unregistered: false },
       message: '반가워요',
     },
     blinded: false,

--- a/packages/chat/src/bubble/parent/parent.stories.tsx
+++ b/packages/chat/src/bubble/parent/parent.stories.tsx
@@ -1,20 +1,20 @@
 import { StoryFn } from '@storybook/react'
 
-import { Bubble } from '../bubble'
+import Bubble from '../bubble'
 import { TextItem } from '../item'
 import { ScrollProvider } from '../../chat'
 
 import ParentMessage from './parent-message'
-import ParentMessageUI, { ParentMessageUIProp } from './parent-ui'
+import { ParentMessageUIProp } from './parent-ui'
 
 const Template: StoryFn<ParentMessageUIProp> = (args) => (
   <ScrollProvider>
-    <Bubble id="bubble" my={false}>
-      <ParentMessageUI {...args} />
+    <Bubble id="bubble" my={false} parentMessage={args}>
       <TextItem text="안녕하세요" />
     </Bubble>
   </ScrollProvider>
 )
+
 export default {
   title: 'chat / BubbleWithParent',
   component: ParentMessage,

--- a/packages/chat/src/bubble/product.tsx
+++ b/packages/chat/src/bubble/product.tsx
@@ -10,7 +10,7 @@ import {
   ProductInfo,
   ProductName,
 } from './elements'
-import { Bubble } from './bubble'
+import Bubble from './bubble'
 import { ProductBubbleProp } from './type'
 
 const PRODUCT_BADGE_COLOR: Record<CustomerBookingStatus, Color> = {

--- a/packages/chat/src/bubble/rich.tsx
+++ b/packages/chat/src/bubble/rich.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { generatePreviewImage } from '../utils'
 
 import { ImageItem, TextItem } from './item'
-import { Bubble } from './bubble'
+import Bubble from './bubble'
 import { RichBubbleProp } from './type'
 
 const Button = styled.a`

--- a/packages/chat/src/bubble/text.tsx
+++ b/packages/chat/src/bubble/text.tsx
@@ -5,8 +5,14 @@ import useATagNavigator from '../utils/a-tag-navigator'
 import { TextItem } from './item'
 import { Bubble } from './bubble'
 import { TextBubbleProp } from './type'
+import ParentMessageUI from './parent/parent-ui'
 
-export function TextBubble({ message, my, ...props }: TextBubbleProp) {
+export function TextBubble({
+  message,
+  my,
+  parentMessage,
+  ...props
+}: TextBubbleProp) {
   const aTagNavigator = useATagNavigator()
 
   return (
@@ -20,6 +26,7 @@ export function TextBubble({ message, my, ...props }: TextBubbleProp) {
       my={my}
       {...props}
     >
+      {parentMessage ? <ParentMessageUI {...parentMessage} /> : null}
       <TextItem text={message} onClick={(e) => aTagNavigator(e)} />
     </Bubble>
   )

--- a/packages/chat/src/bubble/text.tsx
+++ b/packages/chat/src/bubble/text.tsx
@@ -6,43 +6,6 @@ import { TextItem } from './item'
 import { Bubble } from './bubble'
 import { TextBubbleProp } from './type'
 
-/**
- * 
-const BACKGROUND_COLORS: {
-  [key in BackgroundColor]: string
-} = {
-  blue: '#d7e9ff',
-  gray: '#f5f5f5',
-  darkGray: '#F6F6F6',
-  mint: '#24CABD',
-}
-
-const TAIL_POSITION_STYLE_MAP: { [key: string]: ReturnType<typeof css> } = {
-  left: css`
-    &::before {
-      left: -10px;
-    }
-  `,
-  right: css`
-    right: 10px;
-
-    &::before {
-      right: -10px;
-    }
-  `,
-}
-
-const getBackgroundImage = (color: BackgroundColor) => {
-  return `https://assets.triple-dev.titicaca-corp.com/images/img-speechbubble-${color}@3x.png`
-}
-
-function getDefaultBackgroundColor(my: boolean) {
-  return my ? 'blue' : 'gray'
-}
-
- * 
- */
-
 export function TextBubble({ message, my, ...props }: TextBubbleProp) {
   const aTagNavigator = useATagNavigator()
 

--- a/packages/chat/src/bubble/text.tsx
+++ b/packages/chat/src/bubble/text.tsx
@@ -3,16 +3,10 @@ import { css } from 'styled-components'
 import useATagNavigator from '../utils/a-tag-navigator'
 
 import { TextItem } from './item'
-import { Bubble } from './bubble'
+import Bubble from './bubble'
 import { TextBubbleProp } from './type'
-import ParentMessageUI from './parent/parent-ui'
 
-export function TextBubble({
-  message,
-  my,
-  parentMessage,
-  ...props
-}: TextBubbleProp) {
+export function TextBubble({ message, my, ...props }: TextBubbleProp) {
   const aTagNavigator = useATagNavigator()
 
   return (
@@ -26,7 +20,6 @@ export function TextBubble({
       my={my}
       {...props}
     >
-      {parentMessage ? <ParentMessageUI {...parentMessage} /> : null}
       <TextItem text={message} onClick={(e) => aTagNavigator(e)} />
     </Bubble>
   )

--- a/packages/chat/src/bubble/type.ts
+++ b/packages/chat/src/bubble/type.ts
@@ -4,7 +4,7 @@ import { CSSProp } from 'styled-components'
 
 import { MetaDataInterface } from '../types'
 
-import { ImageParentMessage, TextParentMessage } from './parent/parent-ui'
+import { ParentMessageUIProp } from './parent/parent-ui'
 
 type CustomerBookingStatus =
   | 'BOOKED'
@@ -67,7 +67,7 @@ export type BubbleProp = BubbleCSSProp & {
 export type TextBubbleProp = {
   message: string
   my: boolean
-  parentMessage?: TextParentMessage | ImageParentMessage
+  parentMessage?: ParentMessageUIProp
 } & BubbleProp
 
 export type RichBubbleProp = {

--- a/packages/chat/src/bubble/type.ts
+++ b/packages/chat/src/bubble/type.ts
@@ -4,6 +4,8 @@ import { CSSProp } from 'styled-components'
 
 import { MetaDataInterface } from '../types'
 
+import { ImageParentMessage, TextParentMessage } from './parent/parent-ui'
+
 type CustomerBookingStatus =
   | 'BOOKED'
   | 'ONGOING'
@@ -65,6 +67,7 @@ export type BubbleProp = BubbleCSSProp & {
 export type TextBubbleProp = {
   message: string
   my: boolean
+  parentMessage?: TextParentMessage | ImageParentMessage
 } & BubbleProp
 
 export type RichBubbleProp = {

--- a/packages/chat/src/bubble/type.ts
+++ b/packages/chat/src/bubble/type.ts
@@ -53,7 +53,7 @@ export interface BubbleCSSProp {
   hasArrow?: boolean
 }
 
-export type BubbleProp = BubbleCSSProp & {
+export type BaseBubbleProp = BubbleCSSProp & {
   id: string
   onClick?: (e: MouseEvent, messageId: string) => void
   onLongPress?: (
@@ -62,6 +62,10 @@ export type BubbleProp = BubbleCSSProp & {
     context: LongPressCallbackMeta<unknown>,
   ) => void
   css?: CSSProp
+}
+
+export type BubbleProp = BaseBubbleProp & {
+  parentMessage?: ParentMessageUIProp
 }
 
 export type TextBubbleProp = {

--- a/packages/chat/src/messages/messages.stories.tsx
+++ b/packages/chat/src/messages/messages.stories.tsx
@@ -1,8 +1,15 @@
+import { ScrollProvider } from '../chat'
+
 import Messages from './'
 
 export default {
   title: 'chat / Messages',
   component: Messages,
+  render: (args) => (
+    <ScrollProvider>
+      <Messages {...args} />
+    </ScrollProvider>
+  ),
 }
 
 export const Message = {
@@ -24,6 +31,16 @@ export const Message = {
         },
         createdAt: new Date(2022, 10, 1).toISOString(),
         thanks: { count: 1, haveMine: false },
+        parentMessage: {
+          id: 'parent_message',
+          type: 'text',
+          blinded: false,
+          value: { message: '안녕하세요' },
+          sender: {
+            name: '트리플',
+            unregistered: false,
+          },
+        },
       },
       {
         type: 'another',

--- a/packages/chat/src/messages/messages.stories.tsx
+++ b/packages/chat/src/messages/messages.stories.tsx
@@ -37,7 +37,7 @@ export const Message = {
           blinded: false,
           value: { message: '안녕하세요' },
           sender: {
-            name: '트리플',
+            profile: { name: '트리플' },
             unregistered: false,
           },
         },

--- a/packages/chat/src/utils/profile.ts
+++ b/packages/chat/src/utils/profile.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_MAX_USERNAME_LENGTH = 10
+
+export function formatUsername({
+  name,
+  unregistered = false,
+  maxLength,
+}: {
+  name: string
+  unregistered?: boolean | null
+  maxLength?: number
+}) {
+  if (unregistered) {
+    return '***'
+  }
+
+  if (maxLength) {
+    return name.length > maxLength ? `${name.slice(0, maxLength)}⋯` : name
+  }
+
+  return name
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
ParentMessage UI를 추가합니다. 
## 변경 내역

- chat에서 볼 때는 부모 메세지의 경우 없거나/있거나 둘 중 하나이지만, 파트너챗과 같은 서비스에서는 부모 메세지가 존재하지 않으므로 null과 undefined 모두 가능하도록 했습니다. 
- MessageParent UI의 css는 ParentMessage의 prop으로 전달합니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 논의사항
BubbleUI를 Messages 컴포넌트 내에서 렌더링하기 때문에  Bubble은 Messages의 Prop으로 전달하지만, ParentMessageUI 컴포넌트를 Bubble의 children으로 렌더링하기 때문에 이처럼 정했습니다. Bubble과의 통일성을 위해서는 Messages의 prop으로 전달하는 것이 맞을 것 같은데, 의견 부탁드립니다. 물론 이럴 경우에도 Bubble에서 ParentMessageUI를 렌더링할 때 prop으로 전달하게 됩니다.

```
export type ParentMessageUIProp = (TextParentMessage | ImageParentMessage) & {
  blinded: boolean
  style?: {
       css?: CSSProp;
       titleColor?: string;
       previewTextColor?: string;
  }
}
```

```
 bubbleStyle?: {
        received?: {
            css?: CSSProp;
            alteredTextColor?: string;
        };
        sent?: {
            css?: CSSProp;
            alteredTextColor?: string;
        };
        parentMessageCss?: {
            css?: CSSProp;
            titleColor?: string;
            previewTextColor?: string;
        }
    };
```

또는 스타일 전체를 context나 className으로 설정하는 방법도 있습니다. 
<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL
![스크린샷 2024-02-07 오후 3 14 27](https://github.com/titicacadev/triple-frontend/assets/43779313/293ef252-fe37-4e96-b757-b808662c2723)

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
