### PR TITLE
[chat] 버블 스타일을 수정하고 날짜 및 시간 표기, 프로필 생략 기능을 추가합니다.

### DIFF
--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -49,7 +49,7 @@
     "@titicaca/type-definitions": "workspace:*",
     "@titicaca/view-utilities": "workspace:*",
     "autolinker": "^4.0.0",
-    "moment": "^2.29.4",
+    "date-fns": "^3.3.1",
     "use-long-press": "^3.2.0"
   },
   "devDependencies": {

--- a/packages/chat/src/bubble-container/bubble-container.tsx
+++ b/packages/chat/src/bubble-container/bubble-container.tsx
@@ -26,8 +26,12 @@ interface ContainerBaseProp {
   createdAt?: string // Date?
   /** 해당 메시지를 읽지 않은 유저의 수 */
   unreadCount: number | null
-  /** 시간 정보 등의 정보의 노출 여부 */
+  /** 시간 정보, 안읽음 숫자 등의 정보의 노출 여부 */
   showInfo?: boolean
+  /** 날짜 정보의 노출 여부 */
+  showDateInfo?: boolean
+  /** 시간 정보의 노출 여부 */
+  showTimeInfo?: boolean
   /** 좋아요 정보 */
   thanks?: { count: number; haveMine: boolean }
   /** 좋아요 아이콘 클릭 시 작동하는 함수 */
@@ -50,6 +54,8 @@ function SentBubbleContainer({
   onRetryCancel,
   unreadCount,
   showInfo = true,
+  showDateInfo,
+  showTimeInfo,
   thanks,
   onThanksClick,
   children,
@@ -71,6 +77,8 @@ function SentBubbleContainer({
           <BubbleInfo
             unreadCount={unreadCount}
             date={createdAt}
+            showDateInfo={showDateInfo}
+            showTimeInfo={showTimeInfo}
             css={{ marginRight: 8, textAlign: 'right' }}
           />
         ) : null}
@@ -99,6 +107,8 @@ type ReceivedBubbleContainerProp = PropsWithChildren<
       userId: string
       unregistered?: boolean
     }
+    /** 프로필 노출 여부 */
+    showProfile?: boolean
   }
 >
 
@@ -108,6 +118,9 @@ function ReceivedBubbleContainer({
   unreadCount,
   createdAt,
   showInfo,
+  showDateInfo,
+  showTimeInfo,
+  showProfile = true,
   thanks,
   onThanksClick,
   children,
@@ -117,17 +130,21 @@ function ReceivedBubbleContainer({
       id={`${DEFAULT_MESSAGE_ID_PREFIX}-${id}`}
       css={{ ...CHAT_CONTAINER_STYLES }}
     >
-      <ProfileImage src={user?.photo} />
+      {showProfile ? <ProfileImage src={user?.photo} /> : null}
       <Container css={{ marginLeft: 50 }}>
-        <ProfileName size="mini" alpha={0.8} margin={{ bottom: 5 }}>
-          {user?.name || ''}
-        </ProfileName>
+        {showProfile ? (
+          <ProfileName size="mini" alpha={0.8} margin={{ bottom: 5 }}>
+            {user?.name || ''}
+          </ProfileName>
+        ) : null}
 
         {children}
 
         {createdAt && showInfo ? (
           <BubbleInfo
             unreadCount={unreadCount}
+            showDateInfo={showDateInfo}
+            showTimeInfo={showTimeInfo}
             date={createdAt}
             css={{ marginLeft: 8, textAlign: 'left' }}
           />

--- a/packages/chat/src/bubble-container/bubble-container.tsx
+++ b/packages/chat/src/bubble-container/bubble-container.tsx
@@ -24,7 +24,7 @@ interface ContainerBaseProp {
   createdAt?: string // Date?
   /** 해당 메시지를 읽지 않은 유저의 수 */
   unreadCount: number | null
-  /** 시간 정보, 안읽음 숫자 등의 정보의 노출 여부 */
+  /** 정보 영역 노출 여부 (시간, 안읽음 등) */
   showInfo?: boolean
   /** 날짜 정보의 노출 여부 */
   showDateInfo?: boolean

--- a/packages/chat/src/bubble-container/bubble-container.tsx
+++ b/packages/chat/src/bubble-container/bubble-container.tsx
@@ -15,7 +15,6 @@ import {
 
 const CHAT_CONTAINER_STYLES = {
   position: 'relative',
-  minHeight: 46,
   width: '100%',
 } as const
 

--- a/packages/chat/src/bubble-container/bubble-container.tsx
+++ b/packages/chat/src/bubble-container/bubble-container.tsx
@@ -14,7 +14,6 @@ import {
 } from './elements'
 
 const CHAT_CONTAINER_STYLES = {
-  marginTop: 20,
   position: 'relative',
   minHeight: 46,
   width: '100%',
@@ -59,11 +58,13 @@ function SentBubbleContainer({
   thanks,
   onThanksClick,
   children,
+  ...props
 }: SentBubbleContainerProp) {
   return (
     <Container
       id={`${DEFAULT_MESSAGE_ID_PREFIX}-${id}`}
       css={{ textAlign: 'right', ...CHAT_CONTAINER_STYLES }}
+      {...props}
     >
       <div>
         {!createdAt && onRetry && onRetryCancel ? (
@@ -124,16 +125,18 @@ function ReceivedBubbleContainer({
   thanks,
   onThanksClick,
   children,
+  ...props
 }: ReceivedBubbleContainerProp) {
   return (
     <Container
       id={`${DEFAULT_MESSAGE_ID_PREFIX}-${id}`}
       css={{ ...CHAT_CONTAINER_STYLES }}
+      {...props}
     >
       {showProfile ? <ProfileImage src={user?.photo} /> : null}
-      <Container css={{ marginLeft: 50 }}>
+      <Container css={{ marginLeft: 40 }}>
         {showProfile ? (
-          <ProfileName size="mini" alpha={0.8} margin={{ bottom: 5 }}>
+          <ProfileName alpha={0.7} margin={{ bottom: 5 }}>
             {user?.name || ''}
           </ProfileName>
         ) : null}
@@ -146,7 +149,7 @@ function ReceivedBubbleContainer({
             showDateInfo={showDateInfo}
             showTimeInfo={showTimeInfo}
             date={createdAt}
-            css={{ marginLeft: 8, textAlign: 'left' }}
+            css={{ marginLeft: 4, textAlign: 'left' }}
           />
         ) : null}
 

--- a/packages/chat/src/bubble-container/bubble-container.tsx
+++ b/packages/chat/src/bubble-container/bubble-container.tsx
@@ -79,7 +79,7 @@ function SentBubbleContainer({
             date={createdAt}
             showDateInfo={showDateInfo}
             showTimeInfo={showTimeInfo}
-            css={{ marginRight: 8, textAlign: 'right' }}
+            css={{ marginRight: 4, textAlign: 'right' }}
           />
         ) : null}
 

--- a/packages/chat/src/bubble-container/bubble-info.tsx
+++ b/packages/chat/src/bubble-container/bubble-info.tsx
@@ -1,6 +1,7 @@
-import moment from 'moment'
 import styled from 'styled-components'
 import { Container, Text } from '@titicaca/core-elements'
+import { isSameDay, isSameYear, format, setDefaultOptions } from 'date-fns'
+import { ko } from 'date-fns/locale'
 
 const BubbleInfoContainer = styled(Container)`
   vertical-align: bottom;
@@ -11,7 +12,7 @@ const UnreadMessageCountText = styled.div`
   font-size: 10px;
 `
 
-moment.locale('ko')
+setDefaultOptions({ locale: ko })
 
 export function BubbleInfo({
   unreadCount,
@@ -21,8 +22,8 @@ export function BubbleInfo({
   unreadCount: number | null
   date: string
 }) {
-  const showDate = !moment().isSame(date, 'day')
-  const showYear = !moment().isSame(date, 'year')
+  const showDate = !isSameDay(new Date(), new Date(date))
+  const showYear = !isSameYear(new Date(), new Date(date))
 
   return (
     <BubbleInfoContainer position="relative" display="inline-block" {...props}>
@@ -32,12 +33,12 @@ export function BubbleInfo({
 
       {showDate ? (
         <Text size={10} alpha={0.51}>
-          {moment(date).format(showYear ? 'YYYY.MM.DD' : 'MM.DD')}
+          {format(new Date(date), showYear ? 'yyyy.MM.dd' : 'MM.dd')}
         </Text>
       ) : null}
 
       <Text size={10} alpha={0.51}>
-        {moment(date).format('A hh:mm')}
+        {format(new Date(date), 'a h:mm')}
       </Text>
     </BubbleInfoContainer>
   )

--- a/packages/chat/src/bubble-container/bubble-info.tsx
+++ b/packages/chat/src/bubble-container/bubble-info.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import { Container, Text } from '@titicaca/core-elements'
-import { isSameDay, isSameYear, format, setDefaultOptions } from 'date-fns'
+import { format, setDefaultOptions } from 'date-fns'
 import { ko } from 'date-fns/locale'
 
 const BubbleInfoContainer = styled(Container)`
@@ -17,29 +17,32 @@ setDefaultOptions({ locale: ko })
 export function BubbleInfo({
   unreadCount,
   date,
+  showTimeInfo = true,
+  showDateInfo = false,
   ...props
 }: {
   unreadCount: number | null
   date: string
+  showTimeInfo?: boolean
+  showDateInfo?: boolean
 }) {
-  const showDate = !isSameDay(new Date(), new Date(date))
-  const showYear = !isSameYear(new Date(), new Date(date))
-
   return (
     <BubbleInfoContainer position="relative" display="inline-block" {...props}>
       {unreadCount ? (
         <UnreadMessageCountText>{unreadCount}</UnreadMessageCountText>
       ) : null}
 
-      {showDate ? (
+      {showDateInfo ? (
         <Text size={10} alpha={0.51}>
-          {format(new Date(date), showYear ? 'yyyy.MM.dd' : 'MM.dd')}
+          {format(new Date(date), 'MM.dd')}
         </Text>
       ) : null}
 
-      <Text size={10} alpha={0.51}>
-        {format(new Date(date), 'a h:mm')}
-      </Text>
+      {showTimeInfo ? (
+        <Text size={10} alpha={0.51}>
+          {format(new Date(date), 'a h:mm')}
+        </Text>
+      ) : null}
     </BubbleInfoContainer>
   )
 }

--- a/packages/chat/src/bubble-container/elements.tsx
+++ b/packages/chat/src/bubble-container/elements.tsx
@@ -9,7 +9,7 @@ export const ProfileImage = styled.img`
   width: 32px;
   height: 32px;
   border-radius: 32px;
-  box-shadow: rgba(0, 0, 0, 0.02) 0px 0px 0px 1px;
+  box-shadow: rgba(0, 0, 0, 0.02) 0 0 0 1px;
   outline-offset: -1px;
   float: left;
 `

--- a/packages/chat/src/bubble-container/elements.tsx
+++ b/packages/chat/src/bubble-container/elements.tsx
@@ -6,13 +6,16 @@ export const HiddenElement = styled.div`
 `
 
 export const ProfileImage = styled.img`
-  width: 36px;
-  height: 36px;
-  border-radius: 26.8px;
+  width: 32px;
+  height: 32px;
+  border-radius: 32px;
+  box-shadow: rgba(0, 0, 0, 0.02) 0px 0px 0px 1px;
+  outline-offset: -1px;
   float: left;
 `
 
 export const ProfileName = styled(Text)`
+  font-size: 11px;
   font-weight: 600;
 `
 

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -174,6 +174,7 @@ export default function BubbleUI({
           onClick={onBubbleClick}
           onLongPress={onBubbleLongPress}
           maxWidthOffset={maxWidthOffset}
+          hasArrow={hasArrow}
           {...props}
         />
       )

--- a/packages/chat/src/bubble/bubble.tsx
+++ b/packages/chat/src/bubble/bubble.tsx
@@ -12,7 +12,7 @@ const StyledBubble = styled(Text).attrs({
   border-radius: 20px;
   position: relative;
   margin: 0;
-  padding: 12px 14px;
+  padding: 11px;
 
   > div {
     word-break: break-word;

--- a/packages/chat/src/bubble/product.tsx
+++ b/packages/chat/src/bubble/product.tsx
@@ -53,6 +53,7 @@ export const ProductBubble = ({
         width: 'calc(100% - 15px)',
         maxWidth: '768px',
         margin: my ? '0 0 0 8px' : undefined,
+        padding: '12px 14px',
       }}
       {...props}
     >

--- a/packages/chat/src/messages.tsx
+++ b/packages/chat/src/messages.tsx
@@ -147,10 +147,14 @@ export default function Messages<
     )
   }
 
-  function renderMessages(
-    listType: 'normal' | 'failed' | 'pending',
-    messages: MessageInterface<Message, User>[],
-  ) {
+  function renderMessages({
+    listType,
+    messages, // lastMessageOfPrevList: prevMessage,
+  }: {
+    listType: 'normal' | 'failed' | 'pending'
+    messages: MessageInterface<Message, User>[]
+    lastMessageOfPrevList?: MessageInterface<Message, User> | null
+  }) {
     return messages.map((message) => {
       const { id, sender, createdAt, type, thanks } = message
       const my = sender.id === me.id
@@ -192,12 +196,29 @@ export default function Messages<
 
   return (
     <>
-      <div id="messages_list">{renderMessages('normal', messages)}</div>
+      <div id="messages_list">
+        {renderMessages({
+          listType: 'normal',
+          messages,
+          lastMessageOfPrevList: null,
+        })}
+      </div>
       <div id="pending_messages_list">
-        {renderMessages('pending', pendingMessages)}
+        {renderMessages({
+          listType: 'pending',
+          messages: pendingMessages,
+          lastMessageOfPrevList: messages[messages.length - 1],
+        })}
       </div>
       <div id="failed_messages_list">
-        {renderMessages('failed', failedMessages)}
+        {renderMessages({
+          listType: 'failed',
+          messages: failedMessages,
+          lastMessageOfPrevList:
+            pendingMessages.length > 0
+              ? pendingMessages[pendingMessages.length - 1]
+              : messages[messages.length - 1],
+        })}
       </div>
     </>
   )

--- a/packages/chat/src/messages/date-divider.tsx
+++ b/packages/chat/src/messages/date-divider.tsx
@@ -1,0 +1,10 @@
+import { Text } from '@titicaca/core-elements'
+import { format } from 'date-fns'
+
+export function DateDivider({ date }: { date: Date }) {
+  return (
+    <Text textAlign="center" size={11} color="gray700" margin={{ top: 30 }}>
+      {format(date, 'yyyy년 MM월 dd일')}
+    </Text>
+  )
+}

--- a/packages/chat/src/messages/index.tsx
+++ b/packages/chat/src/messages/index.tsx
@@ -48,7 +48,7 @@ export default function Messages<
   calculateUnreadCount,
   customBubble,
   bubbleStyle,
-  hasDateDivider,
+  hasDateDivider = true,
   hasArrow,
   ...bubbleProps
 }: MessagesProp<Message, User> &
@@ -159,7 +159,7 @@ export default function Messages<
       const showTimeInfo =
         listType === 'normal' &&
         isSameSenderAsPrevMessage &&
-        !isSameMinuteAsNextMessage
+        (!isSameMinuteAsNextMessage || !nextMessage.createdAt)
 
       const showProfile = isFirstMessageOfDate || !isSameSenderAsPrevMessage
       const isFirstPendingOrFailedMessageOfDate =

--- a/packages/chat/src/messages/index.tsx
+++ b/packages/chat/src/messages/index.tsx
@@ -49,6 +49,7 @@ export default function Messages<
   customBubble,
   bubbleStyle,
   hasDateDivider,
+  hasArrow,
   ...bubbleProps
 }: MessagesProp<Message, User> &
   Omit<
@@ -65,9 +66,11 @@ export default function Messages<
   function getBubble({
     message,
     my,
+    hasArrow = true,
   }: {
     message: MessageInterface<Message, User>
     my: boolean
+    hasArrow?: boolean
   }) {
     const { id, sender, type, value, blinded, deleted, ...rest } = message
 
@@ -91,6 +94,7 @@ export default function Messages<
                 ? bubbleStyle?.sent?.alteredTextColor
                 : bubbleStyle?.received?.alteredTextColor
             }
+            hasArrow={hasArrow}
           />
         )
       }
@@ -116,6 +120,7 @@ export default function Messages<
             ? bubbleStyle?.sent?.alteredTextColor
             : bubbleStyle?.received?.alteredTextColor
         }
+        hasArrow={hasArrow}
         css={my ? bubbleStyle?.sent?.css : bubbleStyle?.received?.css}
         {...rest}
         {...bubbleProps}
@@ -155,7 +160,8 @@ export default function Messages<
         listType === 'normal' &&
         isSameSenderAsPrevMessage &&
         !isSameMinuteAsNextMessage
-      // && (isSameSenderAsNextMessage ? nextMessage?.type !== 'product' : true)
+
+      const showProfile = isFirstMessageOfDate || !isSameSenderAsPrevMessage
 
       return (
         <Fragment key={id}>
@@ -177,7 +183,7 @@ export default function Messages<
               unregistered: sender.unregistered,
             }}
             showInfo={type !== 'product'}
-            showProfile={isFirstMessageOfDate || !isSameSenderAsPrevMessage}
+            showProfile={showProfile}
             showDateInfo={!hasDateDivider}
             showTimeInfo={showTimeInfo}
             {...(listType === 'failed' && {
@@ -192,8 +198,11 @@ export default function Messages<
             onThanksClick={
               thanks && onThanksClick ? () => onThanksClick(message) : undefined
             }
+            css={{
+              marginTop: isFirstMessageOfDate ? 20 : showProfile ? 16 : 5,
+            }}
           >
-            {getBubble({ message, my })}
+            {getBubble({ message, my, hasArrow: showProfile })}
           </BubbleContainer>
         </Fragment>
       )

--- a/packages/chat/src/messages/index.tsx
+++ b/packages/chat/src/messages/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentType } from 'react'
+import { ComponentType, Fragment } from 'react'
 import { CSSProp } from 'styled-components'
 
 import BubbleContainer from '../bubble-container/bubble-container'
@@ -8,7 +8,8 @@ import AlteredBubble from '../bubble/altered'
 import { ALTERNATIVE_TEXT_MESSAGE } from '../bubble/constants'
 
 import { MessageBase, MessageInterface } from './type'
-import { isBubbleType, isSameSender, isSameDate } from './utils'
+import { isBubbleType, compareSender, compareDate } from './utils'
+import { DateDivider } from './date-divider'
 
 interface MessagesProp<
   Message extends MessageBase<User>,
@@ -139,12 +140,12 @@ export default function Messages<
         index === 0 ? lastMessageOfPrevList : messages[index - 1]
       const nextMessage = messages[index + 1] || null
 
-      const { isSameSenderAsPrevMessage } = isSameSender(
+      const { isSameSenderAsPrevMessage } = compareSender(
         prevMessage,
         message,
         nextMessage,
       )
-      const { isFirstMessageOfDate, isSameMinuteAsNextMessage } = isSameDate(
+      const { isFirstMessageOfDate, isSameMinuteAsNextMessage } = compareDate(
         prevMessage,
         message,
         nextMessage,
@@ -157,39 +158,44 @@ export default function Messages<
       // && (isSameSenderAsNextMessage ? nextMessage?.type !== 'product' : true)
 
       return (
-        <BubbleContainer
-          key={id}
-          id={id.toString()}
-          my={my}
-          unreadCount={
-            calculateUnreadCount ? calculateUnreadCount(message) : null
-          }
-          createdAt={createdAt}
-          user={{
-            photo: sender.profile.photo,
-            name: sender.profile.name,
-            userId: sender.id,
-            unregistered: sender.unregistered,
-          }}
-          showInfo={type !== 'product'}
-          showProfile={isFirstMessageOfDate || !isSameSenderAsPrevMessage}
-          // showDateInfo={!hasDateDivider}
-          showTimeInfo={showTimeInfo}
-          {...(listType === 'failed' && {
-            onRetry: () => {
-              onRetry?.(message)
-            },
-            onRetryCancel: () => {
-              onRetryCancel?.(message)
-            },
-          })}
-          thanks={thanks}
-          onThanksClick={
-            thanks && onThanksClick ? () => onThanksClick(message) : undefined
-          }
-        >
-          {getBubble({ message, my })}
-        </BubbleContainer>
+        <Fragment key={id}>
+          {hasDateDivider && message.createdAt && isFirstMessageOfDate ? (
+            <DateDivider date={new Date(message.createdAt)} />
+          ) : null}
+
+          <BubbleContainer
+            id={id.toString()}
+            my={my}
+            unreadCount={
+              calculateUnreadCount ? calculateUnreadCount(message) : null
+            }
+            createdAt={createdAt}
+            user={{
+              photo: sender.profile.photo,
+              name: sender.profile.name,
+              userId: sender.id,
+              unregistered: sender.unregistered,
+            }}
+            showInfo={type !== 'product'}
+            showProfile={isFirstMessageOfDate || !isSameSenderAsPrevMessage}
+            showDateInfo={!hasDateDivider}
+            showTimeInfo={showTimeInfo}
+            {...(listType === 'failed' && {
+              onRetry: () => {
+                onRetry?.(message)
+              },
+              onRetryCancel: () => {
+                onRetryCancel?.(message)
+              },
+            })}
+            thanks={thanks}
+            onThanksClick={
+              thanks && onThanksClick ? () => onThanksClick(message) : undefined
+            }
+          >
+            {getBubble({ message, my })}
+          </BubbleContainer>
+        </Fragment>
       )
     })
   }

--- a/packages/chat/src/messages/index.tsx
+++ b/packages/chat/src/messages/index.tsx
@@ -162,11 +162,19 @@ export default function Messages<
         !isSameMinuteAsNextMessage
 
       const showProfile = isFirstMessageOfDate || !isSameSenderAsPrevMessage
+      const isFirstPendingOrFailedMessageOfDate =
+        listType !== 'normal' && isFirstMessageOfDate
 
       return (
         <Fragment key={id}>
-          {hasDateDivider && message.createdAt && isFirstMessageOfDate ? (
-            <DateDivider date={new Date(message.createdAt)} />
+          {hasDateDivider && isFirstMessageOfDate ? (
+            <DateDivider
+              date={
+                isFirstPendingOrFailedMessageOfDate || !message.createdAt
+                  ? new Date()
+                  : new Date(message.createdAt)
+              }
+            />
           ) : null}
 
           <BubbleContainer

--- a/packages/chat/src/messages/index.tsx
+++ b/packages/chat/src/messages/index.tsx
@@ -2,7 +2,7 @@ import { ComponentType } from 'react'
 import { CSSProp } from 'styled-components'
 import { isSameDay, isSameMinute } from 'date-fns'
 
-import BubbleContainer from './bubble-container/bubble-container'
+import BubbleContainer from '../bubble-container/bubble-container'
 import BubbleUI, {
   BubbleType,
   BubbleTypeArray,
@@ -11,10 +11,10 @@ import BubbleUI, {
   ProductBubbleUIProp,
   RichBubbleUIProp,
   TextBubbleUIProp,
-} from './bubble/bubble-ui'
-import { UserInterface } from './types'
-import AlteredBubble from './bubble/altered'
-import { ALTERNATIVE_TEXT_MESSAGE } from './bubble/constants'
+} from '../bubble/bubble-ui'
+import { UserInterface } from '../types'
+import AlteredBubble from '../bubble/altered'
+import { ALTERNATIVE_TEXT_MESSAGE } from '../bubble/constants'
 
 interface MessageBase<User extends UserInterface> {
   id: string | number

--- a/packages/chat/src/messages/index.tsx
+++ b/packages/chat/src/messages/index.tsx
@@ -145,11 +145,9 @@ export default function Messages<
         index === 0 ? lastMessageOfPrevList : messages[index - 1]
       const nextMessage = messages[index + 1] || null
 
-      const { isSameSenderAsPrevMessage } = compareSender(
-        prevMessage,
-        message,
-        nextMessage,
-      )
+      const { isSameSenderAsPrevMessage, isSameSenderAsNextMessage } =
+        compareSender(prevMessage, message, nextMessage)
+
       const { isFirstMessageOfDate, isSameMinuteAsNextMessage } = compareDate(
         prevMessage,
         message,
@@ -157,9 +155,9 @@ export default function Messages<
       )
 
       const showTimeInfo =
-        listType === 'normal' &&
-        isSameSenderAsPrevMessage &&
-        (!isSameMinuteAsNextMessage || !nextMessage.createdAt)
+        !isSameSenderAsNextMessage ||
+        !isSameMinuteAsNextMessage ||
+        !nextMessage.createdAt
 
       const showProfile = isFirstMessageOfDate || !isSameSenderAsPrevMessage
       const isFirstPendingOrFailedMessageOfDate =
@@ -193,7 +191,7 @@ export default function Messages<
             showInfo={type !== 'product'}
             showProfile={showProfile}
             showDateInfo={!hasDateDivider}
-            showTimeInfo={showTimeInfo}
+            showTimeInfo={listType === 'normal' && showTimeInfo}
             {...(listType === 'failed' && {
               onRetry: () => {
                 onRetry?.(message)

--- a/packages/chat/src/messages/index.tsx
+++ b/packages/chat/src/messages/index.tsx
@@ -158,7 +158,8 @@ export default function Messages<
       const showTimeInfo =
         !isSameSenderAsNextMessage ||
         !isSameMinuteAsNextMessage ||
-        !nextMessage?.createdAt
+        !nextMessage?.createdAt ||
+        nextMessage?.type === 'product'
 
       const showProfile = isFirstMessageOfDate || !isSameSenderAsPrevMessage
       const isFirstPendingOrFailedMessageOfDate =

--- a/packages/chat/src/messages/index.tsx
+++ b/packages/chat/src/messages/index.tsx
@@ -143,7 +143,8 @@ export default function Messages<
 
       const prevMessage =
         index === 0 ? lastMessageOfPrevList : messages[index - 1]
-      const nextMessage = messages[index + 1] || null
+      const nextMessage =
+        index < messages.length - 1 ? messages[index + 1] : null
 
       const { isSameSenderAsPrevMessage, isSameSenderAsNextMessage } =
         compareSender(prevMessage, message, nextMessage)
@@ -157,7 +158,7 @@ export default function Messages<
       const showTimeInfo =
         !isSameSenderAsNextMessage ||
         !isSameMinuteAsNextMessage ||
-        !nextMessage.createdAt
+        !nextMessage?.createdAt
 
       const showProfile = isFirstMessageOfDate || !isSameSenderAsPrevMessage
       const isFirstPendingOrFailedMessageOfDate =

--- a/packages/chat/src/messages/index.tsx
+++ b/packages/chat/src/messages/index.tsx
@@ -1,42 +1,14 @@
 import { ComponentType } from 'react'
 import { CSSProp } from 'styled-components'
-import { isSameDay, isSameMinute } from 'date-fns'
 
 import BubbleContainer from '../bubble-container/bubble-container'
-import BubbleUI, {
-  BubbleType,
-  BubbleTypeArray,
-  BubbleUIProps,
-  ImageBubbleUIProp,
-  ProductBubbleUIProp,
-  RichBubbleUIProp,
-  TextBubbleUIProp,
-} from '../bubble/bubble-ui'
+import BubbleUI, { BubbleUIProps } from '../bubble/bubble-ui'
 import { UserInterface } from '../types'
 import AlteredBubble from '../bubble/altered'
 import { ALTERNATIVE_TEXT_MESSAGE } from '../bubble/constants'
 
-interface MessageBase<User extends UserInterface> {
-  id: string | number
-  sender: User
-  createdAt?: string
-  blinded?: boolean
-  deleted?: boolean
-  thanks?: { count: number; haveMine: boolean }
-}
-
-type MessageInterface<
-  Message extends MessageBase<User>,
-  User extends UserInterface,
-> = Message &
-  (
-    | TextBubbleUIProp
-    | ImageBubbleUIProp
-    | RichBubbleUIProp
-    | ProductBubbleUIProp
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    | { type: string; value?: any }
-  )
+import { MessageBase, MessageInterface } from './type'
+import { isBubbleType, isSameSender, isSameDate } from './utils'
 
 interface MessagesProp<
   Message extends MessageBase<User>,
@@ -250,69 +222,4 @@ export default function Messages<
       </div>
     </>
   )
-}
-
-function isBubbleType(type: string): type is BubbleType {
-  return BubbleTypeArray.includes(type as BubbleType)
-}
-
-function isSameSender<
-  Message extends MessageBase<User>,
-  User extends UserInterface,
->(
-  prevMessage: Message | null,
-  currentMessage: Message,
-  nextMessage: Message | null,
-) {
-  return {
-    isSameSenderAsPrevMessage:
-      prevMessage?.sender.id === currentMessage.sender.id,
-    isSameSenderAsNextMessage:
-      nextMessage?.sender.id === currentMessage.sender.id,
-  }
-}
-
-function isSameDate<
-  Message extends MessageBase<User>,
-  User extends UserInterface,
->(
-  prevMessage: Message | null,
-  currentMessage: Message,
-  nextMessage: Message | null,
-) {
-  const prevMessageCreatedAt = prevMessage?.createdAt
-    ? new Date(prevMessage?.createdAt)
-    : null
-  const currentMessageCreatedAt = currentMessage.createdAt
-    ? new Date(currentMessage.createdAt)
-    : null
-  const nextMessageCreatedAt = nextMessage?.createdAt
-    ? new Date(nextMessage?.createdAt)
-    : null
-
-  const isSameDateAsPrevMessage = !!(
-    prevMessageCreatedAt &&
-    currentMessageCreatedAt &&
-    isSameDay(prevMessageCreatedAt, currentMessageCreatedAt)
-  )
-  const isSameMinuteAsPrevMessage = !!(
-    prevMessageCreatedAt &&
-    currentMessageCreatedAt &&
-    isSameMinute(prevMessageCreatedAt, currentMessageCreatedAt)
-  )
-
-  const isSameMinuteAsNextMessage = !!(
-    nextMessageCreatedAt &&
-    currentMessageCreatedAt &&
-    isSameMinute(nextMessageCreatedAt, currentMessageCreatedAt)
-  )
-
-  const isFirstMessageOfDate =
-    !!currentMessage.createdAt && (!prevMessage || !isSameDateAsPrevMessage)
-
-  return {
-    isSameMinuteAsPrevMessage,
-    isSameMinuteAsNextMessage,
-    isFirstMessageOfDate,
-  }
 }

--- a/packages/chat/src/messages/messages.stories.tsx
+++ b/packages/chat/src/messages/messages.stories.tsx
@@ -216,3 +216,154 @@ export const Message = {
     hasDateDivider: true,
   },
 }
+
+export const MessageWithTime = {
+  args: {
+    messages: [
+      {
+        type: 'text',
+        value: { message: '안녕하세요.' },
+        id: 'text message 1',
+        sender: {
+          id: 'test user',
+          profile: {
+            name: 'test user',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1, 10, 30).toISOString(),
+        thanks: { count: 1, haveMine: false },
+      },
+      {
+        type: 'text',
+        value: { message: '상단 메세지와 같은 날짜 + 같은 시간' },
+        id: 'text message 2',
+        sender: {
+          id: 'test user',
+          profile: {
+            name: 'test user',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1, 10, 30).toISOString(),
+        thanks: { count: 1, haveMine: false },
+      },
+      {
+        type: 'text',
+        value: { message: '상단 메세지와 같은 날짜 + 다른 시간' },
+        id: 'text message 3',
+        sender: {
+          id: 'test user',
+          profile: {
+            name: 'test user',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1, 10, 31).toISOString(),
+        thanks: { count: 1, haveMine: false },
+      },
+      {
+        type: 'text',
+        value: {
+          message: '상단 메세지와 다른 날짜',
+        },
+        id: 'text message 4',
+        sender: {
+          id: 'test user',
+          profile: {
+            name: 'test user',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 2, 10, 30).toISOString(),
+      },
+      {
+        type: 'text',
+        value: { message: '보낸 첫 메세지' },
+        id: 'my text message 1',
+        sender: {
+          id: 'test',
+          profile: {
+            name: 'test',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 2, 10, 32).toISOString(),
+      },
+      {
+        type: 'text',
+        value: { message: '상단 메세지와 같은 날짜 + 같은 시간' },
+        id: 'my text message 2',
+        sender: {
+          id: 'test',
+          profile: {
+            name: 'test',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 2, 10, 32).toISOString(),
+      },
+      {
+        type: 'text',
+        value: { message: '상단 메세지와 같은 날짜 + 다른 시간' },
+        id: 'my text message 3',
+        sender: {
+          id: 'test',
+          profile: {
+            name: 'test',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 2, 10, 33).toISOString(),
+      },
+      {
+        type: 'text',
+        value: { message: '상단 메세지와 다른 날짜' },
+        id: 'my text message 4',
+        sender: {
+          id: 'test',
+          profile: {
+            name: 'test',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 3, 10, 30).toISOString(),
+      },
+    ],
+    pendingMessages: [],
+    failedMessages: [],
+    me: {
+      id: 'test',
+      profile: {
+        name: '테스트',
+        photo:
+          'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+      },
+    },
+    hasDateDivider: true,
+  },
+}

--- a/packages/chat/src/messages/messages.stories.tsx
+++ b/packages/chat/src/messages/messages.stories.tsx
@@ -1,4 +1,4 @@
-import Messages from './messages'
+import Messages from './'
 
 export default {
   title: 'chat / Messages',

--- a/packages/chat/src/messages/messages.stories.tsx
+++ b/packages/chat/src/messages/messages.stories.tsx
@@ -159,7 +159,7 @@ export const Message = {
           unregistered: false,
           unfriended: false,
         },
-        createdAt: new Date(2022, 10, 1).toISOString(),
+        createdAt: new Date(2022, 10, 2).toISOString(),
       },
     ],
     pendingMessages: [
@@ -213,5 +213,6 @@ export const Message = {
         )
       },
     },
+    hasDateDivider: true,
   },
 }

--- a/packages/chat/src/messages/type.ts
+++ b/packages/chat/src/messages/type.ts
@@ -1,0 +1,29 @@
+import {
+  ImageBubbleUIProp,
+  ProductBubbleUIProp,
+  RichBubbleUIProp,
+  TextBubbleUIProp,
+} from '../bubble/bubble-ui'
+import { UserInterface } from '../types'
+
+export interface MessageBase<User extends UserInterface> {
+  id: string | number
+  sender: User
+  createdAt?: string
+  blinded?: boolean
+  deleted?: boolean
+  thanks?: { count: number; haveMine: boolean }
+}
+
+export type MessageInterface<
+  Message extends MessageBase<User>,
+  User extends UserInterface,
+> = Message &
+  (
+    | TextBubbleUIProp
+    | ImageBubbleUIProp
+    | RichBubbleUIProp
+    | ProductBubbleUIProp
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    | { type: string; value?: any }
+  )

--- a/packages/chat/src/messages/utils.ts
+++ b/packages/chat/src/messages/utils.ts
@@ -1,0 +1,71 @@
+import { isSameDay, isSameMinute } from 'date-fns'
+
+import { BubbleType, BubbleTypeArray } from '../bubble/bubble-ui'
+import { UserInterface } from '../types'
+
+import { MessageBase } from './type'
+
+export function isBubbleType(type: string): type is BubbleType {
+  return BubbleTypeArray.includes(type as BubbleType)
+}
+
+export function isSameSender<
+  Message extends MessageBase<User>,
+  User extends UserInterface,
+>(
+  prevMessage: Message | null,
+  currentMessage: Message,
+  nextMessage: Message | null,
+) {
+  return {
+    isSameSenderAsPrevMessage:
+      prevMessage?.sender.id === currentMessage.sender.id,
+    isSameSenderAsNextMessage:
+      nextMessage?.sender.id === currentMessage.sender.id,
+  }
+}
+
+export function isSameDate<
+  Message extends MessageBase<User>,
+  User extends UserInterface,
+>(
+  prevMessage: Message | null,
+  currentMessage: Message,
+  nextMessage: Message | null,
+) {
+  const prevMessageCreatedAt = prevMessage?.createdAt
+    ? new Date(prevMessage?.createdAt)
+    : null
+  const currentMessageCreatedAt = currentMessage.createdAt
+    ? new Date(currentMessage.createdAt)
+    : null
+  const nextMessageCreatedAt = nextMessage?.createdAt
+    ? new Date(nextMessage?.createdAt)
+    : null
+
+  const isSameDateAsPrevMessage = !!(
+    prevMessageCreatedAt &&
+    currentMessageCreatedAt &&
+    isSameDay(prevMessageCreatedAt, currentMessageCreatedAt)
+  )
+  const isSameMinuteAsPrevMessage = !!(
+    prevMessageCreatedAt &&
+    currentMessageCreatedAt &&
+    isSameMinute(prevMessageCreatedAt, currentMessageCreatedAt)
+  )
+
+  const isSameMinuteAsNextMessage = !!(
+    nextMessageCreatedAt &&
+    currentMessageCreatedAt &&
+    isSameMinute(nextMessageCreatedAt, currentMessageCreatedAt)
+  )
+
+  const isFirstMessageOfDate =
+    !!currentMessage.createdAt && (!prevMessage || !isSameDateAsPrevMessage)
+
+  return {
+    isSameMinuteAsPrevMessage,
+    isSameMinuteAsNextMessage,
+    isFirstMessageOfDate,
+  }
+}

--- a/packages/chat/src/messages/utils.ts
+++ b/packages/chat/src/messages/utils.ts
@@ -67,8 +67,7 @@ export function compareDate<
     isSameMinute(nextMessageCreatedAt, currentMessageCreatedAt)
   )
 
-  const isFirstMessageOfDate =
-    !!currentMessage.createdAt && (!prevMessage || !isSameDateAsPrevMessage)
+  const isFirstMessageOfDate = !prevMessage || !isSameDateAsPrevMessage
 
   return {
     isSameMinuteAsPrevMessage,

--- a/packages/chat/src/messages/utils.ts
+++ b/packages/chat/src/messages/utils.ts
@@ -9,7 +9,7 @@ export function isBubbleType(type: string): type is BubbleType {
   return BubbleTypeArray.includes(type as BubbleType)
 }
 
-export function isSameSender<
+export function compareSender<
   Message extends MessageBase<User>,
   User extends UserInterface,
 >(
@@ -25,7 +25,7 @@ export function isSameSender<
   }
 }
 
-export function isSameDate<
+export function compareDate<
   Message extends MessageBase<User>,
   User extends UserInterface,
 >(
@@ -33,14 +33,21 @@ export function isSameDate<
   currentMessage: Message,
   nextMessage: Message | null,
 ) {
-  const prevMessageCreatedAt = prevMessage?.createdAt
-    ? new Date(prevMessage?.createdAt)
+  /** createdAt이 없는 경우는 pending, failed 메세지임을 가정합니다. */
+  const prevMessageCreatedAt = prevMessage
+    ? prevMessage.createdAt
+      ? new Date(prevMessage?.createdAt)
+      : new Date()
     : null
+
   const currentMessageCreatedAt = currentMessage.createdAt
     ? new Date(currentMessage.createdAt)
-    : null
-  const nextMessageCreatedAt = nextMessage?.createdAt
-    ? new Date(nextMessage?.createdAt)
+    : new Date()
+
+  const nextMessageCreatedAt = nextMessage
+    ? nextMessage.createdAt
+      ? new Date(nextMessage?.createdAt)
+      : new Date()
     : null
 
   const isSameDateAsPrevMessage = !!(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,9 +430,9 @@ importers:
       autolinker:
         specifier: ^4.0.0
         version: 4.0.0
-      moment:
-        specifier: ^2.29.4
-        version: 2.29.4
+      date-fns:
+        specifier: ^3.3.1
+        version: 3.3.1
       use-long-press:
         specifier: ^3.2.0
         version: 3.2.0(react@18.2.0)
@@ -11561,6 +11561,10 @@ packages:
   /dataloader@2.2.2:
     resolution: {integrity: sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==}
     dev: true
+
+  /date-fns@3.3.1:
+    resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
+    dev: false
 
   /dateformat@3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- 버블 스타일을 수정합니다. 디자인을 지오챗과 통일하기 위해 css를 수정했습니다.
- 날짜 및 시간 표기, 프로필 생략 기능을 추가합니다. 동일한 유저가 보낸 메세지일 경우 프로필이 생략되며, 하단 메세지와 날짜와 시간이 같은 경우 시간 표시가 생략됩니다.
- moment를 삭제하고 date-fns를 사용하도록 변경합니다.
- messages.tsx 파일을 messages/index.tsx 경로로 이동하고, messages 관련 유틸 함수, 타입 파일을 분리했습니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

