### PR TITLE
[review] 맞춤 일정 배너를 노출합니다

### DIFF
--- a/packages/review/src/components/reviews-shorten.tsx
+++ b/packages/review/src/components/reviews-shorten.tsx
@@ -22,9 +22,10 @@ import type { ShortenReviewValue } from './shorten-list'
 
 const REVIEWS_SECTION_ID = 'reviews'
 
+type ResourceType = 'article' | 'attraction' | 'restaurant' | 'hotel'
 interface ReviewsShortenProps {
   resourceId: string
-  resourceType: string
+  resourceType: ResourceType
   regionId?: string
   initialReviewsCount: number
   initialMediaFilter?: boolean

--- a/packages/review/src/components/reviews-shorten.tsx
+++ b/packages/review/src/components/reviews-shorten.tsx
@@ -26,7 +26,7 @@ import type { ShortenReviewValue } from './shorten-list'
 
 const REVIEWS_SECTION_ID = 'reviews'
 
-type ResourceType = 'article' | 'attraction' | 'restaurant' | 'hotel'
+type ResourceType = 'article' | 'attraction' | 'restaurant' | 'hotel' | 'tna'
 interface ReviewsShortenProps {
   resourceId: string
   resourceType: ResourceType
@@ -153,6 +153,12 @@ function ReviewsShortenComponent({
     ...(isRatingOption && { sortingLabel: selectedOption }),
   }
 
+  const showCustomizedScheduleBanner = [
+    'article',
+    'attraction',
+    'restaurant',
+  ].includes(resourceType)
+
   return (
     <Section anchor={REVIEWS_SECTION_ID}>
       <FlexBox flex alignItems="center">
@@ -172,7 +178,9 @@ function ReviewsShortenComponent({
           regionId={regionId}
         />
       </FlexBox>
-      {!app && resourceType !== 'hotel' ? <CustomizedScheduleBanner /> : null}
+      {!app && showCustomizedScheduleBanner ? (
+        <CustomizedScheduleBanner />
+      ) : null}
       <OptionContainer>
         <SortingOptions />
 

--- a/packages/review/src/components/reviews-shorten.tsx
+++ b/packages/review/src/components/reviews-shorten.tsx
@@ -3,10 +3,14 @@ import styled from 'styled-components'
 import { FlexBox, Section, Text } from '@titicaca/core-elements'
 import { LoginCtaModalProvider } from '@titicaca/modals'
 import { useTranslation } from '@titicaca/next-i18next'
-import { useTripleClientActions } from '@titicaca/react-triple-client-interfaces'
+import {
+  useTripleClientActions,
+  useTripleClientMetadata,
+} from '@titicaca/react-triple-client-interfaces'
 import { formatNumber } from '@titicaca/view-utilities'
 
 import { useReviewCount } from '../services'
+import CustomizedScheduleBanner from '../customized-schedule-banner'
 
 import { PopularReviews, LatestReviews, RatingReviews } from './shorten-list'
 import { WriteButton } from './write-button'
@@ -106,6 +110,8 @@ function ReviewsShortenComponent({
   const { selectedOption } = useReviewSortingOptions()
   const { t } = useTranslation('common-web')
 
+  const app = useTripleClientMetadata()
+
   const { subscribeReviewUpdateEvent, unsubscribeReviewUpdateEvent } =
     useTripleClientActions()
 
@@ -166,7 +172,7 @@ function ReviewsShortenComponent({
           regionId={regionId}
         />
       </FlexBox>
-
+      {!app && resourceType !== 'hotel' ? <CustomizedScheduleBanner /> : null}
       <OptionContainer>
         <SortingOptions />
 

--- a/packages/review/src/customized-schedule-banner.tsx
+++ b/packages/review/src/customized-schedule-banner.tsx
@@ -1,20 +1,11 @@
 import { Container, FlexBox, Text } from '@titicaca/core-elements'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { useExternalRouter } from '@titicaca/router'
-import { useEffect } from 'react'
+import { StaticIntersectionObserver as IntersectionObserver } from '@titicaca/intersection-observer'
 
 export default function CustomizedScheduleBanner() {
   const routeExternally = useExternalRouter()
   const { trackEvent } = useEventTrackingContext()
-
-  useEffect(() => {
-    trackEvent({
-      ga: ['맞춤일정배너_노출'],
-      fa: {
-        action: '맞춤일정배너_노출',
-      },
-    })
-  }, [])
 
   function handleClick() {
     trackEvent({
@@ -33,30 +24,48 @@ export default function CustomizedScheduleBanner() {
   }
 
   return (
-    <Container
-      css={{
-        padding: '12.5px 16px 12.5px 20px',
-        backgroundColor: '#DBE9FF',
-        borderRadius: 6,
-        marginTop: 20,
-        marginBottom: 28,
-        cursor: 'pointer',
+    <IntersectionObserver
+      onChange={({ isIntersecting }) => {
+        if (isIntersecting) {
+          trackEvent({
+            ga: ['맞춤일정배너_노출'],
+            fa: {
+              action: '맞춤일정배너_노출',
+            },
+          })
+        }
       }}
-      onClick={() => handleClick()}
     >
-      <FlexBox flex justifyContent="space-between">
-        <FlexBox flex flexDirection="column" justifyContent="center" gap="2px">
-          <Text size={16} css={{ fontWeight: 700 }}>
-            일정 알아서 다 짜드려요
-          </Text>
-          <Text size={12}>트리플 맞춤 일정 추천 받으러 가기</Text>
+      <Container
+        css={{
+          padding: '12.5px 16px 12.5px 20px',
+          backgroundColor: '#DBE9FF',
+          borderRadius: 6,
+          marginTop: 20,
+          marginBottom: 28,
+          cursor: 'pointer',
+        }}
+        onClick={() => handleClick()}
+      >
+        <FlexBox flex justifyContent="space-between">
+          <FlexBox
+            flex
+            flexDirection="column"
+            justifyContent="center"
+            gap="2px"
+          >
+            <Text size={16} css={{ fontWeight: 700 }}>
+              일정 알아서 다 짜드려요
+            </Text>
+            <Text size={12}>트리플 맞춤 일정 추천 받으러 가기</Text>
+          </FlexBox>
+          <img
+            src="http://assets.triple-dev.titicaca-corp.com/images/img-map-with-pin.svg"
+            alt=""
+            width={52}
+          />
         </FlexBox>
-        <img
-          src="http://assets.triple-dev.titicaca-corp.com/images/img-map-with-pin.svg"
-          alt=""
-          width={52}
-        />
-      </FlexBox>
-    </Container>
+      </Container>
+    </IntersectionObserver>
   )
 }

--- a/packages/review/src/customized-schedule-banner.tsx
+++ b/packages/review/src/customized-schedule-banner.tsx
@@ -1,0 +1,41 @@
+import { Container, FlexBox, Text } from '@titicaca/core-elements'
+import { useExternalRouter } from '@titicaca/router'
+
+export default function CustomizedScheduleBanner() {
+  const routeExternally = useExternalRouter()
+
+  return (
+    <Container
+      css={{
+        padding: '12.5px 16px 12.5px 20px',
+        backgroundColor: '#DBE9FF',
+        borderRadius: 6,
+        marginTop: 20,
+        marginBottom: 28,
+        cursor: 'pointer',
+      }}
+      onClick={() => {
+        routeExternally({
+          href: `${
+            process.env.NEXT_PUBLIC_WEB_URL_BASE || 'https://triple.guide'
+          }/trips/promotion/customized-schedule`,
+          target: 'new',
+        })
+      }}
+    >
+      <FlexBox flex justifyContent="space-between">
+        <FlexBox flex flexDirection="column" justifyContent="center" gap="2px">
+          <Text size={16} css={{ fontWeight: 700 }}>
+            여행일정 알아서 다 짜드려요
+          </Text>
+          <Text size={12}>트리플 맞춤 일정 추천 받으러 가기</Text>
+        </FlexBox>
+        <img
+          src="http://assets.triple-dev.titicaca-corp.com/images/img-map-with-pin.svg"
+          alt=""
+          width={52}
+        />
+      </FlexBox>
+    </Container>
+  )
+}

--- a/packages/review/src/customized-schedule-banner.tsx
+++ b/packages/review/src/customized-schedule-banner.tsx
@@ -1,8 +1,36 @@
 import { Container, FlexBox, Text } from '@titicaca/core-elements'
+import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { useExternalRouter } from '@titicaca/router'
+import { useEffect } from 'react'
 
 export default function CustomizedScheduleBanner() {
   const routeExternally = useExternalRouter()
+  const { trackEvent } = useEventTrackingContext()
+
+  useEffect(() => {
+    trackEvent({
+      ga: ['맞춤일정배너_노출'],
+      fa: {
+        action: '맞춤일정배너_노출',
+      },
+    })
+  }, [])
+
+  function handleClick() {
+    trackEvent({
+      ga: ['맞춤일정배너_선택'],
+      fa: {
+        action: '맞춤일정배너_선택',
+      },
+    })
+
+    routeExternally({
+      href: `${
+        process.env.NEXT_PUBLIC_WEB_URL_BASE || 'https://triple.guide'
+      }/trips/promotion/customized-schedule`,
+      target: 'new',
+    })
+  }
 
   return (
     <Container
@@ -14,14 +42,7 @@ export default function CustomizedScheduleBanner() {
         marginBottom: 28,
         cursor: 'pointer',
       }}
-      onClick={() => {
-        routeExternally({
-          href: `${
-            process.env.NEXT_PUBLIC_WEB_URL_BASE || 'https://triple.guide'
-          }/trips/promotion/customized-schedule`,
-          target: 'new',
-        })
-      }}
+      onClick={() => handleClick()}
     >
       <FlexBox flex justifyContent="space-between">
         <FlexBox flex flexDirection="column" justifyContent="center" gap="2px">

--- a/packages/review/src/customized-schedule-banner.tsx
+++ b/packages/review/src/customized-schedule-banner.tsx
@@ -47,7 +47,7 @@ export default function CustomizedScheduleBanner() {
       <FlexBox flex justifyContent="space-between">
         <FlexBox flex flexDirection="column" justifyContent="center" gap="2px">
           <Text size={16} css={{ fontWeight: 700 }}>
-            여행일정 알아서 다 짜드려요
+            일정 알아서 다 짜드려요
           </Text>
           <Text size={12}>트리플 맞춤 일정 추천 받으러 가기</Text>
         </FlexBox>

--- a/packages/review/src/customized-schedule-banner.tsx
+++ b/packages/review/src/customized-schedule-banner.tsx
@@ -60,7 +60,7 @@ export default function CustomizedScheduleBanner() {
             <Text size={12}>트리플 맞춤 일정 추천 받으러 가기</Text>
           </FlexBox>
           <img
-            src="http://assets.triple-dev.titicaca-corp.com/images/img-map-with-pin.svg"
+            src="http://assets.triple.guide/images/img-map-with-pin.svg"
             alt=""
             width={52}
           />


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
가이드/관광지/맛집 페이지에서 맞춤 일정 추천 페이지로 랜딩하는 맞춤일정 배너를 리뷰 타이틀 아래에 노출합니다. 
https://inpk.atlassian.net/browse/WATF-48

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- `Review` 컴포넌트를 렌더링하는 페이지를 구분하기 위해 `resourceType`에 타입을 설정했습니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
- [x] 기획자/디자이너에게 확인을 받았나요?

## 스크린샷 & URL
![스크린샷 2024-03-18 오전 9 57 15](https://github.com/titicacadev/triple-frontend/assets/43779313/112e9e03-d837-449e-9b8c-66c9ffb1fd95)
https://triple-staging.titicaca-corp.com/attractions/d2d8ca79-1a9a-4c4b-9bff-7495e5d28046
<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
