### PR TITLE
[reviews] 유저 photo가 없을 때 디폴트 프로필을 설정합니다.

### DIFF
--- a/packages/review/src/components/review-element/user.tsx
+++ b/packages/review/src/components/review-element/user.tsx
@@ -23,6 +23,9 @@ const Badge = styled.img`
   height: 18px;
 `
 
+const DEFAULT_USER_PROFILE_IMAGE =
+  'https://assets.triple.guide/images/ico-default-profile.svg'
+
 export default function User({
   user: { photo, name, userBoard, mileage, unregister },
   onClick,
@@ -37,7 +40,7 @@ export default function User({
 
   return (
     <Container display="flex" css={{ marginBottom: 16 }}>
-      {photo ? <UserPhoto src={photo} onClick={onClick} /> : null}
+      <UserPhoto src={photo || DEFAULT_USER_PROFILE_IMAGE} onClick={onClick} />
       {badges?.[0]?.icon?.image_url ? (
         <Badge src={badges[0]?.icon.image_url} />
       ) : null}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
photo가 존재하지 않지만 badge가 존재하는 유저인 경우 뱃지가 이상한 위치에 있는 경우가 있습니다.
이를 해결하기 위해 photo가 없을 경우 디폴트 프로필을 설정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
|as-is|to-be|
|-----|-----|
|<img width="268" alt="스크린샷 2024-04-02 오후 2 16 51" src="https://github.com/titicacadev/triple-frontend/assets/37494848/0cf4b904-b750-4258-9d81-469f6292d5b4">|<img width="248" alt="스크린샷 2024-04-02 오후 2 16 34" src="https://github.com/titicacadev/triple-frontend/assets/37494848/f2483940-aee3-46ef-a752-a2d196ca1efc">|
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

