### PR TITLE
[v14] TripleWeb 사용 편의성 보완

### DIFF
--- a/packages/router/src/links/use-open-inlink.ts
+++ b/packages/router/src/links/use-open-inlink.ts
@@ -3,7 +3,7 @@ import { useMakeInlink, MakeInlinkOptions } from './use-make-inlink'
 export type OpenInlinkOptions = MakeInlinkOptions
 
 export function useOpenInlink() {
-  const makeInlik = useMakeInlink()
+  const makeInlink = useMakeInlink()
 
   const openInlink = (
     /**
@@ -12,7 +12,7 @@ export function useOpenInlink() {
     path: string,
     options?: OpenInlinkOptions,
   ) => {
-    const href = makeInlik(path, options)
+    const href = makeInlink(path, options)
     window.location.href = href
   }
 

--- a/packages/triple-web-nextjs-pages/src/build-triple-web-props.ts
+++ b/packages/triple-web-nextjs-pages/src/build-triple-web-props.ts
@@ -1,11 +1,16 @@
-import type { TripleWebProps } from '@titicaca/triple-web'
 import { NextPageContext } from 'next'
 
+import type { TripleWebProps } from './triple-web'
 import { getClientApp, getSession, getUserAgent } from './providers'
+
+export type BuildTripleWebPropsResult = Omit<
+  TripleWebProps,
+  'children' | 'envProvider' | 'i18nProvider'
+>
 
 export async function buildTripleWebProps(
   ctx: NextPageContext,
-): Promise<Omit<TripleWebProps, 'children' | 'envProvider' | 'i18nProvider'>> {
+): Promise<BuildTripleWebPropsResult> {
   return {
     clientAppProvider: getClientApp(ctx),
     sessionProvider: await getSession(ctx),

--- a/packages/triple-web-nextjs-pages/src/event-metadata-provider.tsx
+++ b/packages/triple-web-nextjs-pages/src/event-metadata-provider.tsx
@@ -1,0 +1,4 @@
+export {
+  EventMetadataProvider,
+  EventMetadataProviderProps,
+} from '@titicaca/triple-web'

--- a/packages/triple-web-nextjs-pages/src/event-tracking-provider.tsx
+++ b/packages/triple-web-nextjs-pages/src/event-tracking-provider.tsx
@@ -1,0 +1,30 @@
+import {
+  EventTrackingProvider as EventTrackingProviderBase,
+  EventTrackingProviderProps as EventTrackingProviderPropsBase,
+} from '@titicaca/triple-web'
+import { useRouter } from 'next/router'
+
+import { getEventTrackingUtm } from './providers'
+
+export type EventTrackingProviderProps = Omit<
+  EventTrackingProviderPropsBase,
+  'utm'
+>
+
+export function EventTrackingProvider({
+  children,
+  page,
+  onError,
+}: EventTrackingProviderProps) {
+  const router = useRouter()
+
+  return (
+    <EventTrackingProviderBase
+      page={page}
+      utm={getEventTrackingUtm(router.query)}
+      onError={onError}
+    >
+      {children}
+    </EventTrackingProviderBase>
+  )
+}

--- a/packages/triple-web-nextjs-pages/src/get-session-availability.ts
+++ b/packages/triple-web-nextjs-pages/src/get-session-availability.ts
@@ -1,7 +1,7 @@
 import { checkClientApp } from '@titicaca/triple-web-utils'
 import { GetServerSidePropsContext } from 'next'
 
-import { checkClientAppSession, checkWebSession } from './helpers'
+import { checkClientAppSession, checkWebSession } from './helpers/session'
 
 export function getSessionAvailability(
   ctx: GetServerSidePropsContext,

--- a/packages/triple-web-nextjs-pages/src/helpers/index.ts
+++ b/packages/triple-web-nextjs-pages/src/helpers/index.ts
@@ -1,1 +1,0 @@
-export * from './session'

--- a/packages/triple-web-nextjs-pages/src/hooks/use-lang.ts
+++ b/packages/triple-web-nextjs-pages/src/hooks/use-lang.ts
@@ -1,0 +1,8 @@
+import { useRouter } from 'next/router'
+
+export function useLang(fallback: string, key = 'lang') {
+  const router = useRouter()
+  const lang = router.query[key] || fallback
+
+  return Array.isArray(lang) ? lang[0] : lang
+}

--- a/packages/triple-web-nextjs-pages/src/index.ts
+++ b/packages/triple-web-nextjs-pages/src/index.ts
@@ -1,4 +1,6 @@
 export * from './auth-guard'
 export * from './build-triple-web-props'
+export * from './event-metadata-provider'
+export * from './event-tracking-provider'
 export * from './put-invalid-session-id-remover'
 export * from './triple-web'

--- a/packages/triple-web-nextjs-pages/src/triple-web.tsx
+++ b/packages/triple-web-nextjs-pages/src/triple-web.tsx
@@ -1,1 +1,35 @@
-export { TripleWeb, type TripleWebProps } from '@titicaca/triple-web'
+import {
+  TripleWeb as TripleWebBase,
+  type TripleWebProps as TripleWebBaseProps,
+  type I18nValue,
+} from '@titicaca/triple-web'
+
+import { useLang } from './hooks/use-lang'
+
+export interface TripleWebProps
+  extends Omit<TripleWebBaseProps, 'i18nProvider'> {
+  i18nProvider: Omit<I18nValue, 'lang'> & { key?: string; fallback: string }
+}
+
+export function TripleWeb({
+  children,
+  clientAppProvider,
+  envProvider,
+  i18nProvider,
+  sessionProvider,
+  userAgentProvider,
+}: TripleWebProps) {
+  const lang = useLang(i18nProvider.fallback, i18nProvider.key)
+
+  return (
+    <TripleWebBase
+      clientAppProvider={clientAppProvider}
+      envProvider={envProvider}
+      i18nProvider={{ i18n: i18nProvider.i18n, lang }}
+      sessionProvider={sessionProvider}
+      userAgentProvider={userAgentProvider}
+    >
+      {children}
+    </TripleWebBase>
+  )
+}

--- a/packages/triple-web-nextjs/src/build-triple-web-props.ts
+++ b/packages/triple-web-nextjs/src/build-triple-web-props.ts
@@ -1,0 +1,16 @@
+import type { TripleWebProps } from './triple-web'
+
+import { getClientApp, getSession, getUserAgent } from '.'
+
+export type BuildTripleWebPropsResult = Omit<
+  TripleWebProps,
+  'children' | 'envProvider' | 'i18nProvider'
+>
+
+export async function buildTripleWebProps(): Promise<BuildTripleWebPropsResult> {
+  return {
+    clientAppProvider: getClientApp(),
+    sessionProvider: await getSession(),
+    userAgentProvider: getUserAgent(),
+  }
+}

--- a/packages/triple-web-nextjs/src/event-metadata-provider.tsx
+++ b/packages/triple-web-nextjs/src/event-metadata-provider.tsx
@@ -1,0 +1,6 @@
+'use client'
+
+export {
+  EventMetadataProvider,
+  EventMetadataProviderProps,
+} from '@titicaca/triple-web'

--- a/packages/triple-web-nextjs/src/event-tracking-provider.tsx
+++ b/packages/triple-web-nextjs/src/event-tracking-provider.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import {
+  EventTrackingProvider as EventTrackingProviderBase,
+  EventTrackingProviderProps as EventTrackingProviderBaseProps,
+} from '@titicaca/triple-web'
+import { useSearchParams } from 'next/navigation'
+
+import { getEventTrackingUtm } from './providers/event-tracking-utm'
+
+export type EventTrackingProviderProps = Omit<
+  EventTrackingProviderBaseProps,
+  'utm'
+>
+
+export function EventTrackingProvider({
+  children,
+  page,
+  onError,
+}: EventTrackingProviderProps) {
+  const searchParams = useSearchParams()
+
+  return (
+    <EventTrackingProviderBase
+      page={page}
+      utm={getEventTrackingUtm(searchParams)}
+      onError={onError}
+    >
+      {children}
+    </EventTrackingProviderBase>
+  )
+}

--- a/packages/triple-web-nextjs/src/hooks/index.ts
+++ b/packages/triple-web-nextjs/src/hooks/index.ts
@@ -1,1 +1,0 @@
-export * from './use-lang'

--- a/packages/triple-web-nextjs/src/index.ts
+++ b/packages/triple-web-nextjs/src/index.ts
@@ -1,2 +1,5 @@
 export * from './providers'
+export * from './build-triple-web-props'
+export * from './event-metadata-provider'
+export * from './event-tracking-provider'
 export * from './triple-web'

--- a/packages/triple-web-nextjs/src/triple-web.tsx
+++ b/packages/triple-web-nextjs/src/triple-web.tsx
@@ -6,7 +6,7 @@ import {
   type I18nValue,
 } from '@titicaca/triple-web'
 
-import { useLang } from './hooks'
+import { useLang } from './hooks/use-lang'
 
 export interface TripleWebProps
   extends Omit<TripleWebBaseProps, 'i18nProvider'> {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

TripleWeb 사용 편의성 보완

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- utm prop을 전달하지 않아도 되는 EventMetadataProvider, EventTrackingProvider를 triple-web-nextjs, triple-web-nextjs-pages에 추가
- BuildTripleWebResult 타입 추가
- 현재 사용자 언어를 가져오는 기능이 내장된 TripleWeb을 triple-web-nextjs, triple-web-nextjs-pages에 추가
- triple-web-nextjs에도 buildTripleWebProps 추가