### PR TITLE
[review] 웹에서도 리뷰 더보기 버튼을 통해 리뷰 상세 페이지에 접근할 수 있도록 수정합니다.

### DIFF
--- a/packages/modals/src/transition-modal.tsx
+++ b/packages/modals/src/transition-modal.tsx
@@ -31,6 +31,7 @@ export enum TransitionType {
   ReviewSelect = 'reviewSelect',
   ReviewCommentSelect = 'reviewCommentSelect',
   ReviewMenuSelect = 'reviewMenuSelect',
+  ReviewProfile = 'ReviewProfile',
   OpenReviewList = 'openReviewList',
   Article = 'article',
   Tna = 'tna',
@@ -74,6 +75,9 @@ const MODAL_CONTENT: {
   },
   [TransitionType.ReviewMenuSelect]: {
     eventLabel: '리뷰_메뉴_선택',
+  },
+  [TransitionType.ReviewProfile]: {
+    eventLabel: '리뷰_프로필_선택',
   },
   [TransitionType.OpenReviewList]: {
     eventLabel: '리뷰_리스트더보기_선택',

--- a/packages/review/src/components/full-list-button.tsx
+++ b/packages/review/src/components/full-list-button.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Button } from '@titicaca/core-elements'
 import { useSessionCallback } from '@titicaca/ui-flow'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
+import { generateUrl } from '@titicaca/view-utilities'
 
 import { SHORTENED_REVIEWS_COUNT_PER_PAGE } from '../constants'
 import { useClientActions } from '../services'
@@ -40,6 +41,10 @@ export const FullListButton = ({
   const { t } = useTranslation()
   const { trackEvent } = useEventTrackingContext()
   const { navigateReviewList } = useClientActions()
+  const returnUrlWithReviewAnchor = generateUrl(
+    { hash: 'reviews' },
+    window.location.href,
+  )
 
   const fullListButtonClickCallback = useSessionCallback(
     useCallback(() => {
@@ -62,7 +67,10 @@ export const FullListButton = ({
       sortingType,
       sortingOption,
     ]),
-    { triggeredEventAction: '리뷰_리스트더보기_선택' },
+    {
+      returnUrl: returnUrlWithReviewAnchor,
+      triggeredEventAction: '리뷰_리스트더보기_선택',
+    },
   )
 
   const restReviewsCount = reviewsCount

--- a/packages/review/src/components/full-list-button.tsx
+++ b/packages/review/src/components/full-list-button.tsx
@@ -1,8 +1,7 @@
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@titicaca/core-elements'
-import { useAppCallback, useSessionCallback } from '@titicaca/ui-flow'
-import { TransitionType } from '@titicaca/modals'
+import { useSessionCallback } from '@titicaca/ui-flow'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 
 import { SHORTENED_REVIEWS_COUNT_PER_PAGE } from '../constants'
@@ -42,21 +41,9 @@ export const FullListButton = ({
   const { trackEvent } = useEventTrackingContext()
   const { navigateReviewList } = useClientActions()
 
-  const fullListButtonClickCallback = useAppCallback(
-    TransitionType.OpenReviewList,
-    useSessionCallback(
-      useCallback(() => {
-        navigateReviewList({
-          regionId,
-          resourceId,
-          resourceType,
-          hasMedia,
-          recentTrip,
-          sortingType,
-          sortingOption,
-        })
-      }, [
-        navigateReviewList,
+  const fullListButtonClickCallback = useSessionCallback(
+    useCallback(() => {
+      navigateReviewList({
         regionId,
         resourceId,
         resourceType,
@@ -64,9 +51,18 @@ export const FullListButton = ({
         recentTrip,
         sortingType,
         sortingOption,
-      ]),
-      { triggeredEventAction: '리뷰_리스트더보기_선택' },
-    ),
+      })
+    }, [
+      navigateReviewList,
+      regionId,
+      resourceId,
+      resourceType,
+      hasMedia,
+      recentTrip,
+      sortingType,
+      sortingOption,
+    ]),
+    { triggeredEventAction: '리뷰_리스트더보기_선택' },
   )
 
   const restReviewsCount = reviewsCount

--- a/packages/review/src/components/full-list-button.tsx
+++ b/packages/review/src/components/full-list-button.tsx
@@ -42,7 +42,7 @@ export const FullListButton = ({
   const { trackEvent } = useEventTrackingContext()
   const { navigateReviewList } = useClientActions()
   const returnUrlWithReviewAnchor = generateUrl(
-    { hash: 'reviews' },
+    { query: 'anchor=reviews' },
     window.location.href,
   )
 

--- a/packages/review/src/components/review-element/index.tsx
+++ b/packages/review/src/components/review-element/index.tsx
@@ -6,10 +6,7 @@ import {
   useEventTrackingContext,
   useHistoryFunctions,
 } from '@titicaca/react-contexts'
-import {
-  useTripleClientActions,
-  useTripleClientMetadata,
-} from '@titicaca/react-triple-client-interfaces'
+import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
 import { useAppCallback, useSessionCallback } from '@titicaca/ui-flow'
 import { Timestamp } from '@titicaca/view-utilities'
 import moment from 'moment'
@@ -143,7 +140,6 @@ export function ReviewElement({
   const [unfolded, setUnfolded] = useState(false)
   const { trackEvent } = useEventTrackingContext()
   const { push } = useHistoryFunctions()
-  const app = useTripleClientMetadata()
   const { showToast } = useTripleClientActions()
   const { navigateReviewDetail, navigateUserDetail } = useClientActions()
 
@@ -154,44 +150,43 @@ export function ReviewElement({
 
   const likeButtonAction = `리뷰_땡쓰${liked ? '취소' : ''}_선택`
 
-  const handleUserClick = useSessionCallback(
-    useCallback(() => {
-      if (!app) {
-        return
-      }
+  const handleUserClick = useAppCallback(
+    TransitionType.ReviewProfile,
+    useSessionCallback(
+      useCallback(() => {
+        if (!review.user) {
+          return
+        }
 
-      if (!review.user) {
-        return
-      }
+        const { uid, mileage, unregister } = review.user
 
-      const { uid, mileage, unregister } = review.user
+        trackEvent({
+          ga: ['리뷰 프로필'],
+          fa: {
+            action: '리뷰_프로필',
+            item_id: resourceId,
+            user_id: uid,
+            review_id: review.id,
+            level: mileage?.level ?? 0,
+          },
+        })
 
-      trackEvent({
-        ga: ['리뷰 프로필'],
-        fa: {
-          action: '리뷰_프로필',
-          item_id: resourceId,
-          user_id: uid,
-          review_id: review.id,
-          level: mileage?.level ?? 0,
-        },
-      })
-
-      if (unregister) {
-        showToast?.(t(['taltoehan-sayongjaibnida.', '탈퇴한 사용자입니다.']))
-      } else {
-        navigateUserDetail(uid)
-      }
-    }, [
-      app,
-      review.user,
-      review.id,
-      trackEvent,
-      resourceId,
-      showToast,
-      t,
-      navigateUserDetail,
-    ]),
+        if (unregister) {
+          showToast?.(t(['taltoehan-sayongjaibnida.', '탈퇴한 사용자입니다.']))
+        } else {
+          navigateUserDetail(uid)
+        }
+      }, [
+        review.user,
+        review.id,
+        trackEvent,
+        resourceId,
+        showToast,
+        t,
+        navigateUserDetail,
+      ]),
+      { triggeredEventAction: '리뷰_프로필_선택' },
+    ),
   )
 
   const handleMenuClick = useAppCallback(

--- a/packages/review/src/services/use-client-actions.tsx
+++ b/packages/review/src/services/use-client-actions.tsx
@@ -68,11 +68,7 @@ export function useClientActions() {
           opener_id: getWindowId && getWindowId(),
         })
 
-        navigate(
-          `${appUrlScheme}:///inlink?path=${encodeURIComponent(
-            `/reviews/list?_triple_no_navbar&${params}`,
-          )}`,
-        )
+        navigate(`/reviews/list?_triple_no_navbar&${params}`)
       },
       navigateUserDetail(uid: string) {
         navigate(`${appUrlScheme}:///users/${uid}`)

--- a/packages/view-utilities/src/routelist/routelist.ts
+++ b/packages/view-utilities/src/routelist/routelist.ts
@@ -19,6 +19,7 @@ const PUBLIC_ROUTELIST_REGEXES = [
   /^\/tna\/products\/[^/]+\/display$/,
   /^\/trips\/lounge\/itineraries\/[^/]+$/,
   /^\/trips\/plan(\/.*)?$/,
+  /^\/reviews\/list(\/.*)?$/,
 ]
 
 export function checkIfRoutable({ href }: { href: string }) {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[WATF-42] 웹에서도 리뷰 더보기 버튼을 통해 리뷰 상세 페이지에 접근할 수 있도록 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- 기존 더보기 버튼에 있는 useAppCallback을 제거합니다.
- navigate하는 인링크 주소를 웹 주소로 변경합니다.
- routelist에 리뷰 리스트 페이지를 추가합니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
- [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요?

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->


[WATF-42]: https://inpk.atlassian.net/browse/WATF-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