### PR TITLE
[image-viewer] 이미지 확대뷰에서 핀치 줌 기능을 적용합니다

### DIFF
--- a/packages/image-viewer/package.json
+++ b/packages/image-viewer/package.json
@@ -40,12 +40,13 @@
     ]
   },
   "dependencies": {
-    "@titicaca/core-elements": "workspace:*",
-    "@titicaca/intersection-observer": "workspace:*",
-    "@titicaca/react-contexts": "workspace:*",
-    "@titicaca/popup": "workspace:*",
     "@egjs/flicking": "^3.9.3",
-    "@egjs/react-flicking": "^3.8.3"
+    "@egjs/react-flicking": "^3.8.3",
+    "@titicaca/core-elements": "workspace:*",    
+    "@titicaca/intersection-observer": "workspace:*",
+    "@titicaca/popup": "workspace:*",
+    "@titicaca/react-contexts": "workspace:*",
+    "react-zoom-pan-pinch": "^3.4.3"
   },
   "devDependencies": {
     "@titicaca/i18n": "workspace:*",

--- a/packages/image-viewer/src/detail-viewer/image.tsx
+++ b/packages/image-viewer/src/detail-viewer/image.tsx
@@ -1,0 +1,22 @@
+import { ComponentProps } from 'react'
+import styled from 'styled-components'
+import { TransformComponent, TransformWrapper } from 'react-zoom-pan-pinch'
+
+const StyledImage = styled.img`
+  max-width: 100%;
+  max-height: 100%;
+  margin: auto;
+`
+
+export default function Image(props: ComponentProps<typeof StyledImage>) {
+  return (
+    <TransformWrapper wheel={{ wheelDisabled: true }}>
+      <TransformComponent
+        wrapperStyle={{ width: '100%', height: '100%', margin: 'auto' }}
+        contentStyle={{ width: '100%', height: '100%', margin: 'auto' }}
+      >
+        <StyledImage {...props} />
+      </TransformComponent>
+    </TransformWrapper>
+  )
+}

--- a/packages/image-viewer/src/detail-viewer/image.tsx
+++ b/packages/image-viewer/src/detail-viewer/image.tsx
@@ -10,7 +10,10 @@ const StyledImage = styled.img`
 
 export default function Image(props: ComponentProps<typeof StyledImage>) {
   return (
-    <TransformWrapper wheel={{ wheelDisabled: true }}>
+    <TransformWrapper
+      wheel={{ wheelDisabled: true }}
+      panning={{ disabled: true }}
+    >
       <TransformComponent
         wrapperStyle={{ width: '100%', height: '100%', margin: 'auto' }}
         contentStyle={{ width: '100%', height: '100%', margin: 'auto' }}

--- a/packages/image-viewer/src/detail-viewer/image.tsx
+++ b/packages/image-viewer/src/detail-viewer/image.tsx
@@ -1,6 +1,10 @@
-import { ComponentProps } from 'react'
+import { ComponentProps, useEffect, useRef } from 'react'
 import styled from 'styled-components'
-import { TransformComponent, TransformWrapper } from 'react-zoom-pan-pinch'
+import {
+  ReactZoomPanPinchRef,
+  TransformComponent,
+  TransformWrapper,
+} from 'react-zoom-pan-pinch'
 
 const StyledImage = styled.img`
   max-width: 100%;
@@ -8,11 +12,30 @@ const StyledImage = styled.img`
   margin: auto;
 `
 
-export default function Image(props: ComponentProps<typeof StyledImage>) {
+export default function Image({
+  visible,
+  ...props
+}: ComponentProps<typeof StyledImage> & { visible: boolean }) {
+  const transformComponentRef = useRef<ReactZoomPanPinchRef | null>(null)
+
+  const resetImage = () => {
+    if (transformComponentRef.current) {
+      const { resetTransform } = transformComponentRef.current
+      resetTransform()
+    }
+  }
+
+  useEffect(() => {
+    if (!visible) {
+      resetImage()
+    }
+  }, [visible])
+
   return (
     <TransformWrapper
       wheel={{ wheelDisabled: true }}
       panning={{ disabled: true }}
+      ref={transformComponentRef}
     >
       <TransformComponent
         wrapperStyle={{ width: '100%', height: '100%', margin: 'auto' }}

--- a/packages/image-viewer/src/detail-viewer/index.tsx
+++ b/packages/image-viewer/src/detail-viewer/index.tsx
@@ -106,7 +106,7 @@ export default function DetailViewer({
         }}
         autoResize
       >
-        {images.map((image) => (
+        {images.map((image, index) => (
           <Container key={image.id} css={{ width: '100%', height: '100%' }}>
             <Container
               css={{
@@ -118,7 +118,11 @@ export default function DetailViewer({
               {'video' in image ? (
                 <Video medium={image} />
               ) : (
-                <Image src={image.sizes.large.url} alt={image.id} />
+                <Image
+                  visible={imageIndex === index}
+                  src={image.sizes.large.url}
+                  alt={image.id}
+                />
               )}
             </Container>
             {image.sourceUrl ? <SourceUrl>{image.sourceUrl}</SourceUrl> : null}

--- a/packages/image-viewer/src/detail-viewer/index.tsx
+++ b/packages/image-viewer/src/detail-viewer/index.tsx
@@ -5,12 +5,7 @@ import Flicking from '@egjs/react-flicking'
 import { useRef } from 'react'
 
 import { Video } from './video'
-
-const Image = styled.img`
-  max-width: 100%;
-  max-height: 100%;
-  margin: auto;
-`
+import Image from './image'
 
 const SourceUrl = styled.p`
   overflow: hidden;
@@ -22,6 +17,8 @@ const SourceUrl = styled.p`
   line-height: 12px;
   height: 54px;
   color: var(--color-gray700);
+  position: relative;
+  z-index: 9999;
 `
 
 const Button = styled.button<{ direction: 'next' | 'prev' }>`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,6 +783,9 @@ importers:
       '@titicaca/react-contexts':
         specifier: workspace:*
         version: link:../react-contexts
+      react-zoom-pan-pinch:
+        specifier: ^3.4.3
+        version: 3.4.3(react-dom@18.2.0)(react@18.2.0)
     devDependencies:
       '@titicaca/i18n':
         specifier: workspace:*
@@ -19167,6 +19170,17 @@ packages:
       throttle-debounce: 3.0.1
       ts-easing: 0.2.0
       tslib: 2.6.2
+    dev: false
+
+  /react-zoom-pan-pinch@3.4.3(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-x5MFlfAx2D6NTpZu8OISqc2nYn4p+YEaM1p21w7S/VE1wbVzK8vRzTo9Bj1ydufa649MuP7JBRM3vvj1RftFZw==}
+    engines: {node: '>=8', npm: '>=5'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react@18.2.0:


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
이미지 확대뷰 팝업에서 이미지는 핀치 줌이 가능하도록 기능을 적용합니다. [react-zoom-pan-pinch](https://github.com/BetterTyped/react-zoom-pan-pinch) 라이브러리를 사용했습니다. 

https://inpk.atlassian.net/browse/WATF-83
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- `react-zoom-pan-pinch` 라이브러리를 적용해 핀치 줌 적용
  - PC에서의 확대는 막기 위해 `wheel` 이벤트는 disable했습니다.
  - pan 기능 적용 시 슬라이드 기능이 제대로 작동하지 않을 수 있으므로 disable했습니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->


## 스크린샷 & URL

https://github.com/titicacadev/triple-frontend/assets/43779313/d05cea08-1613-44d8-a786-99477e8fb068


<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
