### PR TITLE
triple-document 내 쿠폰 모달 닫기 버튼 문구 수정

### DIFF
--- a/packages/triple-document/src/elements/coupon/modals.tsx
+++ b/packages/triple-document/src/elements/coupon/modals.tsx
@@ -139,7 +139,7 @@ export function CouponModal({ identifier }: { identifier: string }) {
 
       <Modal.Actions>
         <Modal.Action color="gray" onClick={back}>
-          {t(['cwiso', '취소'])}
+          {t(['dadgi', '닫기'])}
         </Modal.Action>
         <Modal.Action
           color="blue"


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

메이가 기획전(아티클) 페이지에서 쿠폰 받기 액션 후 표시되는 모달에서 모달을 닫는 행위가 `취소`로 표시되는 것이 어색하다고 제보를 줬는데요. `닫기`로 수정하는 것이 바람직해 보여 수정했습니다. 프알못이지만 간단한 수정이라 직접 PR 올려 봅니다.

## 변경 내역

CTA 문구와 i18n 메시지 키만 변경했습니다.

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

- 현재 상태 스샷
![IMG_0098](https://github.com/titicacadev/triple-frontend/assets/94351281/6596dcdc-dec1-4ea8-a974-10daeafa3416)
- [관련 슬랙 쓰레드](https://interpark.slack.com/archives/C04QGDR9TDY/p1716465599207829)
