### PR TITLE
[image-viewer] 이미지 확대뷰 팝업을 생성합니다

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@storybook/addon-links": "^7.5.3",
     "@storybook/addon-onboarding": "^1.0.8",
     "@storybook/blocks": "^7.5.3",
+    "@storybook/client-api": "^7.6.17",
     "@storybook/nextjs": "^7.5.3",
     "@storybook/react": "^7.5.3",
     "@swc/cli": "0.1.63",

--- a/packages/image-viewer/package.json
+++ b/packages/image-viewer/package.json
@@ -42,7 +42,9 @@
   "dependencies": {
     "@titicaca/core-elements": "workspace:*",
     "@titicaca/react-contexts": "workspace:*",
-    "@titicaca/popup": "workspace:*"
+    "@titicaca/popup": "workspace:*",
+    "@egjs/flicking": "^3.9.3",
+    "@egjs/react-flicking": "^3.8.3"
   },
   "devDependencies": {
     "@titicaca/i18n": "workspace:*",

--- a/packages/image-viewer/package.json
+++ b/packages/image-viewer/package.json
@@ -39,6 +39,11 @@
       "eslint"
     ]
   },
+  "dependencies": {
+    "@titicaca/core-elements": "workspace:*",
+    "@titicaca/react-contexts": "workspace:*",
+    "@titicaca/popup": "workspace:*"
+  },
   "devDependencies": {
     "@titicaca/i18n": "workspace:*",
     "@titicaca/next-i18next": "13.8.5",

--- a/packages/image-viewer/src/detail-viewer/detail-viewer.stories.tsx
+++ b/packages/image-viewer/src/detail-viewer/detail-viewer.stories.tsx
@@ -42,12 +42,32 @@ export default {
               },
             },
           },
+          {
+            id: 'image3',
+            sizes: {
+              large: {
+                url: 'https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/7095aed4-65f7-4157-9b11-55bc871aac6d.jpeg',
+              },
+              full: {
+                url: 'https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/7095aed4-65f7-4157-9b11-55bc871aac6d.jpeg',
+              },
+              small_square: {
+                url: 'https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/7095aed4-65f7-4157-9b11-55bc871aac6d.jpeg',
+              },
+            },
+          },
         ]}
       >
         <Story />
       </ImagesProvider>
     ),
   ],
