### PR TITLE
[geochat] AlteredBubble에서는 부모 메시지 노출하지 않도록 변경

### DIFF
--- a/packages/chat/src/bubble/altered.tsx
+++ b/packages/chat/src/bubble/altered.tsx
@@ -7,6 +7,7 @@ import { BlindedBubbleProp } from './type'
 
 export default function AlteredBubble({
   my,
+  parentMessage,
   alternativeText,
   textColor,
   ...props


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

삭제되거나 가려지는 등 AlteredBubble이 렌더링되는 경우에는 Parent Message가 노출되지 않도록 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

|AS-IS|TO-BE|
|---|---|
|![스크린샷 2024-02-13 오후 4 58 28](https://github.com/titicacadev/triple-frontend/assets/43779313/c62d49f2-be90-47c7-aa0b-827d3d311359)|![스크린샷 2024-02-13 오후 4 58 14](https://github.com/titicacadev/triple-frontend/assets/43779313/1d62d31b-3dd2-4a10-8021-1ad1e7a5c345)|



<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
