### PR TITLE
[nearby-pois] pois 중복을 제거하는 로직을 수정합니다.

### DIFF
--- a/packages/nearby-pois/src/reducer.ts
+++ b/packages/nearby-pois/src/reducer.ts
@@ -94,8 +94,14 @@ function deduplicateAndMergePoiList(
   nextPoiList: ListingPoi[],
 ) {
   const mergedPoiList = [...prevPoiList, ...nextPoiList]
-  return mergedPoiList.filter(
-    (poiInFilter, index) =>
-      index === mergedPoiList.findIndex((poi) => poi.id === poiInFilter.id),
-  )
+
+  const poiListMap = new Map<string, ListingPoi>()
+
+  for (const poi of mergedPoiList) {
+    if (!poiListMap.has(poi.id)) {
+      poiListMap.set(poi.id, poi)
+    }
+  }
+
+  return poiListMap.values
 }

--- a/packages/nearby-pois/src/reducer.ts
+++ b/packages/nearby-pois/src/reducer.ts
@@ -92,7 +92,7 @@ export default function nearbyPoisReducer(
 function deduplicateAndMergePoiList(
   prevPoiList: ListingPoi[],
   nextPoiList: ListingPoi[],
-) {
+): ListingPoi[] {
   const mergedPoiList = [...prevPoiList, ...nextPoiList]
 
   const poiListMap = new Map<string, ListingPoi>()
@@ -103,5 +103,5 @@ function deduplicateAndMergePoiList(
     }
   }
 
-  return poiListMap.values
+  return Array.from(poiListMap.values())
 }

--- a/packages/nearby-pois/src/reducer.ts
+++ b/packages/nearby-pois/src/reducer.ts
@@ -93,12 +93,10 @@ function deduplicateAndMergePoiList(
   prevPoiList: ListingPoi[],
   nextPoiList: ListingPoi[],
 ): ListingPoi[] {
-  const mergedPoiList = [...prevPoiList, ...nextPoiList]
-
   const poiMap = new Map([
-    ...prevPoiList.map(poi => [poi.id, poi]),
-    ...nextPoiList.map(poi => [poi.id, poi])
-  ]);
- 
+    ...prevPoiList.map<[string, ListingPoi]>((poi) => [poi.id, poi]),
+    ...nextPoiList.map<[string, ListingPoi]>((poi) => [poi.id, poi]),
+  ])
+
   return Array.from(poiMap.values())
 }

--- a/packages/nearby-pois/src/reducer.ts
+++ b/packages/nearby-pois/src/reducer.ts
@@ -95,13 +95,10 @@ function deduplicateAndMergePoiList(
 ): ListingPoi[] {
   const mergedPoiList = [...prevPoiList, ...nextPoiList]
 
-  const poiListMap = new Map<string, ListingPoi>()
-
-  for (const poi of mergedPoiList) {
-    if (!poiListMap.has(poi.id)) {
-      poiListMap.set(poi.id, poi)
-    }
-  }
-
-  return Array.from(poiListMap.values())
+  const poiMap = new Map([
+    ...prevPoiList.map(poi => [poi.id, poi]),
+    ...nextPoiList.map(poi => [poi.id, poi])
+  ]);
+ 
+  return Array.from(poiMap.values())
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
#3140 에서 받은 피드백을 적용합니다([코멘트](https://github.com/titicacadev/triple-frontend/pull/3140#discussion_r1496745679)). deduplicateAndMergePoiList의 중복 제거 로직을 filter에서 Map 객체로 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

