### PR TITLE
[review] 좋아요 카운트 버그 수정

### DIFF
--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -149,7 +149,8 @@ export function ReviewElement({
 
   const { mutate: likeReview, isLoading: isLikeLoading } =
     useLikeReviewMutation()
-  const { mutate: unlikeReview } = useUnlikeReviewMutation()
+  const { mutate: unlikeReview, isLoading: isUnlikeLoading } =
+    useUnlikeReviewMutation()
 
   const likeButtonAction = `리뷰_땡쓰${liked ? '취소' : ''}_선택`
 
@@ -397,7 +398,7 @@ export function ReviewElement({
                 height: 18,
               }}
               onClick={handleLikeButtonClick}
-              disabled={isLikeLoading}
+              disabled={isLikeLoading || isUnlikeLoading}
             >
               {likesCount}
             </LikeButton>

--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -66,7 +66,7 @@ const MessageCount = styled(Container)<{ isCommaVisible?: boolean }>`
     `}
 `
 
-const LikeButton = styled(Container)<{ liked?: boolean }>`
+const LikeButton = styled.button<{ liked?: boolean }>`
   font-weight: bold;
   text-decoration: none;
   background-size: 18px 18px;
@@ -147,7 +147,8 @@ export function ReviewElement({
   const { showToast } = useTripleClientActions()
   const { navigateReviewDetail, navigateUserDetail } = useClientActions()
 
-  const { mutate: likeReview } = useLikeReviewMutation()
+  const { mutate: likeReview, isLoading: isLikeLoading } =
+    useLikeReviewMutation()
   const { mutate: unlikeReview } = useUnlikeReviewMutation()
 
   const likeButtonAction = `리뷰_땡쓰${liked ? '취소' : ''}_선택`
@@ -245,7 +246,6 @@ export function ReviewElement({
           resource_id: resourceId,
         },
       })
-
       liked
         ? unlikeReview({ reviewId: review.id, resourceId })
         : likeReview({ reviewId: review.id, resourceId })
@@ -390,7 +390,6 @@ export function ReviewElement({
         <Meta>
           {!blinded ? (
             <LikeButton
-              display="inline-block"
               liked={liked}
               css={{
                 marginTop: 5,
@@ -398,6 +397,7 @@ export function ReviewElement({
                 height: 18,
               }}
               onClick={handleLikeButtonClick}
+              disabled={isLikeLoading}
             >
               {likesCount}
             </LikeButton>

--- a/packages/review/src/services/use-reviews.ts
+++ b/packages/review/src/services/use-reviews.ts
@@ -71,6 +71,16 @@ export function useLikeReviewMutation() {
               }
             : review
 
+        queryClient.setQueriesData<GetMyReviewQuery | undefined>(
+          ['review/getMyReviews'],
+          (old) =>
+            old
+              ? {
+                  ...old,
+                  ...(old.myReview && { myReview: updater(old.myReview) }),
+                }
+              : old,
+        )
         queryClient.setQueriesData<GetPopularReviewsQuery | undefined>(
           ['review/getPopularReviews'],
           (old) =>

--- a/packages/review/src/services/use-reviews.ts
+++ b/packages/review/src/services/use-reviews.ts
@@ -72,7 +72,7 @@ export function useLikeReviewMutation() {
             : review
 
         queryClient.setQueriesData<GetMyReviewQuery | undefined>(
-          ['review/getMyReviews'],
+          ['review/getMyReview'],
           (old) =>
             old
               ? {
@@ -176,6 +176,16 @@ export function useUnlikeReviewMutation() {
               }
             : review
 
+        queryClient.setQueriesData<GetMyReviewQuery | undefined>(
+          ['review/getMyReview'],
+          (old) =>
+            old
+              ? {
+                  ...old,
+                  ...(old.myReview && { myReview: updater(old.myReview) }),
+                }
+              : old,
+        )
         queryClient.setQueriesData<GetPopularReviewsQuery | undefined>(
           ['review/getPopularReviews'],
           (old) =>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

[제보 스레드](https://interpark.slack.com/archives/C061LUEUP8A/p1705979266405729)

리뷰에서 좋아요 버튼을 여러번 클릭했을 때, 이전 요청이 처리되지 않은 상태에서 새로운 요청들이 들어가며 좋아요/좋아요 취소 handler가 여러번 실행되고 있었습니다. 이를 방지하기 위해 요청이 처리되고 있는 상황에서는 버튼이 클릭되지 않도록 했습니다. 

또한 좋아요/좋아요 취소 로직에서 본인 리뷰 쿼리 데이터가 업데이트에서 빠져있어 본인 리뷰를 좋아요/좋아요 취소할 경우 반영되지 않고 있어 handler에 추가했습니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
 - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? 

## 스크린샷 & URL

문제 상황

https://github.com/titicacadev/triple-frontend/assets/43779313/0459ee0d-b8c5-43b4-8cd4-65ebc7c591fb
<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
