### PR TITLE
[triple-document] tna slot의 타이틀을 두줄 노출하도록 수정

### DIFF
--- a/packages/triple-document/src/elements/tna/price-policy-coupon-info.tsx
+++ b/packages/triple-document/src/elements/tna/price-policy-coupon-info.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { useTranslation } from '@titicaca/next-i18next'
 
 const StyledContainer = styled(Container)`
-  margin-top: 4px;
+  margin-top: 2px;
 `
 
 export function PricePolicyCouponInfo({

--- a/packages/triple-document/src/elements/tna/product.tsx
+++ b/packages/triple-document/src/elements/tna/product.tsx
@@ -177,7 +177,7 @@ export function TnaProductWithPrice({
             margin: '0 0 0 104px',
           }}
         >
-          <Text bold size="large" color="gray" ellipsis>
+          <Text bold size="large" color="gray" ellipsis maxLines={2}>
             {title}
           </Text>
 

--- a/packages/triple-document/src/elements/tna/product.tsx
+++ b/packages/triple-document/src/elements/tna/product.tsx
@@ -32,7 +32,7 @@ function Pricing({
   return (
     <Container
       css={{
-        margin: '8px 0 0',
+        margin: '10px 0 0',
       }}
     >
       {rate ? (

--- a/packages/triple-document/src/elements/tna/product.tsx
+++ b/packages/triple-document/src/elements/tna/product.tsx
@@ -32,16 +32,16 @@ function Pricing({
   return (
     <Container
       css={{
-        margin: '10px 0 0',
+        margin: '8px 0 0',
       }}
     >
       {rate ? (
         <Container
           css={{
-            margin: '0 0 2px',
+            margin: '0 0 1px',
           }}
         >
-          <Text color="red" bold>
+          <Text color="red" bold size={18}>
             {rate}%
           </Text>
         </Container>
@@ -209,7 +209,10 @@ export function TnaProductWithPrice({
           {reviewsCount ? (
             <Container
               css={{
+                display: 'flex',
+                alignItems: 'flex-end',
                 margin: '4px 0 0',
+                height: 16,
               }}
             >
               <Rating size="tiny" score={reviewRating} />
@@ -218,7 +221,7 @@ export function TnaProductWithPrice({
                 size="tiny"
                 color="gray400"
                 lineHeight={1.08}
-                margin={{ left: 6 }}
+                margin={{ left: 3 }}
               >
                 ({reviewsCount})
               </Text>

--- a/packages/triple-document/src/mocks/slots.sample.json
+++ b/packages/triple-document/src/mocks/slots.sample.json
@@ -69,8 +69,8 @@
       "heroImage": "https://media.triple.guide/triple-dev/c_limit,f_auto,h_2048,w_2048/f90fe57e-d2eb-45d2-b204-a652f093e2bf.jpeg",
       "supplierType": "YANOLJA",
       "basePrice": 116000,
-      "reviewRating": 0,
-      "reviewsCount": 0,
+      "reviewRating": 4,
+      "reviewsCount": 3,
       "domesticAreas": [
         {
           "id": "4146100000",


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
tna slot의 타이틀을 두 줄로 노출하도록 수정하고, 간격 조정 등 디자인을 수정합니다. ([관련 스레드](https://interpark.slack.com/archives/C05FBAEJPJM/p1707192636278089))
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
- [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? 

## 스크린샷 & URL
<img width="390" alt="스크린샷 2024-02-13 오후 3 24 58" src="https://github.com/titicacadev/triple-frontend/assets/37494848/212bd8a7-48c8-40d0-a5a3-4c1431709958">

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
