### PR TITLE
fix: input error border-color 변경

### DIFF
--- a/packages/core-elements/src/elements/input/input.tsx
+++ b/packages/core-elements/src/elements/input/input.tsx
@@ -25,7 +25,7 @@ const BaseInput = styled(InputMask)`
   }
 
   &[aria-invalid='true'] {
-    border-color: var(--color-red);
+    border-color: var(--color-mediumRed);
   }
 
   &::placeholder {


### PR DESCRIPTION
## PR 설명

#3234 작업에서 input의 border-color 변경을 누락하여 추가합니다.

