### PR TITLE
ES Module 빌드

### DIFF
--- a/packages/ab-experiments/package.json
+++ b/packages/ab-experiments/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/ab-experiments/package.json
+++ b/packages/ab-experiments/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -18,9 +18,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -16,6 +16,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/intersection-observer/package.json
+++ b/packages/intersection-observer/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/intersection-observer/package.json
+++ b/packages/intersection-observer/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/meta-tags/package.json
+++ b/packages/meta-tags/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "lib/index.d.ts",
   "publishConfig": {

--- a/packages/meta-tags/package.json
+++ b/packages/meta-tags/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
-  "types": "lib/index.d.ts",
+  "module": "src/index.ts",
+  "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/middlewares/package.json
+++ b/packages/middlewares/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/middlewares/package.json
+++ b/packages/middlewares/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/scroll-to-element/package.json
+++ b/packages/scroll-to-element/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/scroll-to-element/package.json
+++ b/packages/scroll-to-element/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/standard-action-handler/package.json
+++ b/packages/standard-action-handler/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/standard-action-handler/package.json
+++ b/packages/standard-action-handler/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/tds-theme/package.json
+++ b/packages/tds-theme/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/tds-theme/package.json
+++ b/packages/tds-theme/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/tds-ui/package.json
+++ b/packages/tds-ui/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/tds-ui/package.json
+++ b/packages/tds-ui/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/tds-widget/package.json
+++ b/packages/tds-widget/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/tds-widget/package.json
+++ b/packages/tds-widget/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/triple-email-document/package.json
+++ b/packages/triple-email-document/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/triple-email-document/package.json
+++ b/packages/triple-email-document/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/triple-fallback-action/package.json
+++ b/packages/triple-fallback-action/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/triple-fallback-action/package.json
+++ b/packages/triple-fallback-action/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/triple-header/package.json
+++ b/packages/triple-header/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/triple-header/package.json
+++ b/packages/triple-header/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/triple-web-nextjs-pages/package.json
+++ b/packages/triple-web-nextjs-pages/package.json
@@ -10,6 +10,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/triple-web-nextjs-pages/package.json
+++ b/packages/triple-web-nextjs-pages/package.json
@@ -12,9 +12,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/triple-web-nextjs/package.json
+++ b/packages/triple-web-nextjs/package.json
@@ -10,6 +10,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/triple-web-nextjs/package.json
+++ b/packages/triple-web-nextjs/package.json
@@ -12,9 +12,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/triple-web-test-utils/package.json
+++ b/packages/triple-web-test-utils/package.json
@@ -10,6 +10,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/triple-web-test-utils/package.json
+++ b/packages/triple-web-test-utils/package.json
@@ -12,9 +12,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/triple-web-utils/package.json
+++ b/packages/triple-web-utils/package.json
@@ -10,6 +10,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/triple-web-utils/package.json
+++ b/packages/triple-web-utils/package.json
@@ -12,9 +12,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/triple-web/package.json
+++ b/packages/triple-web/package.json
@@ -10,6 +10,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/triple-web/package.json
+++ b/packages/triple-web/package.json
@@ -12,9 +12,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/type-definitions/package.json
+++ b/packages/type-definitions/package.json
@@ -18,9 +18,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/type-definitions/package.json
+++ b/packages/type-definitions/package.json
@@ -16,6 +16,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/packages/view-utilities/package.json
+++ b/packages/view-utilities/package.json
@@ -13,9 +13,11 @@
   },
   "sideEffects": false,
   "main": "src/index.ts",
+  "module": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
     "main": "lib/index.js",
+    "module": "lib/index.mjs",
     "types": "lib/index.d.ts"
   },
   "files": [

--- a/packages/view-utilities/package.json
+++ b/packages/view-utilities/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/titicacadev/triple-frontend/issues"
   },
