### PR TITLE
[triple-document] itinerary의 transportation 타입에 bike를 추가합니다.

### DIFF
--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@titicaca/color-palette": "workspace:*",
-    "@titicaca/content-type-definitions": "8.22.0",
+    "@titicaca/content-type-definitions": "8.34.0",
     "@titicaca/core-elements": "workspace:*",
     "@titicaca/fetcher": "workspace:*",
     "@titicaca/intersection-observer": "workspace:*",

--- a/packages/triple-document/src/elements/itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary.tsx
@@ -34,7 +34,7 @@ import {
   Cable,
   Plane,
   Ship,
-  Bicycle,
+  Bike,
 } from './itinerary/icons'
 import SaveToItinerary, { Geotag } from './itinerary/save-to-itinerary'
 
@@ -276,7 +276,7 @@ function PoiCircleBadge(type: ItineraryItemType['poi']['type']) {
   throw new Error(`Unknown card type of poi "${type}"`)
 }
 
-function TransportationIcon(type?: TransportationType | 'bicycle') {
+function TransportationIcon(type?: TransportationType) {
   switch (type) {
     case 'car':
       return Car
@@ -294,8 +294,8 @@ function TransportationIcon(type?: TransportationType | 'bicycle') {
       return Cable
     case 'ship':
       return Ship
-    case 'bicycle':
-      return Bicycle
+    case 'bike':
+      return Bike
     default:
       return () => null
   }

--- a/packages/triple-document/src/elements/itinerary.tsx
+++ b/packages/triple-document/src/elements/itinerary.tsx
@@ -34,6 +34,7 @@ import {
   Cable,
   Plane,
   Ship,
+  Bicycle,
 } from './itinerary/icons'
 import SaveToItinerary, { Geotag } from './itinerary/save-to-itinerary'
 
@@ -275,7 +276,7 @@ function PoiCircleBadge(type: ItineraryItemType['poi']['type']) {
   throw new Error(`Unknown card type of poi "${type}"`)
 }
 
-function TransportationIcon(type?: TransportationType) {
+function TransportationIcon(type?: TransportationType | 'bicycle') {
   switch (type) {
     case 'car':
       return Car
@@ -293,6 +294,8 @@ function TransportationIcon(type?: TransportationType) {
       return Cable
     case 'ship':
       return Ship
+    case 'bicycle':
+      return Bicycle
     default:
       return () => null
   }

--- a/packages/triple-document/src/elements/itinerary/icons.tsx
+++ b/packages/triple-document/src/elements/itinerary/icons.tsx
@@ -115,7 +115,7 @@ export function Ship(props: IconDefaultProps) {
   )
 }
 
-export function Bicycle(props: IconDefaultProps) {
+export function Bike(props: IconDefaultProps) {
   return (
     <ImageIcon
       name="ico_contents_trans_bicycle"

--- a/packages/triple-document/src/elements/itinerary/icons.tsx
+++ b/packages/triple-document/src/elements/itinerary/icons.tsx
@@ -115,6 +115,17 @@ export function Ship(props: IconDefaultProps) {
   )
 }
 
+export function Bicycle(props: IconDefaultProps) {
+  return (
+    <ImageIcon
+      name="ico_contents_trans_bicycle"
+      width={11}
+      height={11}
+      {...props}
+    />
+  )
+}
+
 export function Download({
   color,
   width = 18,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1659,8 +1659,8 @@ importers:
         specifier: workspace:*
         version: link:../color-palette
       '@titicaca/content-type-definitions':
-        specifier: 8.22.0
-        version: 8.22.0
+        specifier: 8.34.0
+        version: 8.34.0
       '@titicaca/core-elements':
         specifier: workspace:*
         version: link:../core-elements
@@ -8498,6 +8498,10 @@ packages:
 
   /@titicaca/content-type-definitions@8.22.0:
     resolution: {integrity: sha512-W34j2tG0fHP/Wf0aXibUhAsiUnxVyD+W8RVNr8UgyyXra73nULZL3Vsker2Ljawt4c2Qfl9izSinGfBP0UXFUw==}
+    dev: false
+
+  /@titicaca/content-type-definitions@8.34.0:
+    resolution: {integrity: sha512-oA/5qsJ1wysBoMYywGA9XhFVjPlJ7dRUXqouA2aiy8FPSh/H8qKB1y+R9lIWq5b5cVOz14jyRLy2ItSvsoGC6Q==}
     dev: false
 
   /@titicaca/content-utilities@8.22.0:


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
triple-document itinerary의 transportation 타입에 bike를 추가합니다.
([관련 스레드](https://interpark.slack.com/archives/C05FT7UHU7N/p1711527724887739))
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- triple-content v8.23.0을 설치합니다.
- bike 아이콘을 추가하고 렌더링합니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 스크린샷 & URL
<img width="277" alt="스크린샷 2024-04-01 오후 3 13 37" src="https://github.com/titicacadev/triple-frontend/assets/37494848/b43c9bc6-763d-4b33-ba98-052bbee9f711">

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
