### PR TITLE
[Review] notifyReviewDeleted 중복 호출 제거 및 리뷰 메뉴 선택 시 앱 설치 유도팝업 노출

### DIFF
--- a/packages/modals/src/transition-modal.tsx
+++ b/packages/modals/src/transition-modal.tsx
@@ -30,6 +30,7 @@ export enum TransitionType {
   ReviewThumbnail = 'reviewThumbnail',
   ReviewSelect = 'reviewSelect',
   ReviewCommentSelect = 'reviewCommentSelect',
+  ReviewMenuSelect = 'reviewMenuSelect',
   OpenReviewList = 'openReviewList',
   Article = 'article',
   Tna = 'tna',
@@ -68,6 +69,9 @@ const MODAL_CONTENT: {
   },
   [TransitionType.ReviewCommentSelect]: {
     eventLabel: '리뷰_댓글_선택',
+  },
+  [TransitionType.ReviewMenuSelect]: {
+    eventLabel: '리뷰_메뉴_선택',
   },
   [TransitionType.OpenReviewList]: {
     eventLabel: '리뷰_리스트더보기_선택',

--- a/packages/review/src/components/my-review-action-sheet.tsx
+++ b/packages/review/src/components/my-review-action-sheet.tsx
@@ -6,7 +6,6 @@ import {
   useUriHash,
   useEnv,
 } from '@titicaca/react-contexts'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 import qs from 'qs'
 
 import { useDeleteReviewMutation } from '../services'
@@ -36,7 +35,6 @@ export function MyReviewActionSheet({
   const { appUrlScheme } = useEnv()
   const uriHash = useUriHash()
   const { replace, back } = useHistoryFunctions()
-  const { notifyReviewDeleted } = useTripleClientActions()
 
   const { mutate } = useDeleteReviewMutation()
 
@@ -47,8 +45,7 @@ export function MyReviewActionSheet({
   }
 
   const handleDeleteReview = () => {
-    mutate({ id: reviewId, resourceId })
-    notifyReviewDeleted?.(resourceId, reviewId, resourceType)
+    mutate({ id: reviewId, resourceId, resourceType })
 
     back()
   }

--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -194,19 +194,18 @@ export function ReviewElement({
     ]),
   )
 
-  const handleMenuClick = useSessionCallback(
-    useCallback(() => {
-      if (!app) {
-        return
-      }
-
-      if (isMyReview) {
-        push(HASH_MY_REVIEW_ACTION_SHEET)
-      } else {
-        onMenuClick?.(review.id)
-        push(HASH_REVIEW_ACTION_SHEET)
-      }
-    }, [app, isMyReview, onMenuClick, push, review.id]),
+  const handleMenuClick = useAppCallback(
+    TransitionType.ReviewMenuSelect,
+    useSessionCallback(
+      useCallback(() => {
+        if (isMyReview) {
+          push(HASH_MY_REVIEW_ACTION_SHEET)
+        } else {
+          onMenuClick?.(review.id)
+          push(HASH_REVIEW_ACTION_SHEET)
+        }
+      }, [app, isMyReview, onMenuClick, push, review.id]),
+    ),
   )
 
   const handleReviewClick = useAppCallback(

--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -204,7 +204,7 @@ export function ReviewElement({
           onMenuClick?.(review.id)
           push(HASH_REVIEW_ACTION_SHEET)
         }
-      }, [app, isMyReview, onMenuClick, push, review.id]),
+      }, [isMyReview, onMenuClick, push, review.id]),
     ),
   )
 

--- a/packages/review/src/services/use-reviews.ts
+++ b/packages/review/src/services/use-reviews.ts
@@ -265,11 +265,19 @@ export function useDeleteReviewMutation() {
   const queryClient = useQueryClient()
 
   return useMutation(
-    (variables: DeleteReviewMutationVariables & { resourceId: string }) =>
-      client.DeleteReview(variables),
+    (
+      variables: DeleteReviewMutationVariables & {
+        resourceId: string
+        resourceType: string
+      },
+    ) => client.DeleteReview(variables),
     {
       onSuccess: (data, variables) => {
-        notifyReviewDeleted?.(variables.resourceId, variables.id)
+        notifyReviewDeleted?.(
+          variables.resourceId,
+          variables.id,
+          variables.resourceType,
+        )
 
         const updater = (review: BaseReviewFragment) =>
           review.id !== variables.id


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

- [제보 스레드](https://interpark.slack.com/archives/C05FBAEJPJM/p1706087418447099)
- 리뷰 삭제 시 호출되는 web to app 이벤트 `notifyReviewDeleted`가 중복 호출되고 `resourceType`이 `null`로 전달되는 이슈를 수정합니다.
- 웹에서 리뷰 메뉴(쓰리닷) 선택 시 앱 설치 유도 팝업이 노출되지 않는 이슈를 수정합니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

- [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요?


## 스크린샷 & URL
https://github.com/titicacadev/triple-frontend/assets/133629020/fe9ba214-c55f-4d39-b685-6c64b6a59958