+  "sideEffects": false,
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
     lib: {
       entry: ['src/index.ts'],
       fileName: (format, entryName) =>
-        format === 'es' ? `${entryName}.js` : `${entryName}.cjs`,
+        format === 'es' ? `${entryName}.mjs` : `${entryName}.js`,
       formats: ['es', 'cjs'],
     },
     rollupOptions: {

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -5,7 +5,7 @@ import { nodeExternals } from 'rollup-plugin-node-externals'
 
 export default defineConfig({
   build: {
-    target: 'es2018',
+    target: 'es6',
     outDir: 'lib',
     lib: {
       entry: ['src/index.ts'],

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -5,28 +5,21 @@ import { nodeExternals } from 'rollup-plugin-node-externals'
 
 export default defineConfig({
   build: {
-    target: 'es6',
+    target: 'es2018',
     outDir: 'lib',
     lib: {
-      entry: 'src/index.ts',
+      entry: ['src/index.ts'],
+      fileName: (format, entryName) =>
+        format === 'es' ? `${entryName}.js` : `${entryName}.cjs`,
+      formats: ['es', 'cjs'],
     },
     rollupOptions: {
       plugins: [nodeExternals()],
-      output: [
-        {
-          format: 'cjs',
-          interop: 'auto',
-          preserveModules: true,
-          preserveModulesRoot: 'src',
-          entryFileNames: '[name].js',
-        },
-        // {
-        //   format: 'es',
-        //   preserveModules: true,
-        //   preserveModulesRoot: 'src',
-        //   entryFileNames: '[name].mjs',
-        // },
-      ],
+      output: {
+        interop: 'auto',
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+      },
     },
     minify: false,
   },


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

ES Module 빌드

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- vite 컨픽을 esm 빌드가 가능하도록 수정했습니다.
- package.json에 module, sideEffects 필드를 추가합니다.

triple-newsletter-web 기준으로 아래만큼 tree shaking이 적용된 결과입니다.

기존

```
Route (pages)                                 Size     First Load JS
┌   /_app                                     0 B             452 kB
├ λ /404                                      1.06 kB         454 kB
├ λ /api/health-check                         0 B             452 kB
├ λ /articles                                 494 B           548 kB
├ λ /articles/[articleId]                     302 B           548 kB
├ λ /lists/[listId]/[subscriptionId]/confirm  345 B           453 kB
├ λ /lists/[listId]/[subscriptionId]/error    334 B           453 kB
├ λ /lists/[listId]/subscribe                 24.9 kB         488 kB
├ λ /subscription/[subscriptionId]/confirm    265 B           453 kB
├ λ /subscription/[subscriptionId]/error      1.14 kB         454 kB
├ λ /subscription/[subscriptionId]/success    1.14 kB         454 kB
└ λ /unsubscription/[subscriptionId]          1.12 kB         454 kB
+ First Load JS shared by all                 452 kB
  ├ chunks/framework-18c7e6fcf99e5daa.js      45.2 kB
  ├ chunks/main-1d1b2bb274fc1418.js           34.6 kB
  ├ chunks/pages/_app-cee4a208bdab4293.js     372 kB
  └ chunks/webpack-896d15a924e97dd1.js        1.17 kB

ƒ Middleware                                  119 kB
```

ESM 적용

```
Route (pages)                                 Size     First Load JS
┌   /_app                                     0 B             250 kB
├ λ /404                                      958 B           261 kB
├ λ /api/health-check                         0 B             250 kB
├ λ /articles                                 1.32 kB         358 kB
├ λ /articles/[articleId]                     298 B           357 kB
├ λ /lists/[listId]/[subscriptionId]/confirm  342 B           251 kB
├ λ /lists/[listId]/[subscriptionId]/error    332 B           251 kB
├ λ /lists/[listId]/subscribe                 33.8 kB         284 kB
├ λ /subscription/[subscriptionId]/confirm    263 B           251 kB
├ λ /subscription/[subscriptionId]/error      2.59 kB         253 kB
├ λ /subscription/[subscriptionId]/success    2.59 kB         253 kB
└ λ /unsubscription/[subscriptionId]          2.57 kB         253 kB
+ First Load JS shared by all                 250 kB
  ├ chunks/framework-7a7e500878b44665.js      45.2 kB
  ├ chunks/main-79570aa9d847afec.js           34.4 kB
  ├ chunks/pages/_app-ba86a8bffcde950b.js     169 kB
  └ chunks/webpack-4c0c308797e9e17f.js        1.99 kB

ƒ Middleware                                  99 kB
```
