### PR TITLE
[poi-detail] 리뷰 영상 관련 툴팁 노출 버그를 수정합니다

### DIFF
--- a/packages/poi-detail/src/actions/actions.stories.tsx
+++ b/packages/poi-detail/src/actions/actions.stories.tsx
@@ -7,7 +7,6 @@ export default {
   component: Actions,
   decorators: [
     (Story) => {
-      localStorage.setItem('REVIEW_TOOLTIP_EXPOSED', 'false')
       return Story()
     },
   ],

--- a/packages/poi-detail/src/actions/actions.stories.tsx
+++ b/packages/poi-detail/src/actions/actions.stories.tsx
@@ -7,6 +7,7 @@ export default {
   component: Actions,
   decorators: [
     (Story) => {
+      localStorage.setItem('REVIEW_TOOLTIP_EXPOSED', 'false')
       return Story()
     },
   ],

--- a/packages/poi-detail/src/actions/actions.tsx
+++ b/packages/poi-detail/src/actions/actions.tsx
@@ -5,31 +5,19 @@ import {
   HR1,
   Button,
   MarginPadding,
-  Tooltip,
   ButtonGroup,
 } from '@titicaca/core-elements'
-import { useEffect, useRef } from 'react'
-import { useLocalStorage } from '@titicaca/react-hooks'
+import dynamic from 'next/dynamic'
+
+const ReviewTooltip = dynamic(() => import('./review-tooltip'), {
+  ssr: false,
+})
 
 const ActionButton = styled(Button)`
   position: relative;
   padding-left: 0;
   padding-right: 0;
 `
-
-const ReviewTooltip = styled(Tooltip)`
-  width: max-content;
-  padding: 9px 15px 8px;
-  transform: translateX(-50%);
-  left: 50%;
-
-  &::after {
-    transform: translateX(-50%);
-    left: 50%;
-  }
-`
-
-const REVIEW_TOOLTIP_EXPOSED = 'REVIEW_TOOLTIP_EXPOSED'
 
 function Actions({
   scraped,
@@ -53,15 +41,6 @@ function Actions({
   noDivider?: boolean
 }) {
   const { t } = useTranslation('common-web')
-
-  const [isReviewTooltipExposed, setIsReviewTooltipExposed] = useLocalStorage(
-    REVIEW_TOOLTIP_EXPOSED,
-  )
-  const isReviewTooltipExposedCopy = useRef(isReviewTooltipExposed)
-
-  useEffect(() => {
-    setIsReviewTooltipExposed('true')
-  }, [setIsReviewTooltipExposed])
 
   return (
     <Section {...props}>
@@ -92,19 +71,7 @@ function Actions({
           icon={reviewed ? 'starFilled' : 'starEmpty'}
           onClick={onReviewEdit}
         >
-          {isReviewTooltipExposedCopy.current !== 'true' ? (
-            <ReviewTooltip
-              label="이제 영상도 올릴 수 있어요!"
-              pointing={{
-                vertical: 'bottom',
-                horizontal: 'right',
-              }}
-              nowrap={false}
-              borderRadius="16.17"
-              backgroundColor="var(--color-blue)"
-              positioning={{ top: -26 }}
-            />
-          ) : null}
+          <ReviewTooltip />
           {reviewed
             ? t(['ribyusujeong', '리뷰수정'])
             : t(['ribyusseugi', '리뷰쓰기'])}

--- a/packages/poi-detail/src/actions/review-tooltip.tsx
+++ b/packages/poi-detail/src/actions/review-tooltip.tsx
@@ -1,0 +1,43 @@
+import { Tooltip as CoreTooltip } from '@titicaca/core-elements'
+import { useLocalStorage } from '@titicaca/react-hooks'
+import { useEffect, useRef } from 'react'
+import styled from 'styled-components'
+
+const Tooltip = styled(CoreTooltip)`
+  width: max-content;
+  padding: 9px 15px 8px;
+  transform: translateX(-50%);
+  left: 50%;
+
+  &::after {
+    transform: translateX(-50%);
+    left: 50%;
+  }
+`
+
+const REVIEW_TOOLTIP_EXPOSED = 'REVIEW_TOOLTIP_EXPOSED'
+
+export default function ReviewTooltip() {
+  const [isReviewTooltipExposed, setIsReviewTooltipExposed] = useLocalStorage(
+    REVIEW_TOOLTIP_EXPOSED,
+  )
+  const isReviewTooltipExposedCopy = useRef(isReviewTooltipExposed)
+
+  useEffect(() => {
+    setIsReviewTooltipExposed('true')
+  }, [setIsReviewTooltipExposed])
+
+  return isReviewTooltipExposedCopy.current !== 'true' ? (
+    <Tooltip
+      label="이제 영상도 올릴 수 있어요!"
+      pointing={{
+        vertical: 'bottom',
+        horizontal: 'right',
+      }}
+      nowrap={false}
+      borderRadius="16.17"
+      backgroundColor="var(--color-blue)"
+      positioning={{ top: -26 }}
+    />
+  ) : null
+}

--- a/packages/poi-detail/src/index.ts
+++ b/packages/poi-detail/src/index.ts
@@ -1,4 +1,4 @@
-export { default as Actions } from './actions'
+export { default as Actions } from './actions/actions'
 export { default as DetailHeader } from './detail-header'
 export { default as ImageCarousel } from './image-carousel'
 export { default as RecommendedArticles } from './recommended-articles'


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

`useLocalStorage` hook을 사용하게 되면서 `REVIEW_TOOLTIP_EXPOSED` 의 초기값이 항상 `null`로 저장되어 리뷰 영상 툴팁이 항상 노출되고 있었습니다. 이를 방지하기 위해 `ReviewTooltip` 컴포넌트를 따로 만들어 해당 컴포넌트를 클라이언트 사이드에서만 렌더링하도록 수정했습니다. 

### 참고
오프라인 패키지에서는 `Actions` 컴포넌트를 렌더링하지 않으므로 영향이 없습니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- `actions` 폴더 생성
- `ReviewTooltip` 컴포넌트 생성
- `ReviewTooltip` 컴포넌트 dynamic import로 수정
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL
<img src="https://github.com/titicacadev/triple-frontend/assets/43779313/8f4bab88-48f3-4df4-a70a-322f98f9d80c" width="300px"/>



<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
