### PR TITLE
querystring 대신 qs 모듈 사용

### DIFF
--- a/packages/tds-widget/src/ad-banners/api.ts
+++ b/packages/tds-widget/src/ad-banners/api.ts
@@ -1,5 +1,4 @@
-import qs from 'querystring'
-
+import qs from 'qs'
 import { get, post } from '@titicaca/fetcher'
 
 import { Banner } from './typing'

--- a/packages/tds-widget/src/chat/utils/image.ts
+++ b/packages/tds-widget/src/chat/utils/image.ts
@@ -1,5 +1,4 @@
-import qs from 'querystring'
-
+import qs from 'qs'
 import { generateUrl } from '@titicaca/view-utilities'
 
 import { UserInterface, MetaDataInterface } from '../types'


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

querystring은 node.js 모듈이기 때문에 qs를 사용합니다.