+  parameters: {
+    viewport: {
+      viewports: 'mobile',
+      defaultViewport: 'mobile',
+    },
+  },
   args: {
     open: true,
     imageIndex: 0,

--- a/packages/image-viewer/src/detail-viewer/detail-viewer.stories.tsx
+++ b/packages/image-viewer/src/detail-viewer/detail-viewer.stories.tsx
@@ -16,6 +16,8 @@ export default {
         images={[
           {
             id: 'test image',
+            sourceUrl:
+              '출처가 있는 이미지입니다. 아주 긴 출처를 가지고 있습니다.',
             sizes: {
               large: {
                 url: 'https://res.cloudinary.com/triple-entry/image/upload/w_1024,h_1024,c_limit,f_auto/07f5ed9c-1102-4ec0-b07c-7b1b098311b2.jpg',

--- a/packages/image-viewer/src/detail-viewer/detail-viewer.stories.tsx
+++ b/packages/image-viewer/src/detail-viewer/detail-viewer.stories.tsx
@@ -59,6 +59,7 @@ export default {
             },
           },
         ]}
+        total={3}
       >
         <Story />
       </ImagesProvider>

--- a/packages/image-viewer/src/detail-viewer/detail-viewer.stories.tsx
+++ b/packages/image-viewer/src/detail-viewer/detail-viewer.stories.tsx
@@ -1,0 +1,69 @@
+import { useArgs } from '@storybook/client-api'
+
+import { DetailViewerPopup, DetailViewerPopupProp } from '../image-viewer'
+import { ImagesProvider } from '../../../react-contexts/src'
+
+export default {
+  title: 'Image Viewer / Detail Viewer',
+  component: DetailViewerPopup,
+  decorators: [
+    (Story) => (
+      <ImagesProvider
+        source={{
+          id: 'e889ae22-0336-4cf9-8fbb-742b95fd09d0',
+          type: 'attraction',
+        }}
+        images={[
+          {
+            id: 'test image',
+            sizes: {
+              large: {
+                url: 'https://res.cloudinary.com/triple-entry/image/upload/w_1024,h_1024,c_limit,f_auto/07f5ed9c-1102-4ec0-b07c-7b1b098311b2.jpg',
+              },
+              full: {
+                url: 'https://res.cloudinary.com/triple-entry/image/upload/w_1024,h_1024,c_limit,f_auto/07f5ed9c-1102-4ec0-b07c-7b1b098311b2.jpg',
+              },
+              small_square: {
+                url: 'https://res.cloudinary.com/triple-entry/image/upload/w_1024,h_1024,c_limit,f_auto/07f5ed9c-1102-4ec0-b07c-7b1b098311b2.jpg',
+              },
+            },
+          },
+          {
+            id: 'test image2',
+            sizes: {
+              full: {
+                url: 'https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/be33afd8-c14b-4508-b1f9-8b36bfb29f64.jpeg',
+              },
+              large: {
+                url: 'https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/be33afd8-c14b-4508-b1f9-8b36bfb29f64.jpeg',
+              },
+              smallSquare: {
+                url: 'https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/be33afd8-c14b-4508-b1f9-8b36bfb29f64.jpeg',
+              },
+            },
+          },
+        ]}
+      >
+        <Story />
+      </ImagesProvider>
+    ),
+  ],
+  args: {
+    open: true,
+    imageIndex: 0,
+  },
+}
+
+export const DetailViewer = ({
+  open: argsOpen,
+  onClose: argsOnClose,
+  ...args
+}: DetailViewerPopupProp) => {
+  const [{ open }, updateArgs] = useArgs()
+
+  function onClose() {
+    updateArgs({ open: false })
+  }
+
+  return <DetailViewerPopup open={open} onClose={onClose} {...args} />
+}

--- a/packages/image-viewer/src/detail-viewer/index.tsx
+++ b/packages/image-viewer/src/detail-viewer/index.tsx
@@ -1,8 +1,7 @@
 import styled from 'styled-components'
 import { useState } from 'react'
-
-import { Container } from '../../../core-elements/src'
-import { useImagesContext } from '../../../react-contexts/src'
+import { Container } from '@titicaca/core-elements'
+import { useImagesContext } from '@titicaca/react-contexts'
 
 const Image = styled.img`
   max-width: 100%;

--- a/packages/image-viewer/src/detail-viewer/index.tsx
+++ b/packages/image-viewer/src/detail-viewer/index.tsx
@@ -94,6 +94,7 @@ export default function DetailViewer({
           changeImageIndex(index)
           fetchNewImages(index)
         }}
+        autoResize
       >
         {images.map((image) => (
           <Container key={image.id} css={{ width: '100%', height: '100%' }}>

--- a/packages/image-viewer/src/detail-viewer/index.tsx
+++ b/packages/image-viewer/src/detail-viewer/index.tsx
@@ -1,3 +1,26 @@
-export default function DetailViewer() {
-  return <div>확대뷰</div>
+import styled from 'styled-components'
+import { useState } from 'react'
+
+import { Container } from '../../../core-elements/src'
+import { useImagesContext } from '../../../react-contexts/src'
+
+const Image = styled.img``
+
+export interface DetailViewerProp {
+  imageIndex: number
+}
+
+export default function DetailViewer({
+  imageIndex: initialImageIndex,
+}: DetailViewerProp) {
+  const [imageIndex] = useState(initialImageIndex)
+  const { images } = useImagesContext()
+
+  const image = images[imageIndex]
+
+  return (
+    <Container css={{ width: '100%', height: '100%' }}>
+      <Image src={image.sizes.large.url} alt={image.id} />
+    </Container>
+  )
 }

--- a/packages/image-viewer/src/detail-viewer/index.tsx
+++ b/packages/image-viewer/src/detail-viewer/index.tsx
@@ -46,7 +46,6 @@ const Button = styled.button<{ direction: 'next' | 'prev' }>`
   background-color: white;
   border-radius: 50%;
 `
-
 const SOURCE_HEIGHT = 54
 
 export interface DetailViewerProp {
@@ -85,10 +84,22 @@ export default function DetailViewer({
   }
 
   return (
-    <Container css={{ position: 'relative', width: '100%', height: '100%' }}>
+    <Container
+      css={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        maxWidth: 768,
+        margin: 'auto',
+      }}
+    >
       <Flicking
         ref={flickingRef}
-        css={{ position: 'relative', width: '100%', height: '100%' }}
+        css={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+        }}
         defaultIndex={imageIndex}
         onMoveEnd={({ index }) => {
           changeImageIndex(index)

--- a/packages/image-viewer/src/detail-viewer/index.tsx
+++ b/packages/image-viewer/src/detail-viewer/index.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { useState } from 'react'
 import { Container } from '@titicaca/core-elements'
 import { useImagesContext } from '@titicaca/react-contexts'
 
@@ -27,16 +26,13 @@ export interface DetailViewerProp {
   imageIndex: number
 }
 
-export default function DetailViewer({
-  imageIndex: initialImageIndex,
-}: DetailViewerProp) {
-  const [imageIndex] = useState(initialImageIndex)
+export default function DetailViewer({ imageIndex }: DetailViewerProp) {
   const { images } = useImagesContext()
 
   const image = images[imageIndex]
 
   return (
-    <Container css={{ width: '100%', height: '100%' }}>
+    <Container css={{ position: 'relative', width: '100%', height: '100%' }}>
       <Container
         css={{
           width: '100%',

--- a/packages/image-viewer/src/detail-viewer/index.tsx
+++ b/packages/image-viewer/src/detail-viewer/index.tsx
@@ -58,7 +58,11 @@ export default function DetailViewer({
   imageIndex,
   changeImageIndex,
 }: DetailViewerProp) {
-  const { images, total } = useImagesContext()
+  const {
+    images,
+    total,
+    actions: { fetch },
+  } = useImagesContext()
   const { isMobile } = useUserAgentContext()
   const flickingRef = useRef<Flicking>(null)
 
@@ -74,14 +78,21 @@ export default function DetailViewer({
     }
   }
 
+  async function fetchNewImages(index: number) {
+    if (index > images.length - 5) {
+      await fetch()
+    }
+  }
+
   return (
     <Container css={{ position: 'relative', width: '100%', height: '100%' }}>
       <Flicking
         ref={flickingRef}
         css={{ position: 'relative', width: '100%', height: '100%' }}
         defaultIndex={imageIndex}
-        onChange={(e) => {
-          changeImageIndex(e.index)
+        onMoveEnd={({ index }) => {
+          changeImageIndex(index)
+          fetchNewImages(index)
         }}
       >
         {images.map((image) => (

--- a/packages/image-viewer/src/detail-viewer/index.tsx
+++ b/packages/image-viewer/src/detail-viewer/index.tsx
@@ -66,14 +66,12 @@ export default function DetailViewer({
     if (flickingRef.current) {
       flickingRef.current.next()
     }
-    changeImageIndex((imageIndex + 1) % total)
   }
 
   function onPrevImageShow() {
     if (flickingRef.current) {
       flickingRef.current.prev()
     }
-    changeImageIndex(imageIndex === 0 ? total - 1 : imageIndex - 1)
   }
 
   return (

--- a/packages/image-viewer/src/detail-viewer/index.tsx
+++ b/packages/image-viewer/src/detail-viewer/index.tsx
@@ -9,6 +9,20 @@ const Image = styled.img`
   margin: auto;
 `
 
+const SourceUrl = styled.p`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background-color: var(--color-white900);
+  padding: 20px;
+  font-size: 12px;
+  line-height: 12px;
+  height: 54px;
+  color: var(--color-gray700);
+`
+
+const SOURCE_HEIGHT = 54
+
 export interface DetailViewerProp {
   imageIndex: number
 }
@@ -22,8 +36,17 @@ export default function DetailViewer({
   const image = images[imageIndex]
 
   return (
-    <Container css={{ width: '100%', height: '100%', display: 'flex' }}>
-      <Image src={image.sizes.large.url} alt={image.id} />
+    <Container css={{ width: '100%', height: '100%' }}>
+      <Container
+        css={{
+          width: '100%',
+          height: `calc(100% - ${image.sourceUrl ? SOURCE_HEIGHT : 0}px)`,
+          display: 'flex',
+        }}
+      >
+        <Image src={image.sizes.large.url} alt={image.id} />
+      </Container>
+      {image.sourceUrl ? <SourceUrl>{image.sourceUrl}</SourceUrl> : null}
     </Container>
   )
 }

--- a/packages/image-viewer/src/detail-viewer/index.tsx
+++ b/packages/image-viewer/src/detail-viewer/index.tsx
@@ -4,7 +4,11 @@ import { useState } from 'react'
 import { Container } from '../../../core-elements/src'
 import { useImagesContext } from '../../../react-contexts/src'
 
-const Image = styled.img``
+const Image = styled.img`
+  max-width: 100%;
+  max-height: 100%;
+  margin: auto;
+`
 
 export interface DetailViewerProp {
   imageIndex: number
@@ -19,7 +23,7 @@ export default function DetailViewer({
   const image = images[imageIndex]
 
   return (
-    <Container css={{ width: '100%', height: '100%' }}>
+    <Container css={{ width: '100%', height: '100%', display: 'flex' }}>
       <Image src={image.sizes.large.url} alt={image.id} />
     </Container>
   )

--- a/packages/image-viewer/src/image-viewer.stories.tsx
+++ b/packages/image-viewer/src/image-viewer.stories.tsx
@@ -1,11 +1,11 @@
+import { Meta } from '@storybook/react'
+import { ImagesProvider } from '@titicaca/react-contexts'
 import { useArgs } from '@storybook/client-api'
 
-import { DetailViewerPopup, DetailViewerPopupProp } from '../image-viewer'
-import { ImagesProvider } from '../../../react-contexts/src'
+import { ImageViewerPopup, ImageViewerPopupProps } from './image-viewer'
 
 export default {
-  title: 'Image Viewer / Detail Viewer',
-  component: DetailViewerPopup,
+  title: 'Image Viewer',
   decorators: [
     (Story) => (
       <ImagesProvider
@@ -65,28 +65,22 @@ export default {
       </ImagesProvider>
     ),
   ],
-  parameters: {
-    viewport: {
-      viewports: 'mobile',
-      defaultViewport: 'mobile',
-    },
-  },
   args: {
     open: true,
-    imageIndex: 0,
+    defaultImageIndex: 0,
   },
-}
+} as Meta
 
-export const DetailViewer = ({
+export const ImageViewer = ({
   open: argsOpen,
   onClose: argsOnClose,
   ...args
-}: DetailViewerPopupProp) => {
+}: ImageViewerPopupProps) => {
   const [{ open }, updateArgs] = useArgs()
 
   function onClose() {
     updateArgs({ open: false })
   }
 
-  return <DetailViewerPopup open={open} onClose={onClose} {...args} />
+  return <ImageViewerPopup open={open} onClose={onClose} {...args} />
 }

--- a/packages/image-viewer/src/image-viewer.tsx
+++ b/packages/image-viewer/src/image-viewer.tsx
@@ -1,0 +1,35 @@
+import { PropsWithChildren } from 'react'
+
+import Popup from '../../popup/src/popup'
+
+import DetailViewer from './detail-viewer'
+
+function ImageViewerPopup({
+  open,
+  onClose,
+  children,
+}: PropsWithChildren<{ open: boolean; onClose: () => void }>) {
+  return (
+    <Popup open={open} onClose={onClose}>
+      {children}
+    </Popup>
+  )
+}
+
+export interface DetailViewerPopupProp {
+  open: boolean
+  onClose: () => void
+  imageIndex: number
+}
+
+export function DetailViewerPopup({
+  open,
+  onClose,
+  imageIndex,
+}: DetailViewerPopupProp) {
+  return (
+    <ImageViewerPopup open={open} onClose={onClose}>
+      <DetailViewer imageIndex={imageIndex} />
+    </ImageViewerPopup>
+  )
+}

--- a/packages/image-viewer/src/image-viewer.tsx
+++ b/packages/image-viewer/src/image-viewer.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from 'react'
 
 import Popup from '../../popup/src/popup'
+import { Container, Navbar } from '../../core-elements/src'
 
 import DetailViewer from './detail-viewer'
 
@@ -10,7 +11,7 @@ function ImageViewerPopup({
   children,
 }: PropsWithChildren<{ open: boolean; onClose: () => void }>) {
   return (
-    <Popup open={open} onClose={onClose}>
+    <Popup open={open} onClose={onClose} noNavbar>
       {children}
     </Popup>
   )
@@ -22,6 +23,8 @@ export interface DetailViewerPopupProp {
   imageIndex: number
 }
 
+const NAVBAR_HEIGHT = 52
+
 export function DetailViewerPopup({
   open,
   onClose,
@@ -29,7 +32,14 @@ export function DetailViewerPopup({
 }: DetailViewerPopupProp) {
   return (
     <ImageViewerPopup open={open} onClose={onClose}>
-      <DetailViewer imageIndex={imageIndex} />
+      <Navbar css={{ height: NAVBAR_HEIGHT }}>
+        <Navbar.Item icon="close" onClick={onClose} />
+      </Navbar>
+      <Container
+        css={{ height: `calc(100vh - ${NAVBAR_HEIGHT}px)`, width: '100vw' }}
+      >
+        <DetailViewer imageIndex={imageIndex} />
+      </Container>
     </ImageViewerPopup>
   )
 }

--- a/packages/image-viewer/src/image-viewer.tsx
+++ b/packages/image-viewer/src/image-viewer.tsx
@@ -34,6 +34,10 @@ export function ImageViewerPopup({
     setImageIndex(defaultImageIndex)
   }, [defaultImageIndex])
 
+  function changeImageIndex(idx: number) {
+    setImageIndex(idx)
+  }
+
   function handleClose() {
     setImageIndex(null)
     onClose?.()
@@ -41,7 +45,11 @@ export function ImageViewerPopup({
   return (
     <Popup open={open} onClose={handleClose} noNavbar>
       {imageIndex != null ? (
-        <DetailViewerContainer onClose={handleClose} imageIndex={imageIndex} />
+        <DetailViewerContainer
+          onClose={handleClose}
+          imageIndex={imageIndex}
+          changeImageIndex={changeImageIndex}
+        />
       ) : null}
     </Popup>
   )
@@ -50,22 +58,15 @@ export function ImageViewerPopup({
 export interface DetailViewerContainerProp {
   onClose?: () => void
   imageIndex: number
+  changeImageIndex: (index: number) => void
 }
 
 export function DetailViewerContainer({
   onClose,
-  imageIndex: initialImageIndex,
+  imageIndex,
+  changeImageIndex,
 }: DetailViewerContainerProp) {
   const { total } = useImagesContext()
-  const [imageIndex, setImageIndex] = useState(initialImageIndex)
-
-  function changeImageIndex(idx: number) {
-    setImageIndex(idx)
-  }
-
-  useEffect(() => {
-    setImageIndex(initialImageIndex)
-  }, [initialImageIndex])
 
   return (
     <>

--- a/packages/image-viewer/src/image-viewer.tsx
+++ b/packages/image-viewer/src/image-viewer.tsx
@@ -1,7 +1,6 @@
 import { PropsWithChildren } from 'react'
-
-import Popup from '../../popup/src/popup'
-import { Container, Navbar } from '../../core-elements/src'
+import Popup from '@titicaca/popup'
+import { Container, Navbar } from '@titicaca/core-elements'
 
 import DetailViewer from './detail-viewer'
 

--- a/packages/image-viewer/src/image-viewer.tsx
+++ b/packages/image-viewer/src/image-viewer.tsx
@@ -1,6 +1,8 @@
-import { PropsWithChildren } from 'react'
+import { PropsWithChildren, useState } from 'react'
 import Popup from '@titicaca/popup'
 import { Container, Navbar } from '@titicaca/core-elements'
+import styled, { css } from 'styled-components'
+import { useImagesContext, useUserAgentContext } from '@titicaca/react-contexts'
 
 import DetailViewer from './detail-viewer'
 
@@ -24,11 +26,48 @@ export interface DetailViewerPopupProp {
 
 const NAVBAR_HEIGHT = 52
 
+const Button = styled.button<{ direction: 'next' | 'prev' }>`
+  position: absolute;
+  background-image: url('https://assets.triple.guide/images/ico-arrow-right-black@3x.png');
+  background-size: 30px;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 44px;
+  height: 44px;
+  top: 50%;
+  border: 1px solid var(--color-gray100);
+  ${({ direction }) =>
+    direction === 'next'
+      ? css`
+          transform: translateY(-50%);
+          right: 20px;
+        `
+      : css`
+          transform: rotate(180deg) translateY(50%);
+          left: 20px;
+        `}
+  background-color: white;
+  border-radius: 50%;
+`
+
 export function DetailViewerPopup({
   open,
   onClose,
-  imageIndex,
+  imageIndex: initialImageIndex,
 }: DetailViewerPopupProp) {
+  const { isMobile } = useUserAgentContext()
+
+  const { total } = useImagesContext()
+  const [imageIndex, setImageIndex] = useState(initialImageIndex)
+
+  function showNextImage() {
+    setImageIndex((imageIndex + 1) % total)
+  }
+
+  function showPrevImage() {
+    setImageIndex(imageIndex === 0 ? total - 1 : imageIndex - 1)
+  }
+
   return (
     <ImageViewerPopup open={open} onClose={onClose}>
       <Navbar css={{ height: NAVBAR_HEIGHT }}>
@@ -38,6 +77,12 @@ export function DetailViewerPopup({
         css={{ height: `calc(100vh - ${NAVBAR_HEIGHT}px)`, width: '100vw' }}
       >
         <DetailViewer imageIndex={imageIndex} />
+        {!isMobile ? (
+          <>
+            <Button direction="prev" onClick={showPrevImage} />
+            <Button direction="next" onClick={showNextImage} />
+          </>
+        ) : null}
       </Container>
     </ImageViewerPopup>
   )

--- a/packages/image-viewer/src/image-viewer.tsx
+++ b/packages/image-viewer/src/image-viewer.tsx
@@ -1,28 +1,10 @@
-import { PropsWithChildren, useState } from 'react'
+import { useEffect, useState } from 'react'
 import Popup from '@titicaca/popup'
 import { Container, Navbar } from '@titicaca/core-elements'
 import { useImagesContext } from '@titicaca/react-contexts'
 import styled from 'styled-components'
 
 import DetailViewer from './detail-viewer'
-
-function ImageViewerPopup({
-  open,
-  onClose,
-  children,
-}: PropsWithChildren<{ open: boolean; onClose: () => void }>) {
-  return (
-    <Popup open={open} onClose={onClose} noNavbar>
-      {children}
-    </Popup>
-  )
-}
-
-export interface DetailViewerPopupProp {
-  open: boolean
-  onClose: () => void
-  imageIndex: number
-}
 
 const NAVBAR_HEIGHT = 52
 
@@ -32,11 +14,54 @@ const Text = styled.span`
   line-height: 34px;
 `
 
-export function DetailViewerPopup({
+export interface ImageViewerPopupProps {
+  open: boolean
+  onClose?: () => void
+  defaultImageIndex: number | null
+}
+/**
+ *
+ * @param defaultImageIndex: 이미지 확대뷰로 띄울 이미지의 index. TODD: null인 경우에는 격자뷰가 뜨게 됩니다.
+ */
+export function ImageViewerPopup({
   open,
   onClose,
+  defaultImageIndex,
+}: ImageViewerPopupProps) {
+  const [imageIndex, setImageIndex] = useState<null | number>(defaultImageIndex)
+
+  useEffect(() => {
+    setImageIndex(defaultImageIndex)
+  }, [defaultImageIndex])
+
+  return (
+    <Popup
+      open={open}
+      onClose={() => {
+        setImageIndex(null)
+        onClose?.()
+      }}
+      noNavbar
+    >
+      {imageIndex != null ? (
+        <DetailViewerContainer
+          onClose={() => setImageIndex(null)}
+          imageIndex={imageIndex}
+        />
+      ) : null}
+    </Popup>
+  )
+}
+
+export interface DetailViewerContainerProp {
+  onClose?: () => void
+  imageIndex: number
+}
+
+export function DetailViewerContainer({
+  onClose,
   imageIndex: initialImageIndex,
-}: DetailViewerPopupProp) {
+}: DetailViewerContainerProp) {
   const { total } = useImagesContext()
   const [imageIndex, setImageIndex] = useState(initialImageIndex)
 
@@ -44,8 +69,12 @@ export function DetailViewerPopup({
     setImageIndex(idx)
   }
 
+  useEffect(() => {
+    setImageIndex(initialImageIndex)
+  }, [initialImageIndex])
+
   return (
-    <ImageViewerPopup open={open} onClose={onClose}>
+    <>
       <Navbar
         css={{
           height: NAVBAR_HEIGHT,
@@ -77,6 +106,6 @@ export function DetailViewerPopup({
           changeImageIndex={changeImageIndex}
         />
       </Container>
-    </ImageViewerPopup>
+    </>
   )
 }

--- a/packages/image-viewer/src/image-viewer.tsx
+++ b/packages/image-viewer/src/image-viewer.tsx
@@ -34,20 +34,14 @@ export function ImageViewerPopup({
     setImageIndex(defaultImageIndex)
   }, [defaultImageIndex])
 
+  function handleClose() {
+    setImageIndex(null)
+    onClose?.()
+  }
   return (
-    <Popup
-      open={open}
-      onClose={() => {
-        setImageIndex(null)
-        onClose?.()
-      }}
-      noNavbar
-    >
+    <Popup open={open} onClose={handleClose} noNavbar>
       {imageIndex != null ? (
-        <DetailViewerContainer
-          onClose={() => setImageIndex(null)}
-          imageIndex={imageIndex}
-        />
+        <DetailViewerContainer onClose={handleClose} imageIndex={imageIndex} />
       ) : null}
     </Popup>
   )

--- a/packages/image-viewer/src/image-viewer.tsx
+++ b/packages/image-viewer/src/image-viewer.tsx
@@ -1,6 +1,8 @@
 import { PropsWithChildren, useState } from 'react'
 import Popup from '@titicaca/popup'
 import { Container, Navbar } from '@titicaca/core-elements'
+import { useImagesContext } from '@titicaca/react-contexts'
+import styled from 'styled-components'
 
 import DetailViewer from './detail-viewer'
 
@@ -24,11 +26,18 @@ export interface DetailViewerPopupProp {
 
 const NAVBAR_HEIGHT = 52
 
+const Text = styled.span`
+  font-size: 16px;
+  height: 34px;
+  line-height: 34px;
+`
+
 export function DetailViewerPopup({
   open,
   onClose,
   imageIndex: initialImageIndex,
 }: DetailViewerPopupProp) {
+  const { total } = useImagesContext()
   const [imageIndex, setImageIndex] = useState(initialImageIndex)
 
   function changeImageIndex(idx: number) {
@@ -37,8 +46,28 @@ export function DetailViewerPopup({
 
   return (
     <ImageViewerPopup open={open} onClose={onClose}>
-      <Navbar css={{ height: NAVBAR_HEIGHT }}>
-        <Navbar.Item icon="close" onClick={onClose} />
+      <Navbar
+        css={{
+          height: NAVBAR_HEIGHT,
+          display: 'flex',
+        }}
+      >
+        <Navbar.Item
+          icon="close"
+          onClick={onClose}
+          css={{ position: 'absolute' }}
+        />
+        <Navbar.Item
+          css={{
+            float: 'none',
+            margin: 0,
+            flexGrow: 1,
+            textAlign: 'center',
+          }}
+        >
+          <Text>{imageIndex + 1}</Text>
+          <Text css={{ color: 'var(--color-gray300)' }}>&nbsp;/ {total}</Text>
+        </Navbar.Item>
       </Navbar>
       <Container
         css={{ height: `calc(100vh - ${NAVBAR_HEIGHT}px)`, width: '100vw' }}

--- a/packages/image-viewer/src/image-viewer.tsx
+++ b/packages/image-viewer/src/image-viewer.tsx
@@ -1,8 +1,6 @@
 import { PropsWithChildren, useState } from 'react'
 import Popup from '@titicaca/popup'
 import { Container, Navbar } from '@titicaca/core-elements'
-import styled, { css } from 'styled-components'
-import { useImagesContext, useUserAgentContext } from '@titicaca/react-contexts'
 
 import DetailViewer from './detail-viewer'
 
@@ -26,46 +24,15 @@ export interface DetailViewerPopupProp {
 
 const NAVBAR_HEIGHT = 52
 
-const Button = styled.button<{ direction: 'next' | 'prev' }>`
-  position: absolute;
-  background-image: url('https://assets.triple.guide/images/ico-arrow-right-black@3x.png');
-  background-size: 30px;
-  background-repeat: no-repeat;
-  background-position: center;
-  width: 44px;
-  height: 44px;
-  top: 50%;
-  border: 1px solid var(--color-gray100);
-  ${({ direction }) =>
-    direction === 'next'
-      ? css`
-          transform: translateY(-50%);
-          right: 20px;
-        `
-      : css`
-          transform: rotate(180deg) translateY(50%);
-          left: 20px;
-        `}
-  background-color: white;
-  border-radius: 50%;
-`
-
 export function DetailViewerPopup({
   open,
   onClose,
   imageIndex: initialImageIndex,
 }: DetailViewerPopupProp) {
-  const { isMobile } = useUserAgentContext()
-
-  const { total } = useImagesContext()
   const [imageIndex, setImageIndex] = useState(initialImageIndex)
 
-  function showNextImage() {
-    setImageIndex((imageIndex + 1) % total)
-  }
-
-  function showPrevImage() {
-    setImageIndex(imageIndex === 0 ? total - 1 : imageIndex - 1)
+  function changeImageIndex(idx: number) {
+    setImageIndex(idx)
   }
 
   return (
@@ -76,13 +43,10 @@ export function DetailViewerPopup({
       <Container
         css={{ height: `calc(100vh - ${NAVBAR_HEIGHT}px)`, width: '100vw' }}
       >
-        <DetailViewer imageIndex={imageIndex} />
-        {!isMobile ? (
-          <>
-            <Button direction="prev" onClick={showPrevImage} />
-            <Button direction="next" onClick={showNextImage} />
-          </>
-        ) : null}
+        <DetailViewer
+          imageIndex={imageIndex}
+          changeImageIndex={changeImageIndex}
+        />
       </Container>
     </ImageViewerPopup>
   )

--- a/packages/image-viewer/src/index.ts
+++ b/packages/image-viewer/src/index.ts
@@ -1,1 +1,1 @@
-export { default } from './detail-viewer'
+export * from './image-viewer'

--- a/packages/image-viewer/src/styled.d.ts
+++ b/packages/image-viewer/src/styled.d.ts
@@ -1,0 +1,1 @@
+import {} from 'styled-components/cssprop'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@storybook/blocks':
         specifier: ^7.5.3
         version: 7.5.3(@types/react-dom@18.2.20)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/client-api':
+        specifier: ^7.6.17
+        version: 7.6.17
       '@storybook/nextjs':
         specifier: ^7.5.3
         version: 7.5.3(@swc/core@1.3.102)(@types/react-dom@18.2.20)(@types/react@18.2.63)(esbuild@0.18.20)(next@13.4.13)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.88.1)
@@ -1994,7 +1997,7 @@ packages:
       '@babel/generator': 7.22.10
       '@babel/parser': 7.22.13
       '@babel/runtime': 7.22.6
-      '@babel/traverse': 7.22.11(supports-color@5.5.0)
+      '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
       babel-preset-fbjs: 3.4.0(@babel/core@7.22.11)
       chalk: 4.1.2
@@ -2058,7 +2061,7 @@ packages:
       '@babel/helpers': 7.22.11
       '@babel/parser': 7.22.13
       '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.11(supports-color@5.5.0)
+      '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
       convert-source-map: 1.9.0
       debug: 4.3.4(supports-color@5.5.0)
@@ -2230,7 +2233,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
       '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.11(supports-color@5.5.0)
+      '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
     transitivePeerDependencies:
       - supports-color
@@ -2281,7 +2284,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.11(supports-color@5.5.0)
+      '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
     transitivePeerDependencies:
       - supports-color
@@ -3409,7 +3412,7 @@ packages:
       '@babel/parser': 7.22.13
       '@babel/types': 7.22.11
 
-  /@babel/traverse@7.22.11(supports-color@5.5.0):
+  /@babel/traverse@7.22.11:
     resolution: {integrity: sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
@@ -4776,7 +4779,7 @@ packages:
     dependencies:
       '@babel/parser': 7.22.13
       '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.22.11)
-      '@babel/traverse': 7.22.11(supports-color@5.5.0)
+      '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
       '@graphql-tools/utils': 10.0.3(graphql@16.8.0)
       graphql: 16.8.0
@@ -7538,6 +7541,17 @@ packages:
       tiny-invariant: 1.3.1
     dev: true
 
+  /@storybook/channels@7.6.17:
+    resolution: {integrity: sha512-GFG40pzaSxk1hUr/J/TMqW5AFDDPUSu+HkeE/oqSWJbOodBOLJzHN6CReJS6y1DjYSZLNFt1jftPWZZInG/XUA==}
+    dependencies:
+      '@storybook/client-logger': 7.6.17
+      '@storybook/core-events': 7.6.17
+      '@storybook/global': 5.0.0
+      qs: 6.11.2
+      telejson: 7.2.0
+      tiny-invariant: 1.3.1
+    dev: true
+
   /@storybook/cli@7.5.3:
     resolution: {integrity: sha512-XysHSnknZTAcTbQ0bQsbfv5J8ifHpOBsmXjk1HCA05E9WGGrn9JrQRCfpDUQJ6O6UWq0bpMqzP8gFLWXFE7hug==}
     hasBin: true
@@ -7590,6 +7604,13 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@storybook/client-api@7.6.17:
+    resolution: {integrity: sha512-rsxKBRLtUmBXbxG79Pf1GzUuMDMsFdhNR/a5k7kIA/mlEsvWD8are/aH/zk1oLr7+5QOqEkiXLL6+Erry7dzXA==}
+    dependencies:
+      '@storybook/client-logger': 7.6.17
+      '@storybook/preview-api': 7.6.17
+    dev: true
+
   /@storybook/client-logger@6.5.16:
     resolution: {integrity: sha512-pxcNaCj3ItDdicPTXTtmYJE3YC1SjxFrBmHcyrN+nffeNyiMuViJdOOZzzzucTUG0wcOOX8jaSyak+nnHg5H1Q==}
     dependencies:
@@ -7605,6 +7626,12 @@ packages:
 
   /@storybook/client-logger@7.5.3:
     resolution: {integrity: sha512-vUFYALypjix5FoJ5M/XUP6KmyTnQJNW1poHdW7WXUVSg+lBM6E5eAtjTm0hdxNNDH8KSrdy24nCLra5h0X0BWg==}
+    dependencies:
+      '@storybook/global': 5.0.0
+    dev: true
+
+  /@storybook/client-logger@7.6.17:
+    resolution: {integrity: sha512-6WBYqixAXNAXlSaBWwgljWpAu10tPRBJrcFvx2gPUne58EeMM20Gi/iHYBz2kMCY+JLAgeIH7ZxInqwO8vDwiQ==}
     dependencies:
       '@storybook/global': 5.0.0
     dev: true
@@ -7739,6 +7766,12 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
+  /@storybook/core-events@7.6.17:
+    resolution: {integrity: sha512-AriWMCm/k1cxlv10f+jZ1wavThTRpLaN3kY019kHWbYT9XgaSuLU67G7GPr3cGnJ6HuA6uhbzu8qtqVCd6OfXA==}
+    dependencies:
+      ts-dedent: 2.2.0
+    dev: true
+
   /@storybook/core-server@7.5.3:
     resolution: {integrity: sha512-Gmq1w7ulN/VIeTDboNcb6GNM+S8T0SqhJUqeoHzn0vLGnzxeuYRJ0V3ZJhGZiJfSmCNqYAjC8QUBf6uU1gLipw==}
     dependencies:
@@ -7817,7 +7850,7 @@ packages:
     dependencies:
       '@babel/generator': 7.22.10
       '@babel/parser': 7.22.13
-      '@babel/traverse': 7.22.11(supports-color@5.5.0)
+      '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
       '@storybook/csf': 0.1.1
       '@storybook/types': 7.4.0
@@ -7833,7 +7866,7 @@ packages:
     dependencies:
       '@babel/generator': 7.22.10
       '@babel/parser': 7.22.13
-      '@babel/traverse': 7.22.11(supports-color@5.5.0)
+      '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
       '@storybook/csf': 0.1.1
       '@storybook/types': 7.5.3
@@ -7858,6 +7891,12 @@ packages:
 
   /@storybook/csf@0.1.1:
     resolution: {integrity: sha512-4hE3AlNVxR60Wc5KSC68ASYzUobjPqtSKyhV6G+ge0FIXU55N5nTY7dXGRZHQGDBPq+XqchMkIdlkHPRs8nTHg==}
+    dependencies:
+      type-fest: 2.19.0
+    dev: true
+
+  /@storybook/csf@0.1.3:
+    resolution: {integrity: sha512-IPZvXXo4b3G+gpmgBSBqVM81jbp2ePOKsvhgJdhyZJtkYQCII7rg9KKLQhvBQM5sLaF1eU6r0iuwmyynC9d9SA==}
     dependencies:
       type-fest: 2.19.0
     dev: true
@@ -8084,6 +8123,25 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
+  /@storybook/preview-api@7.6.17:
+    resolution: {integrity: sha512-wLfDdI9RWo1f2zzFe54yRhg+2YWyxLZvqdZnSQ45mTs4/7xXV5Wfbv3QNTtcdw8tT3U5KRTrN1mTfTCiRJc0Kw==}
+    dependencies:
+      '@storybook/channels': 7.6.17
+      '@storybook/client-logger': 7.6.17
+      '@storybook/core-events': 7.6.17
+      '@storybook/csf': 0.1.3
+      '@storybook/global': 5.0.0
+      '@storybook/types': 7.6.17
+      '@types/qs': 6.9.9
+      dequal: 2.0.3
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      qs: 6.11.2
+      synchronous-promise: 2.0.17
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: true
+
   /@storybook/preview@7.5.3:
     resolution: {integrity: sha512-Hf90NlLaSrdMZXPOHDCMPjTywVrQKK0e5CtzqWx/ZQz91JDINxJD+sGj2wZU+wuBtQcTtlsXc9OewlJ+9ETwIw==}
     dev: true
@@ -8268,6 +8326,15 @@ packages:
     resolution: {integrity: sha512-iu5W0Kdd6nysN5CPkY4GRl+0BpxRTdSfBIJak7mb6xCIHSB5t1tw4BOuqMQ5EgpikRY3MWJ4gY647QkWBX3MNQ==}
     dependencies:
       '@storybook/channels': 7.5.3
+      '@types/babel__core': 7.20.1
+      '@types/express': 4.17.17
+      file-system-cache: 2.3.0
+    dev: true
+
+  /@storybook/types@7.6.17:
+    resolution: {integrity: sha512-GRY0xEJQ0PrL7DY2qCNUdIfUOE0Gsue6N+GBJw9ku1IUDFLJRDOF+4Dx2BvYcVCPI5XPqdWKlEyZdMdKjiQN7Q==}
+    dependencies:
+      '@storybook/channels': 7.6.17
       '@types/babel__core': 7.20.1
       '@types/express': 4.17.17
       file-system-cache: 2.3.0
@@ -12892,7 +12959,7 @@ packages:
     resolution: {integrity: sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==}
     engines: {node: '>=8.3.0'}
     dependencies:
-      '@babel/traverse': 7.22.11(supports-color@5.5.0)
+      '@babel/traverse': 7.22.11
       '@babel/types': 7.22.11
       c8: 7.14.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,6 +764,16 @@ importers:
         version: 5.3.11(@babel/core@7.22.11)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
 
   packages/image-viewer:
+    dependencies:
+      '@titicaca/core-elements':
+        specifier: workspace:*
+        version: link:../core-elements
+      '@titicaca/popup':
+        specifier: workspace:*
+        version: link:../popup
+      '@titicaca/react-contexts':
+        specifier: workspace:*
+        version: link:../react-contexts
     devDependencies:
       '@titicaca/i18n':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,6 +765,12 @@ importers:
 
   packages/image-viewer:
     dependencies:
+      '@egjs/flicking':
+        specifier: ^3.9.3
+        version: 3.9.3
+      '@egjs/react-flicking':
+        specifier: ^3.8.3
+        version: 3.8.3
       '@titicaca/core-elements':
         specifier: workspace:*
         version: link:../core-elements


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
웹에서도 이미지를 확대해서 볼 수 있도록 이미지 뷰어 패키지를 생성합니다.
https://inpk.atlassian.net/browse/WATF-67
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- `ImageViewerPopup` 생성
  -  `imageIndex`가 있을 경우 확대뷰를 노출합니다.
   - PC에서는 좌우 버튼으로, 모든 환경에서 슬라이드로 이전/다음 사진으로 이동할 수 있습니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->


## 스크린샷 & URL
![스크린샷 2024-03-27 오전 10 36 13](https://github.com/titicacadev/triple-frontend/assets/43779313/6fc3cebb-353f-404f-9e31-70cbafc51917)

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
