### PR TITLE
[v14] beforeScrapedChange prop 복구

### DIFF
--- a/packages/tds-widget/src/scrap/context.ts
+++ b/packages/tds-widget/src/scrap/context.ts
@@ -1,6 +1,6 @@
 import { Dispatch, createContext } from 'react'
 
-import { Scraps } from './types'
+import { Scraps, Target } from './types'
 import { ActionType } from './reducer'
 
 export const ScrapContext = createContext<
@@ -9,6 +9,7 @@ export const ScrapContext = createContext<
       updating: {
         [id: string]: boolean
       }
+      beforeScrapedChange?: (target: Target, scraped: boolean) => boolean
     }
   | undefined
 >(undefined)

--- a/packages/tds-widget/src/scrap/provider.tsx
+++ b/packages/tds-widget/src/scrap/provider.tsx
@@ -4,17 +4,19 @@ import {
   unsubscribeScrapedChangeEvent,
 } from '@titicaca/triple-web-to-native-interfaces'
 
-import { Scraps } from './types'
+import { Scraps, Target } from './types'
 import { reducer } from './reducer'
 import { SCRAPE, UNSCRAPE } from './constants'
 import { ScrapContext, ScrapDispatchContext } from './context'
 
 interface ScrapsProviderProps {
   initialScraps?: Scraps
+  beforeScrapedChange?: (target: Target, scraped: boolean) => boolean
 }
 
 export function ScrapsProvider({
   initialScraps,
+  beforeScrapedChange,
   children,
 }: PropsWithChildren<ScrapsProviderProps>) {
   const [value, dispatch] = useReducer(reducer, {
@@ -37,7 +39,7 @@ export function ScrapsProvider({
   }, [dispatch])
 
   return (
-    <ScrapContext.Provider value={value}>
+    <ScrapContext.Provider value={{ ...value, beforeScrapedChange }}>
       <ScrapDispatchContext.Provider value={dispatch}>
         {children}
       </ScrapDispatchContext.Provider>

--- a/packages/tds-widget/src/scrap/use-scrap.ts
+++ b/packages/tds-widget/src/scrap/use-scrap.ts
@@ -28,7 +28,7 @@ export function useScrap() {
     throw new Error('ScrapProvider가 없습니다.')
   }
 
-  const { scraps, updating } = scrapsContext
+  const { scraps, updating, beforeScrapedChange } = scrapsContext
 
   const app = useClientApp()
   const { notifyScraped, notifyUnscraped } = useClientAppActions()
@@ -85,6 +85,13 @@ export function useScrap() {
         },
       },
     }: Target) => {
+      if (
+        beforeScrapedChange &&
+        beforeScrapedChange({ id, type }, true) === false
+      ) {
+        return
+      }
+
       if (typeof updating[id] !== 'undefined') {
         return
       }
@@ -110,10 +117,11 @@ export function useScrap() {
       }
     },
     [
-      dispatch,
+      beforeScrapedChange,
       updating,
       app,
       sessionAvailable,
+      dispatch,
       showAppInstallCtaModal,
       showLoginCta,
       notifyScraped,
@@ -134,6 +142,13 @@ export function useScrap() {
         },
       },
     }: Target) => {
+      if (
+        beforeScrapedChange &&
+        beforeScrapedChange({ id, type }, true) === false
+      ) {
+        return
+      }
+
       if (typeof updating[id] !== 'undefined') {
         return
       }
@@ -159,10 +174,11 @@ export function useScrap() {
       }
     },
     [
-      dispatch,
+      beforeScrapedChange,
       updating,
       app,
       sessionAvailable,
+      dispatch,
       showAppInstallCtaModal,
       showLoginCta,
       notifyUnscraped,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
기존 v13에서 제공되던 `beforeScrpaedChange` prop을 복구합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
