### PR TITLE
[modals] loginCtaModal의 로그인 클릭시에도 리퍼럴 이벤트를 기록하도록 수정합니다.

### DIFF
--- a/packages/modals/src/login-cta-modal.tsx
+++ b/packages/modals/src/login-cta-modal.tsx
@@ -37,7 +37,7 @@ export function LoginCtaModalProvider({
   const hasParentModal = useContext(LoginCtaContext)
   const open = uriHash === LOGIN_CTA_MODAL_HASH
   const [returnUrl, setReturnUrl] = useState<string | undefined>()
-  const [referrerEvent, setReferrerEvent] = useState<string | undefined>()
+  const [referrerEvent, setReferrerEvent] = useState<string | null>(null)
 
   if (hasParentModal) {
     return <>{children}</>
@@ -51,7 +51,7 @@ export function LoginCtaModalProvider({
         open={open}
         title={t(['rogeuini-pilyohabnida.', '로그인이 필요합니다.'])}
         onClose={() => {
-          setReferrerEvent(undefined)
+          referrerEvent && setReferrerEvent(null)
           back()
         }}
         onCancel={back}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
loginCtaModal에서 노출 이벤트 뿐 아니라 로그인 클릭 이벤트에도 리퍼럴 이벤트를 기록하도록 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

