### PR TITLE
[geochat] 대체 말풍선 컬러 버그 수정

### DIFF
--- a/packages/chat/src/bubble/altered.tsx
+++ b/packages/chat/src/bubble/altered.tsx
@@ -12,15 +12,12 @@ export default function AlteredBubble({
   textColor,
   ...props
 }: BlindedBubbleProp) {
+  const alteredCSS = {
+    margin: my ? '0 0 0 8px' : undefined,
+    ...(textColor && { color: textColor }),
+  }
   return (
-    <Bubble
-      my={my}
-      {...props}
-      css={{
-        margin: my ? '0 0 0 8px' : undefined,
-        ...(textColor && { color: textColor }),
-      }}
-    >
+    <Bubble my={my} css={alteredCSS} {...props}>
       <FlexBox flex alignItems="center" gap="4px">
         <ExclamationMarkIcon color={textColor} />
         <span>{alternativeText ?? '관리자에 의해 삭제되었습니다'}</span>

--- a/packages/chat/src/bubble/altered.tsx
+++ b/packages/chat/src/bubble/altered.tsx
@@ -17,7 +17,7 @@ export default function AlteredBubble({
     ...(textColor && { color: textColor }),
   }
   return (
-    <Bubble my={my} css={alteredCSS} {...props}>
+    <Bubble my={my} {...props} css={alteredCSS}>
       <FlexBox flex alignItems="center" gap="4px">
         <ExclamationMarkIcon color={textColor} />
         <span>{alternativeText ?? '관리자에 의해 삭제되었습니다'}</span>

--- a/packages/chat/src/bubble/altered.tsx
+++ b/packages/chat/src/bubble/altered.tsx
@@ -15,11 +15,11 @@ export default function AlteredBubble({
   return (
     <Bubble
       my={my}
+      {...props}
       css={{
         margin: my ? '0 0 0 8px' : undefined,
         ...(textColor && { color: textColor }),
       }}
-      {...props}
     >
       <FlexBox flex alignItems="center" gap="4px">
         <ExclamationMarkIcon color={textColor} />

--- a/packages/chat/src/bubble/altered.tsx
+++ b/packages/chat/src/bubble/altered.tsx
@@ -1,9 +1,18 @@
 import { FlexBox } from '@titicaca/core-elements'
+import styled, { css } from 'styled-components'
 
 import ExclamationMarkIcon from '../icons/ExclamationMarkIcon'
 
 import Bubble from './bubble'
 import { BlindedBubbleProp } from './type'
+
+const AlteredText = styled.span<{ color?: string }>`
+  ${({ color }) =>
+    color &&
+    css`
+      color: ${color};
+    `}
+`
 
 export default function AlteredBubble({
   my,
@@ -14,13 +23,14 @@ export default function AlteredBubble({
 }: BlindedBubbleProp) {
   const alteredCSS = {
     margin: my ? '0 0 0 8px' : undefined,
-    ...(textColor && { color: textColor }),
   }
   return (
     <Bubble my={my} {...props} css={alteredCSS}>
       <FlexBox flex alignItems="center" gap="4px">
         <ExclamationMarkIcon color={textColor} />
-        <span>{alternativeText ?? '관리자에 의해 삭제되었습니다'}</span>
+        <AlteredText color={textColor}>
+          {alternativeText ?? '관리자에 의해 삭제되었습니다'}
+        </AlteredText>
       </FlexBox>
     </Bubble>
   )


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
`bubbleStyle`에 기본 텍스트 컬러를 설정하면 대체 텍스트 컬러에 `alteredTextColor`가 적용되지 않는 버그를 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL
|AS-IS|TO-BE|
|------|-------|
|<img width="260" alt="image" src="https://github.com/titicacadev/triple-frontend/assets/43779313/2bf368d7-da53-47f9-b1e2-effab63be2e8">|<img width="281" alt="스크린샷 2024-03-07 오후 4 24 54" src="https://github.com/titicacadev/triple-frontend/assets/43779313/44e11d60-400d-4efd-b353-1b26c8514348">|



<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
