### PR TITLE
[geochat] 리트라이 아이콘을 추가합니다

### DIFF
--- a/packages/chat/src/bubble-container/bubble-container.tsx
+++ b/packages/chat/src/bubble-container/bubble-container.tsx
@@ -13,6 +13,7 @@ import {
   SendingFailureHandlerContainer,
   Thanks,
 } from './elements'
+import { DeleteIcon, RetryIcon } from './icons'
 
 const CHAT_CONTAINER_STYLES = {
   position: 'relative',
@@ -76,8 +77,12 @@ function SentBubbleContainer({
       <div>
         {!createdAt && onRetry && onRetryCancel ? (
           <SendingFailureHandlerContainer>
-            <RetryButton onClick={onRetry} />
-            <DeleteButton onClick={onRetryCancel} />
+            <RetryButton onClick={onRetry}>
+              <RetryIcon />
+            </RetryButton>
+            <DeleteButton onClick={onRetryCancel}>
+              <DeleteIcon />
+            </DeleteButton>
           </SendingFailureHandlerContainer>
         ) : null}
 

--- a/packages/chat/src/bubble-container/elements.tsx
+++ b/packages/chat/src/bubble-container/elements.tsx
@@ -44,7 +44,6 @@ export const RetryButton = styled.button`
   ${sendingFailureHandlerStyle};
 
   width: 23.5px;
-  background-image: url('https://assets.triple.guide/images/btn-message-resend@3x.png');
 `
 
 export const DeleteButton = styled.button`
@@ -52,7 +51,6 @@ export const DeleteButton = styled.button`
 
   width: 24.5px;
   border-left: 1px solid rgba(255, 255, 255, 0.3);
-  background-image: url('https://assets.triple.guide/images/btn-message-delete@3x.png');
 `
 
 const ThanksButton = styled(Button)<{ haveMine: boolean }>`

--- a/packages/chat/src/bubble-container/icons.tsx
+++ b/packages/chat/src/bubble-container/icons.tsx
@@ -1,0 +1,52 @@
+export function RetryIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11.1765 9.09523C10.4332 10.6599 8.83833 11.7417 6.99083 11.7417C4.43302 11.7417 2.3595 9.66818 2.3595 7.11037C2.3595 4.55256 4.43302 2.47905 6.99083 2.47905C8.96589 2.47905 10.6522 3.71537 11.3181 5.45633"
+        stroke="white"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M9.73587 5.33219L11.7016 5.60706L11.9765 3.64133"
+        stroke="white"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+export function DeleteIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 14 14"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3.047 11L7 7.024L3 3"
+        stroke="white"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M10.953 11L7 7.024L11 3"
+        stroke="white"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
리트라이 관련 아이콘을 TF chat 패키지 내부에 저장해 오프라인 상태에서도 아이콘이 보일 수 있도록 합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL


![스크린샷 2024-02-14 오후 4 17 26](https://github.com/titicacadev/triple-frontend/assets/43779313/da65ef19-2aa1-46f4-be10-16c508916157)
