### PR TITLE
[view-utilities] 항공 시세 페이지를 routelist에 추가합니다.

### DIFF
--- a/packages/view-utilities/src/routelist/routelist.ts
+++ b/packages/view-utilities/src/routelist/routelist.ts
@@ -13,6 +13,7 @@ const PUBLIC_ROUTELIST_REGEXES = [
   /^\/hotels\/[^/]+\/breakdown(\/.+?)?$/,
   /^(\/hotels)?\/regions\/[^/]+\/hotel-areas$/,
   /^\/air\/curation(\/.+)?$/,
+  /^\/air\/price-board(\/.+)?$/,
   /^\/tna\/curation(\/.+)?$/,
   /^\/tna\/regions\/[^/]+\/products\/[^/]+$/,
   /^\/tna\/products\/[^/]+$/,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- 항공 시세 페이지를 routelist에 추가합니다. (인링크와 web_expand 옵션을 통해 앱이 아닌 웹으로 이동할 수 있습니다.) 
  - [관련 스레드](https://interpark.slack.com/archives/C05GCN0AYSZ/p1710467691146349)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
