### PR TITLE
[triple-document] 싱글 쿠폰 다운로드 버튼 다운로드 여부 미인식 이슈 수정

### DIFF
--- a/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
+++ b/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
@@ -135,7 +135,7 @@ export function CouponDownloadButton({
 
   useEffect(() => {
     async function fetchCoupon() {
-      const response = await authGuardedFetchers.get<CouponData>(
+      const response = await authGuardedFetchers.get<CouponData[]>(
         `/api/benefit/coupons/${slugId}`,
       )
 
@@ -147,12 +147,10 @@ export function CouponDownloadButton({
       captureHttpError(response)
 
       if (response.ok === true) {
-        const {
-          parsedBody: { downloaded },
-        } = response
+        const { parsedBody: items } = response
 
         setCouponFetched(true)
-        setDownloaded(!!downloaded)
+        setDownloaded(!!items[0]?.downloaded)
       }
     }
 


### PR DESCRIPTION
## PR 설명
싱글 쿠폰 다운로드 여부를 인식하지 못해 올바르지 않은 모달 메시지를 띄우는 문제를 수정합니다.

이슈 수정 전에 14버전 배포가 먼저 나가게 되면 triple-content-web 14버전 마이그레이션 후 진행하겠습니다.