### PR TITLE
[triple-document] sticky-tabs의 z-index 수정

### DIFF
--- a/packages/triple-document/src/elements/sticky-tabs.tsx
+++ b/packages/triple-document/src/elements/sticky-tabs.tsx
@@ -125,7 +125,7 @@ export default function StickyTabs({
         position: 'sticky',
         top: headerHeight || 0,
         left: 0,
-        zIndex: 2,
+        zIndex: 3,
         background: '#fff',
       }}
     >


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
triple-document의 animaion 컴포넌트가 탭 컴포넌트보다 상위로 올라오는 이슈를 수정
<img width="767" alt="스크린샷 2024-05-22 오후 1 05 57" src="https://github.com/titicacadev/triple-frontend/assets/1519159/92ced8e3-4fb9-42da-a1ca-cda17779d788">

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
