### PR TITLE
[view-utilities] 말줄임 함수 수정

### DIFF
--- a/packages/view-utilities/src/find-folded-position.ts
+++ b/packages/view-utilities/src/find-folded-position.ts
@@ -10,13 +10,15 @@ export function findFoldedPosition(
   for (const line of lines) {
     const rest = (maxLines - linesCount) * (charactersPerLine || 25)
 
-    if (line.length > rest) {
+    if (line.length > rest || linesCount === maxLines) {
       return foldedIndex + rest
     }
 
     foldedIndex = foldedIndex + line.length
     linesCount =
-      linesCount + 1 + Math.floor(line.length / (charactersPerLine || 25))
+      line.length > 0
+        ? linesCount + 1 + Math.floor(line.length / (charactersPerLine || 25))
+        : linesCount
   }
 
   return null

--- a/packages/view-utilities/src/find-folded-position.ts
+++ b/packages/view-utilities/src/find-folded-position.ts
@@ -1,24 +1,24 @@
 export function findFoldedPosition(
   maxLines: number,
   comment?: string | null,
-  charactersPerLine?: number,
+  charactersPerLine: number = 25,
 ) {
   const lines = (comment || '').split('\n')
 
+  let rest = maxLines * charactersPerLine
   let linesCount = 0
   let foldedIndex = 0
   for (const line of lines) {
-    const rest = (maxLines - linesCount) * (charactersPerLine || 25)
-
-    if (line.length > rest || linesCount === maxLines) {
+    if (linesCount === maxLines) {
+      return foldedIndex
+    }
+    if (line.length > rest) {
       return foldedIndex + rest
     }
 
-    foldedIndex = foldedIndex + line.length
-    linesCount =
-      line.length > 0
-        ? linesCount + 1 + Math.floor(line.length / (charactersPerLine || 25))
-        : linesCount
+    foldedIndex = foldedIndex + line.length + 1
+    linesCount = linesCount + 1 + Math.floor(line.length / charactersPerLine)
+    rest -= line.length
   }
 
   return null


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

엔터가 많이 포함된 댓글에서 말줄임이 제대로 되지 않는 버그를 수정합니다. 

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- 빈 줄이 많이 포함되어 있는 경우 `rest>line.length`에 조건문이 걸리지 않아 말줄임이 제대로 이루어지지 않고 있습니다. 이에 빈줄이 많은 경우도 조건문을 추가합니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

|AS-IS|TO-BE|
|-----|-------|
|![스크린샷 2024-03-11 오후 5 31 08](https://github.com/titicacadev/triple-frontend/assets/43779313/9a9eddbc-8221-428b-84a5-e4f5efdd8b88)|![스크린샷 2024-03-11 오후 5 31 23](https://github.com/titicacadev/triple-frontend/assets/43779313/031c61ec-45e4-400a-b1ba-0781c88610f1)|


|AS-IS|TO-BE|
|-----|-------|
|![스크린샷 2024-03-13 오후 5 26 35](https://github.com/titicacadev/triple-frontend/assets/43779313/2d92a7e3-1bac-4c20-9729-24b4a06b86b2)|![스크린샷 2024-03-13 오후 5 26 55](https://github.com/titicacadev/triple-frontend/assets/43779313/b66b2c29-b21e-4189-a2d5-87f1010000f3)|




<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
