### PR TITLE
[nearby-pois] 더보기 버튼 클릭 시 api 호출이 중복되는 이슈 수정

### DIFF
--- a/packages/nearby-pois/src/nearby-pois.tsx
+++ b/packages/nearby-pois/src/nearby-pois.tsx
@@ -114,6 +114,8 @@ function NearbyPois({
       label: EVENT_LABELS[currentTab],
     })
 
+    setFetchingStatus({ type: currentTab })
+
     const additionalPois = await fetchPois({
       regionId,
       lat,

--- a/packages/nearby-pois/src/nearby-pois.tsx
+++ b/packages/nearby-pois/src/nearby-pois.tsx
@@ -19,6 +19,7 @@ import nearbyPoisReducer, {
   NearbyPoisState,
   setCurrentTab,
   appendPois,
+  setFetchingStatus,
 } from './reducer'
 import { fetchPois } from './service'
 import PoiEntry from './poi-entry'
@@ -73,16 +74,18 @@ function NearbyPois({
   useEffect(() => {
     async function fetchAndSetPois() {
       const [attractions, restaurants] = await Promise.all(
-        (['attraction', 'restaurant'] as NearByPoiType[]).map((type) =>
-          fetchPois({
+        (['attraction', 'restaurant'] as NearByPoiType[]).map((type) => {
+          setFetchingStatus({ type })
+
+          return fetchPois({
             type,
             excludedIds: [poiId],
             regionId,
             lon,
             lat,
             size: DEFAULT_PAGE_SIZE,
-          }),
-        ),
+          })
+        }),
       )
 
       dispatch(

--- a/packages/nearby-pois/src/reducer.ts
+++ b/packages/nearby-pois/src/reducer.ts
@@ -74,7 +74,7 @@ export default function nearbyPoisReducer(
         [action.payload.type]: {
           ...state[action.payload.type],
           fetching: false,
-          pois: deduplicateAndMerge(
+          pois: deduplicateAndMergePoiList(
             state[action.payload.type].pois,
             action.payload.pois,
           ),
@@ -89,6 +89,13 @@ export default function nearbyPoisReducer(
   }
 }
 
-function deduplicateAndMerge<T>(array1: Array<T>, array2: Array<T>) {
-  return [...new Set([...array1, ...array2])]
+function deduplicateAndMergePoiList(
+  prevPoiList: ListingPoi[],
+  nextPoiList: ListingPoi[],
+) {
+  const mergedPoiList = [...prevPoiList, ...nextPoiList]
+  return mergedPoiList.filter(
+    (poiInFilter, index) =>
+      index === mergedPoiList.findIndex((poi) => poi.id === poiInFilter.id),
+  )
 }

--- a/packages/nearby-pois/src/reducer.ts
+++ b/packages/nearby-pois/src/reducer.ts
@@ -74,7 +74,10 @@ export default function nearbyPoisReducer(
         [action.payload.type]: {
           ...state[action.payload.type],
           fetching: false,
-          pois: [...state[action.payload.type].pois, ...action.payload.pois],
+          pois: deduplicateAndMerge(
+            state[action.payload.type].pois,
+            action.payload.pois,
+          ),
           hasMore: action.payload.hasMore,
         },
       }
@@ -84,4 +87,8 @@ export default function nearbyPoisReducer(
         currentTab: action.payload.type,
       }
   }
+}
+
+function deduplicateAndMerge<T>(array1: Array<T>, array2: Array<T>) {
+  return [...new Set([...array1, ...array2])]
 }

--- a/packages/nearby-pois/src/reducer.ts
+++ b/packages/nearby-pois/src/reducer.ts
@@ -5,7 +5,7 @@ const APPEND_POIS = 'nearby-pois/APPEND_POIS'
 const SET_CURRENT_TAB = 'nearby-pois/SET_CURRENT_TAB'
 
 type NearbyPoisAction = ReturnType<
-  typeof fetchPois | typeof appendPois | typeof setCurrentTab
+  typeof setFetchingStatus | typeof appendPois | typeof setCurrentTab
 >
 
 export interface NearbyPoisState {
@@ -22,7 +22,7 @@ export interface NearbyPoisState {
   currentTab: NearByPoiType
 }
 
-export function fetchPois({ type }: { type: NearByPoiType }) {
+export function setFetchingStatus({ type }: { type: NearByPoiType }) {
   return {
     type: FETCH_POIS,
     payload: { type },


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
더보기 버튼을 여러번 클릭할 경우 poi가 중복 노출되는 이슈를 수정합니다. ([관련 스레드](https://interpark.slack.com/archives/C05GCN0AYSZ/p1708294659165219))
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- 기존 fetching status를 수정하는 액션(fetchPois)이 선언만 되어 있고 사용하지 않은 문제를 수정합니다. api 호출과 변수명이 겹쳐 setFetchingStatus로 변경합니다.
- fetching 상태를 변경해 더보기 버튼을 disable 처리해도 느린 네트워크 환경에서는 api의 중복 호출이 가능한 것 같습니다. api의 응답값을 리듀서에서 머지할 때 중복을 제거하도록 수정합니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

