### PR TITLE
styled components 6 prop forward warning 수정 

### DIFF
--- a/packages/tds-ui/package.json
+++ b/packages/tds-ui/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@egjs/flicking": "^3.9.3",
     "@egjs/react-flicking": "^3.8.3",
+    "@emotion/is-prop-valid": "^1.3.0",
     "@floating-ui/react": "^0.26.20",
     "@titicaca/content-utilities": "8.34.0",
     "@titicaca/intersection-observer": "workspace:*",

--- a/packages/tds-ui/src/components/action-sheet/action-sheet-body.tsx
+++ b/packages/tds-ui/src/components/action-sheet/action-sheet-body.tsx
@@ -3,7 +3,7 @@ import { styled, css } from 'styled-components'
 
 import { Container } from '../container'
 import { MarginPadding } from '../../commons'
-import { safeAreaInsetMixin } from '../../mixins'
+import { safeAreaInsetMixin, SafeAreaInsetMixinProps } from '../../mixins'
 
 import { ActionSheetTitle } from './action-sheet-title'
 import { TRANSITION_DURATION } from './constants'
@@ -33,7 +33,7 @@ const Sheet = styled.div<SheetProps>`
           border-radius: 0 0 ${$borderRadius}px ${$borderRadius}px;
         `
       case 'bottom':
-        return css`
+        return css<SafeAreaInsetMixinProps>`
           bottom: 0;
           border-radius: ${$borderRadius}px ${$borderRadius}px 0 0;
           ${safeAreaInsetMixin};

--- a/packages/tds-ui/src/components/button/basic-button.tsx
+++ b/packages/tds-ui/src/components/button/basic-button.tsx
@@ -1,7 +1,7 @@
 import { css } from 'styled-components'
 import type { Theme } from '@titicaca/tds-theme'
 
-import { buttonBaseMixin, ButtonBaseOwnProps } from './button-base'
+import { buttonBaseMixin, ButtonBaseMixinProps } from './button-base'
 
 type Color = keyof Theme['colors']
 
@@ -10,7 +10,7 @@ const BASIC_INVERTED_COLORS: Partial<Record<Color, string>> = {
   gray: '#3a3a3a',
 }
 
-export interface BasicButtonOwnProps extends ButtonBaseOwnProps {
+export interface BasicButtonOwnProps extends ButtonBaseMixinProps {
   color?: Color
   /**
    * Compact 버튼을 사용합니다. Normal 및 Basic 버튼에서만 사용할 수 있습니다.

--- a/packages/tds-ui/src/components/button/button-base.tsx
+++ b/packages/tds-ui/src/components/button/button-base.tsx
@@ -5,7 +5,8 @@ import type { Theme } from '@titicaca/tds-theme'
 
 import { GetGlobalColor, MarginPadding } from '../../commons'
 import { unit } from '../../utils/unit'
-import { marginMixin } from '../../mixins'
+import { marginMixin, MarginMixinProps } from '../../mixins'
+import { shouldForwardProp } from '../../utils/should-forward-prop'
 
 import { ButtonSize } from './types'
 
@@ -23,7 +24,7 @@ const SIZES: Record<ButtonSize, ReturnType<typeof css>> = {
   `,
 }
 
-export interface ButtonBaseOwnProps {
+export interface ButtonBaseMixinProps extends MarginMixinProps {
   /**
    * Basic 및 Normal 버튼에서는 항상 `true` 입니다.
    */
@@ -43,7 +44,7 @@ export interface ButtonBaseOwnProps {
   textColor?: keyof Theme['colors']
 }
 
-export type ButtonBaseProps = ButtonBaseOwnProps &
+export type ButtonBaseProps = ButtonBaseMixinProps &
   PropsWithChildren &
   ButtonHTMLAttributes<HTMLButtonElement>
 
@@ -55,7 +56,8 @@ export const buttonBaseMixin = ({
   lineHeight,
   textAlpha = 1,
   textColor = 'gray',
-}: ButtonBaseOwnProps) => css`
+  margin,
+}: ButtonBaseMixinProps) => css`
   display: inline-block;
   color: rgba(${GetGlobalColor(textColor)}, ${textAlpha});
   float: ${floated};
@@ -73,7 +75,7 @@ export const buttonBaseMixin = ({
     display: block;
   `};
 
-  ${marginMixin}
+  ${marginMixin({ margin })}
 
   ${SIZES[size]}
 
@@ -82,7 +84,9 @@ export const buttonBaseMixin = ({
   }
 `
 
-export const ButtonBase = styled.button.attrs((props) => ({
-  /* stylelint-disable-next-line property-no-unknown */
-  type: props.type ?? 'button',
-}))(buttonBaseMixin)
+export const ButtonBase = styled.button
+  .withConfig({ shouldForwardProp })
+  .attrs((props) => ({
+    /* stylelint-disable-next-line property-no-unknown */
+    type: props.type ?? 'button',
+  }))<ButtonBaseMixinProps>(buttonBaseMixin)

--- a/packages/tds-ui/src/components/button/button-group.ts
+++ b/packages/tds-ui/src/components/button/button-group.ts
@@ -1,6 +1,7 @@
 import { styled } from 'styled-components'
 
 import { Container } from '../container'
+import { shouldForwardProp } from '../../utils/should-forward-prop'
 
 import { ButtonBase } from './button-base'
 
@@ -9,7 +10,9 @@ export interface ButtonGroupProps {
   buttonCount?: number
 }
 
-export const ButtonGroup = styled(Container)<ButtonGroupProps>`
+export const ButtonGroup = styled(Container).withConfig({
+  shouldForwardProp,
+})<ButtonGroupProps>`
   width: 100%;
   display: flex;
   align-items: center;

--- a/packages/tds-ui/src/components/button/button-icon.tsx
+++ b/packages/tds-ui/src/components/button/button-icon.tsx
@@ -1,5 +1,7 @@
 import { styled, css } from 'styled-components'
 
+import { shouldForwardProp } from '../../utils/should-forward-prop'
+
 type ButtonIconSize = 'tiny' | 'small'
 
 const BUTTON_ICON_STYLES: Record<ButtonIconSize, ReturnType<typeof css>> = {
@@ -22,7 +24,9 @@ export interface ButtonIconProps {
   src?: string
 }
 
-export const ButtonIcon = styled.div<ButtonIconProps>`
+export const ButtonIcon = styled.div.withConfig({
+  shouldForwardProp,
+})<ButtonIconProps>`
   display: inline-block;
   ${({ size = 'tiny' }) => BUTTON_ICON_STYLES[size]};
   vertical-align: text-top;

--- a/packages/tds-ui/src/components/button/button.tsx
+++ b/packages/tds-ui/src/components/button/button.tsx
@@ -1,15 +1,17 @@
 import { ButtonHTMLAttributes, PropsWithChildren } from 'react'
 import { styled } from 'styled-components'
 
+import { shouldForwardProp } from '../../utils/should-forward-prop'
+
 import { basicButtonMixin, BasicButtonOwnProps } from './basic-button'
 import { ButtonBase } from './button-base'
-import { iconButtonMixin, IconButtonOwnProps } from './icon-button'
-import { normalButtonMixin, NormalButtonOwnProps } from './normal-button'
+import { iconButtonMixin, IconButtonMixinProps } from './icon-button'
+import { normalButtonMixin, NormalButtonMixinProps } from './normal-button'
 
 export interface ButtonOwnProps
   extends BasicButtonOwnProps,
-    Omit<IconButtonOwnProps, 'icon'>,
-    NormalButtonOwnProps {
+    Omit<IconButtonMixinProps, 'icon'>,
+    NormalButtonMixinProps {
   /**
    * Basic 유형 버튼을 사용합니다.
    */
@@ -17,14 +19,16 @@ export interface ButtonOwnProps
   /**
    * Block Icon 유형 버튼을 사용합니다.
    */
-  icon?: IconButtonOwnProps['icon']
+  icon?: IconButtonMixinProps['icon']
 }
 
 export type ButtonProps = ButtonOwnProps &
   PropsWithChildren &
   ButtonHTMLAttributes<HTMLButtonElement>
 
-export const Button = styled(ButtonBase)<ButtonProps>((props) => {
+export const Button = styled(ButtonBase).withConfig({
+  shouldForwardProp,
+})<ButtonProps>((props) => {
   if (props.basic) {
     return basicButtonMixin({
       ...props,

--- a/packages/tds-ui/src/components/button/icon-button.tsx
+++ b/packages/tds-ui/src/components/button/icon-button.tsx
@@ -1,6 +1,6 @@
 import { css } from 'styled-components'
 
-import { buttonBaseMixin, ButtonBaseOwnProps } from './button-base'
+import { buttonBaseMixin, ButtonBaseMixinProps } from './button-base'
 import { ButtonSize } from './types'
 
 const ICON_BUTTON_URLS = {
@@ -19,7 +19,7 @@ const ICON_PADDINGS: Partial<Record<ButtonSize, ReturnType<typeof css>>> = {
   tiny: css({ padding: '12px' }),
 }
 
-export interface IconButtonOwnProps extends ButtonBaseOwnProps {
+export interface IconButtonMixinProps extends ButtonBaseMixinProps {
   icon: Icon
 }
 
@@ -27,7 +27,7 @@ export const iconButtonMixin = ({
   icon,
   size = 'tiny',
   ...props
-}: IconButtonOwnProps) => css`
+}: IconButtonMixinProps) => css`
   ${buttonBaseMixin({ size, ...props })}
   ${ICON_PADDINGS[size]}
 

--- a/packages/tds-ui/src/components/button/normal-button.tsx
+++ b/packages/tds-ui/src/components/button/normal-button.tsx
@@ -1,7 +1,7 @@
 import { css } from 'styled-components'
 import type { Theme } from '@titicaca/tds-theme'
 
-import { buttonBaseMixin, ButtonBaseOwnProps } from './button-base'
+import { buttonBaseMixin, ButtonBaseMixinProps } from './button-base'
 import { ButtonSize } from './types'
 
 const NORMAL_PADDINGS: Partial<Record<ButtonSize, ReturnType<typeof css>>> = {
@@ -16,7 +16,7 @@ const COMPACT_NORMAL_PADDINGS: Partial<
   tiny: css({ padding: '9px 15px' }),
 }
 
-export interface NormalButtonOwnProps extends ButtonBaseOwnProps {
+export interface NormalButtonMixinProps extends ButtonBaseMixinProps {
   borderRadius?: number
   /**
    * Compact 버튼을 사용합니다. Normal 및 Basic 버튼에서만 사용할 수 있습니다.
@@ -31,7 +31,7 @@ export const normalButtonMixin = ({
   color = 'blue',
   size = 'tiny',
   ...props
-}: NormalButtonOwnProps) => css`
+}: NormalButtonMixinProps) => css`
   ${buttonBaseMixin({ size, ...props })}
   border-radius: ${borderRadius ? `${borderRadius}px` : undefined};
   background-color: ${({ theme }) => theme.colors[color]};

--- a/packages/tds-ui/src/components/container/container.tsx
+++ b/packages/tds-ui/src/components/container/container.tsx
@@ -11,6 +11,7 @@ import {
   clearingMixin,
   horizontalScrollMixin,
 } from '../../mixins'
+import { shouldForwardProp } from '../../utils/should-forward-prop'
 
 export type ContainerProps = PropsWithChildren<{
   position?: Property.Position
@@ -30,7 +31,9 @@ export type ContainerProps = PropsWithChildren<{
  *
  * - 제공된 prop 외의 스타일은 css prop을 사용합니다.
  */
-export const Container = styled.div<ContainerProps>(
+export const Container = styled.div.withConfig({
+  shouldForwardProp,
+})<ContainerProps>(
   (props) => ({
     boxSizing: 'border-box',
     position: props.position,
@@ -45,4 +48,5 @@ export const Container = styled.div<ContainerProps>(
   horizontalScrollMixin,
   shadowMixin,
   borderRadiusMixin,
+  (props) => props.css,
 )

--- a/packages/tds-ui/src/components/drawer-button/drawer-button.tsx
+++ b/packages/tds-ui/src/components/drawer-button/drawer-button.tsx
@@ -3,9 +3,13 @@ import { styled } from 'styled-components'
 import { Drawer, DrawerProps } from '../drawer/drawer'
 import { Container } from '../container'
 import { Button, ButtonProps } from '../button'
-import { paddingMixin, safeAreaInsetMixin } from '../../mixins'
+import {
+  paddingMixin,
+  PaddingMixinProps,
+  safeAreaInsetMixin,
+} from '../../mixins'
 
-const ButtonWithSafeAreaInset = styled(Button)`
+const ButtonWithSafeAreaInset = styled(Button)<PaddingMixinProps>`
   ${paddingMixin}
   ${safeAreaInsetMixin}
 `

--- a/packages/tds-ui/src/components/flex-box/flex-box.tsx
+++ b/packages/tds-ui/src/components/flex-box/flex-box.tsx
@@ -3,6 +3,7 @@ import { Property } from 'csstype'
 import { HTMLAttributes } from 'react'
 
 import { Container, ContainerProps } from '../container'
+import { shouldForwardProp } from '../../utils/should-forward-prop'
 
 export interface FlexItemOwnProps extends ContainerProps {
   /**
@@ -28,7 +29,9 @@ export interface FlexItemOwnProps extends ContainerProps {
 
 export type FlexItemProps = FlexItemOwnProps & HTMLAttributes<Element>
 
-export const FlexBoxItem = styled(Container)<FlexItemProps>((props) => ({
+export const FlexBoxItem = styled(Container).withConfig({
+  shouldForwardProp,
+})<FlexItemProps>((props) => ({
   flex: props.flex,
   flexGrow: props.flexGrow,
   flexShrink: props.flexShrink,
@@ -79,7 +82,9 @@ export interface FlexBoxProps
  * flex children 요소가 사용 가능한 flex, flexGrow, flexShrink, flexBasis,
  * alignSelf, order는 중첩된 구조의 flex 사용 시에만 사용 권장합니다.
  */
-export const FlexBox = styled(Container)<FlexBoxProps>((props) => ({
+export const FlexBox = styled(Container).withConfig({
+  shouldForwardProp,
+})<FlexBoxProps>((props) => ({
   display: props.flex ? 'flex' : undefined,
   flexDirection: props.flexDirection,
   flexWrap: props.flexWrap,

--- a/packages/tds-ui/src/components/hr/hr.ts
+++ b/packages/tds-ui/src/components/hr/hr.ts
@@ -1,11 +1,13 @@
 import { styled, css } from 'styled-components'
 
+import { shouldForwardProp } from '../../utils/should-forward-prop'
+
 export interface HrProps {
   compact?: boolean
   color?: string
 }
 
-export const HR1 = styled.div<HrProps>`
+export const HR1 = styled.div.withConfig({ shouldForwardProp })<HrProps>`
   margin: 50px 30px;
   height: 1px;
   background-color: ${({ color }) => color || '#efefef'};
@@ -17,7 +19,7 @@ export const HR1 = styled.div<HrProps>`
     `};
 `
 
-export const HR2 = styled.div<HrProps>`
+export const HR2 = styled.div.withConfig({ shouldForwardProp })<HrProps>`
   margin: 50px 0;
   height: 10px;
   background-color: #efefef;
@@ -29,7 +31,9 @@ export const HR2 = styled.div<HrProps>`
     `};
 `
 
-export const HR3 = styled.div<{ height?: number }>`
+export const HR3 = styled.div.withConfig({
+  shouldForwardProp,
+})<{ height?: number }>`
   height: ${({ height }) => height || 10}px;
   background-color: transparent;
 `
@@ -61,7 +65,7 @@ export const HR6 = styled.div`
   background-image: url('https://assets.triple.guide/images/img-line3@2x.png');
 `
 
-export const HR7 = styled.div<HrProps>`
+export const HR7 = styled.div.withConfig({ shouldForwardProp })<HrProps>`
   margin: 30px auto;
   ${({ compact }) =>
     compact &&

--- a/packages/tds-ui/src/components/icon/icon.ts
+++ b/packages/tds-ui/src/components/icon/icon.ts
@@ -2,6 +2,7 @@ import { styled } from 'styled-components'
 
 import { GlobalSizes, MarginPadding } from '../../commons'
 import { marginMixin, paddingMixin } from '../../mixins'
+import { shouldForwardProp } from '../../utils/should-forward-prop'
 
 type Icons = 'save' | 'web' | 'call' | 'map' | 'arrowRight'
 
@@ -21,7 +22,9 @@ const SIZES: Partial<Record<GlobalSizes, string>> = {
   big: '24px',
 }
 
-export const Icon = styled.div<{
+export const Icon = styled.div.withConfig({
+  shouldForwardProp,
+})<{
   size?: GlobalSizes
   src?: string
   name?: Icons

--- a/packages/tds-ui/src/components/image/circular.ts
+++ b/packages/tds-ui/src/components/image/circular.ts
@@ -2,13 +2,16 @@ import { styled } from 'styled-components'
 import * as CSS from 'csstype'
 
 import { GlobalSizes } from '../../commons'
+import { shouldForwardProp } from '../../utils/should-forward-prop'
 
 const ROUND_SIZES: Partial<Record<GlobalSizes, number>> = {
   small: 40,
   medium: 60,
 }
 
-export const ImageCircular = styled.img<{
+export const ImageCircular = styled.img.withConfig({
+  shouldForwardProp,
+})<{
   size?: GlobalSizes
   floated?: CSS.Property.Float
   width?: number

--- a/packages/tds-ui/src/components/label/label.tsx
+++ b/packages/tds-ui/src/components/label/label.tsx
@@ -148,7 +148,7 @@ interface PromoLabelProps {
   verticalAlign?: CSS.Property.VerticalAlign<string>
 }
 
-export const PromoLabel = styled.div<PromoLabelProps>`
+const PromoLabel = styled.div<PromoLabelProps>`
   display: inline-block;
   ${marginMixin}
 

--- a/packages/tds-ui/src/components/list/list.tsx
+++ b/packages/tds-ui/src/components/list/list.tsx
@@ -3,6 +3,7 @@ import { styled, css } from 'styled-components'
 
 import { MarginPadding } from '../../commons'
 import { marginMixin } from '../../mixins'
+import { shouldForwardProp } from '../../utils/should-forward-prop'
 
 interface ListBaseProp {
   margin?: MarginPadding
@@ -23,7 +24,9 @@ export interface ListItemProps {
   minHeight?: number
 }
 
-const ListBase = styled.ul<ListBaseProp & DividerOptions>`
+const ListBase = styled.ul.withConfig({ shouldForwardProp })<
+  ListBaseProp & DividerOptions
+>`
   ${marginMixin}
 
   > li:not(:first-child) {
@@ -78,7 +81,9 @@ const ListBase = styled.ul<ListBaseProp & DividerOptions>`
       : ''}
 `
 
-const ListItem = styled.li<ListItemProps>`
+const ListItem = styled.li.withConfig({
+  shouldForwardProp,
+})<ListItemProps>`
   clear: both;
   position: relative;
   list-style-type: none;

--- a/packages/tds-ui/src/components/modal/modal-action.tsx
+++ b/packages/tds-ui/src/components/modal/modal-action.tsx
@@ -1,13 +1,16 @@
 import { styled } from 'styled-components'
 
 import { GlobalColors } from '../../commons'
+import { shouldForwardProp } from '../../utils/should-forward-prop'
 
 const ACTION_COLORS: Partial<Record<GlobalColors, string>> = {
   gray: 'rgba(58, 58, 58, 0.5)',
   blue: '#368fff',
 }
 
-export const ModalAction = styled.a<{ color?: GlobalColors }>`
+export const ModalAction = styled.a.withConfig({
+  shouldForwardProp,
+})<{ color?: GlobalColors }>`
   display: inline-block;
   white-space: nowrap;
   height: 50px;

--- a/packages/tds-ui/src/components/navbar/navbar.tsx
+++ b/packages/tds-ui/src/components/navbar/navbar.tsx
@@ -14,6 +14,7 @@ import type { Theme } from '@titicaca/tds-theme'
 import { MarginPadding } from '../../commons'
 import { layeringMixin, LayeringMixinProps, paddingMixin } from '../../mixins'
 import { unit } from '../../utils/unit'
+import { shouldForwardProp } from '../../utils/should-forward-prop'
 
 interface NavbarProps {
   maxWidth?: number
@@ -129,11 +130,15 @@ interface NavbarItemProps {
   hasTitle?: boolean
 }
 
-const NavbarItem = styled.div.attrs<NavbarItemProps>(({ icon }) => ({
-  className: ['back', 'close'].includes(icon || '')
-    ? TRIPLE_FALLBACK_ACTION_CLASS_NAME
-    : '',
-}))<NavbarItemProps>`
+const NavbarItem = styled.div
+  .attrs<NavbarItemProps>(({ icon }) => ({
+    className: ['back', 'close'].includes(icon || '')
+      ? TRIPLE_FALLBACK_ACTION_CLASS_NAME
+      : '',
+  }))
+  .withConfig({
+    shouldForwardProp,
+  })<NavbarItemProps>`
   ${({ position }) => position && `position: ${position};`}
   float: ${({ floated }) => floated || 'left'};
   background-image: url(${({ icon }) => (icon ? ICON_URL_BY_NAMES[icon] : '')});
@@ -156,7 +161,9 @@ const NavbarItem = styled.div.attrs<NavbarItemProps>(({ icon }) => ({
     `}
 `
 
-const SecondaryNavbar = styled.div<NavbarProps & LayeringMixinProps>`
+const SecondaryNavbar = styled.div.withConfig({
+  shouldForwardProp,
+})<NavbarProps & LayeringMixinProps>`
   background-color: ${({ backgroundColor = 'white', theme }) =>
     theme.colors[backgroundColor]};
   ${({ position = 'sticky' }) => `

--- a/packages/tds-ui/src/components/responsive/responsive.tsx
+++ b/packages/tds-ui/src/components/responsive/responsive.tsx
@@ -1,13 +1,17 @@
 import { PropsWithChildren } from 'react'
 import { styled, css } from 'styled-components'
 
+import { shouldForwardProp } from '../../utils/should-forward-prop'
+
 export type ResponsiveProps = PropsWithChildren<{
   inline?: boolean
   maxWidth?: number
   minWidth?: number
 }>
 
-export const Responsive = styled.div<ResponsiveProps>`
+export const Responsive = styled.div.withConfig({
+  shouldForwardProp,
+})<ResponsiveProps>`
   display: ${({ inline }) => (inline ? 'inline' : 'block')};
 
   ${({ minWidth }) =>

--- a/packages/tds-ui/src/components/segment/segment.tsx
+++ b/packages/tds-ui/src/components/segment/segment.tsx
@@ -1,7 +1,12 @@
 import { PropsWithChildren } from 'react'
-import { styled, css, ThemedStyledProps } from 'styled-components'
+import { styled } from 'styled-components'
 
-import { KeyOfShadowSize, shadowMixin, ShadowMixinProps } from '../../mixins'
+import {
+  borderRadiusMixin,
+  BorderRadiusMixinProps,
+  shadowMixin,
+  ShadowMixinProps,
+} from '../../mixins'
 
 export const Segment = styled.div`
   padding: 20px;
@@ -15,48 +20,39 @@ export const Segment = styled.div`
   }
 `
 
-export interface BoxProps {
-  radius: number
-}
-
-export type CardProps = Partial<
-  BoxProps & {
-    shadow: KeyOfShadowSize
-    shadowValue?: string
-  }
->
-
-const borderRadius = ({
-  radius = 0,
-}: ThemedStyledProps<{ radius?: number }, unknown>) => css`
-  border-radius: ${radius}px;
-`
-
 const shadowMixinWithDefault = (props: ShadowMixinProps) =>
   shadowMixin({ shadow: 'medium', ...props })
 
-export const CardFrame = styled.div<CardProps>`
-  ${borderRadius}
+export const CardFrame = styled.div<BorderRadiusMixinProps & ShadowMixinProps>`
+  ${borderRadiusMixin}
   ${shadowMixinWithDefault}
 `
+
+export interface CardProps
+  extends PropsWithChildren<BorderRadiusMixinProps & ShadowMixinProps> {}
 
 /**
  * Card Component
  *
  * Props
- *  - radius: number
+ *  - borderRadius: number
  *  - shadow: ShadowType
  *  - shadowValue: string
  */
 export function Card({
   children,
-  className,
+  borderRadius,
+  shadow,
+  shadowValue,
   ...props
-}: PropsWithChildren<CardProps> & {
-  className?: string
-}) {
+}: CardProps) {
   return (
-    <CardFrame className={className} {...props}>
+    <CardFrame
+      {...props}
+      borderRadius={borderRadius}
+      shadow={shadow}
+      shadowValue={shadowValue}
+    >
       {children}
     </CardFrame>
   )

--- a/packages/tds-ui/src/components/tag/tag.tsx
+++ b/packages/tds-ui/src/components/tag/tag.tsx
@@ -3,6 +3,7 @@ import { styled, css } from 'styled-components'
 
 import { GlobalSizes, MarginPadding } from '../../commons'
 import { marginMixin } from '../../mixins'
+import { shouldForwardProp } from '../../utils/should-forward-prop'
 
 export type TagColors = 'special' | 'pink' | 'purple' | 'default'
 
@@ -27,7 +28,7 @@ const PADDING_SIZE: Partial<Record<GlobalSizes, MarginPadding>> = {
   medium: { top: 6, right: 10, bottom: 6, left: 10 },
 }
 
-export const Tag = styled.div<{
+export const Tag = styled.div.withConfig({ shouldForwardProp })<{
   type?: TagColors
   margin?: MarginPadding
   size?: GlobalSizes

--- a/packages/tds-ui/src/components/text/text.tsx
+++ b/packages/tds-ui/src/components/text/text.tsx
@@ -12,6 +12,7 @@ import {
   paddingMixin,
   textStyleMixin,
 } from '../../mixins'
+import { shouldForwardProp } from '../../utils/should-forward-prop'
 
 function rgba({ color, alpha }: { color?: string; alpha?: number }) {
   return `rgba(${GetGlobalColor(color || 'gray')}, ${alpha || 1})`
@@ -41,7 +42,7 @@ export type TextProps = PropsWithChildren<{
   wordBreak?: Property.WordBreak
 }>
 
-export const Text = styled.div<TextProps>(
+export const Text = styled.div.withConfig({ shouldForwardProp })<TextProps>(
   (props) => ({
     boxSizing: 'border-box',
     overflowWrap: 'break-word',

--- a/packages/tds-ui/src/mixins/border-radius.ts
+++ b/packages/tds-ui/src/mixins/border-radius.ts
@@ -1,17 +1,19 @@
 import { css } from 'styled-components'
 
+export interface BorderRadiusMixinProps {
+  borderRadius?: number
+}
+
 /**
  * border-radius를 지정하는 mixin
  * 자식 엘리먼트가 border-radius를 무시하지 않도록 overflow: hidden이 추가됩니다.
  * 또한, 관련한 safari 버그를 우회하는 workaround도 포함합니다.
  * @param  borderRadiusMixin
  */
-export const borderRadiusMixin = css<{ borderRadius?: number }>`
-  ${({ borderRadius }) =>
-    borderRadius &&
-    `
+export const borderRadiusMixin = ({ borderRadius }: BorderRadiusMixinProps) =>
+  borderRadius &&
+  css`
     overflow: hidden;
     mask-image: radial-gradient(white, black);
     border-radius: ${borderRadius}px;
-  `}
-`
+  `

--- a/packages/tds-ui/src/mixins/box.ts
+++ b/packages/tds-ui/src/mixins/box.ts
@@ -1,4 +1,4 @@
-import { ThemedStyledProps } from 'styled-components'
+import { css } from 'styled-components'
 
 import { BaseSizes } from '../commons'
 
@@ -9,10 +9,10 @@ const ShadowSizeMap: { [key in BaseSizes | 'none']: string } = {
   none: '',
 }
 
-export type ShadowMixinProps = ThemedStyledProps<
-  { shadow?: KeyOfShadowSize; shadowValue?: string },
-  unknown
->
+export interface ShadowMixinProps {
+  shadow?: KeyOfShadowSize
+  shadowValue?: string
+}
 
 /**
  * Usage
@@ -35,7 +35,11 @@ export type ShadowMixinProps = ThemedStyledProps<
 export const shadowMixin = ({ shadow, shadowValue }: ShadowMixinProps) => {
   const value = shadow ? ShadowSizeMap[shadow] : shadowValue
 
-  return value ? `box-shadow: ${value};` : ''
+  return value
+    ? css`
+        box-shadow: ${value};
+      `
+    : undefined
 }
 
 export type KeyOfShadowSize = keyof typeof ShadowSizeMap

--- a/packages/tds-ui/src/mixins/centered.ts
+++ b/packages/tds-ui/src/mixins/centered.ts
@@ -1,10 +1,10 @@
 import { css } from 'styled-components'
 
-interface Params {
+export interface CenteredMixinProps {
   centered?: boolean
 }
 
-export const centeredMixin = ({ centered }: Params) =>
+export const centeredMixin = ({ centered }: CenteredMixinProps) =>
   centered
     ? css`
         margin-left: auto;

--- a/packages/tds-ui/src/mixins/clearing.ts
+++ b/packages/tds-ui/src/mixins/clearing.ts
@@ -1,10 +1,10 @@
 import { css } from 'styled-components'
 
-interface Params {
+export interface ClearingMixinProps {
   clearing?: boolean
 }
 
-export const clearingMixin = ({ clearing }: Params) =>
+export const clearingMixin = ({ clearing }: ClearingMixinProps) =>
   clearing
     ? css`
         &::after {

--- a/packages/tds-ui/src/mixins/ellipsis.ts
+++ b/packages/tds-ui/src/mixins/ellipsis.ts
@@ -1,10 +1,10 @@
 import { css } from 'styled-components'
 
-interface Params {
+export interface EllipsisMixinProps {
   ellipsis?: boolean
 }
 
-export const ellipsisMixin = ({ ellipsis }: Params) =>
+export const ellipsisMixin = ({ ellipsis }: EllipsisMixinProps) =>
   ellipsis
     ? css`
         white-space: nowrap;

--- a/packages/tds-ui/src/mixins/horizontal-scroll.ts
+++ b/packages/tds-ui/src/mixins/horizontal-scroll.ts
@@ -1,10 +1,12 @@
 import { css } from 'styled-components'
 
-interface Params {
+export interface HorizontalScrollMixinProps {
   horizontalScroll?: boolean
 }
 
-export const horizontalScrollMixin = ({ horizontalScroll }: Params) =>
+export const horizontalScrollMixin = ({
+  horizontalScroll,
+}: HorizontalScrollMixinProps) =>
   horizontalScroll
     ? css`
         white-space: nowrap;

--- a/packages/tds-ui/src/mixins/layering.ts
+++ b/packages/tds-ui/src/mixins/layering.ts
@@ -5,6 +5,8 @@ export interface LayeringMixinProps {
   zIndex?: number
 }
 
-export const layeringMixin = (defaultTier: number) => css<LayeringMixinProps>`
-  z-index: ${({ zTier = defaultTier, zIndex = 0 }) => zTier * 100 + zIndex};
-`
+export const layeringMixin =
+  (defaultTier: number) =>
+  ({ zIndex = defaultTier, zTier = 0 }: LayeringMixinProps) => css`
+    z-index: ${zTier * 100 + zIndex};
+  `

--- a/packages/tds-ui/src/mixins/margin-padding.ts
+++ b/packages/tds-ui/src/mixins/margin-padding.ts
@@ -8,19 +8,40 @@ export function formatMarginPadding(
   key: 'margin' | 'padding',
 ) {
   if (!marginPadding) {
-    return ''
+    return undefined
   }
 
-  return css`
-    ${key}: ${unit(marginPadding.top || 0)} ${unit(marginPadding.right || 0)}
-      ${unit(marginPadding.bottom || 0)} ${unit(marginPadding.left || 0)};
-  `
+  if (key === 'margin') {
+    return css`
+      /* stylelint-disable declaration-block-no-redundant-longhand-properties */
+      margin-top: ${unit(marginPadding.top || 0)};
+      margin-left: ${unit(marginPadding.left || 0)};
+      margin-right: ${unit(marginPadding.right || 0)};
+      margin-bottom: ${unit(marginPadding.bottom || 0)};
+      /* stylelint-enable declaration-block-no-redundant-longhand-properties */
+    `
+  } else {
+    return css`
+      /* stylelint-disable declaration-block-no-redundant-longhand-properties */
+      padding-top: ${unit(marginPadding.top || 0)};
+      padding-left: ${unit(marginPadding.left || 0)};
+      padding-right: ${unit(marginPadding.right || 0)};
+      padding-bottom: ${unit(marginPadding.bottom || 0)};
+      /* stylelint-enable declaration-block-no-redundant-longhand-properties */
+    `
+  }
 }
 
-export const marginMixin = css<{ margin?: MarginPadding }>`
-  ${({ margin }) => formatMarginPadding(margin, 'margin')}
-`
+export interface MarginMixinProps {
+  margin?: MarginPadding
+}
 
-export const paddingMixin = css<{ padding?: MarginPadding }>`
-  ${({ padding }) => formatMarginPadding(padding, 'padding')}
-`
+export const marginMixin = ({ margin }: MarginMixinProps) =>
+  formatMarginPadding(margin, 'margin')
+
+export interface PaddingMixinProps {
+  padding?: MarginPadding
+}
+
+export const paddingMixin = ({ padding }: PaddingMixinProps) =>
+  formatMarginPadding(padding, 'padding')

--- a/packages/tds-ui/src/mixins/max-lines.ts
+++ b/packages/tds-ui/src/mixins/max-lines.ts
@@ -1,10 +1,10 @@
 import { css } from 'styled-components'
 
-interface Params {
+export interface MaxLinesMixinProps {
   maxLines?: number
 }
 
-export const maxLinesMixin = ({ maxLines }: Params) =>
+export const maxLinesMixin = ({ maxLines }: MaxLinesMixinProps) =>
   maxLines
     ? css`
         /* stylelint-disable-next-line value-no-vendor-prefix */

--- a/packages/tds-ui/src/mixins/positioning.ts
+++ b/packages/tds-ui/src/mixins/positioning.ts
@@ -3,18 +3,24 @@ import { css } from 'styled-components'
 import { MarginPadding } from '../commons'
 import { unit } from '../utils/unit'
 
-export const positioningMixin = css<{
+export interface PositioningMixinProps {
   positioning?: MarginPadding
-}>`
-  ${({ positioning }) =>
-    positioning
-      ? (Object.keys(positioning) as Array<keyof MarginPadding>)
-          .map(
-            (key) =>
-              positioning[key] !== undefined &&
-              `${key}: ${unit(positioning[key] as string | number)};`,
-          )
-          .filter(Boolean)
-          .join('\n')
-      : ''}
-`
+}
+
+export const positioningMixin = ({ positioning }: PositioningMixinProps) =>
+  positioning
+    ? css`
+        top: ${positioning.top !== undefined
+          ? unit(positioning.top)
+          : undefined};
+        right: ${positioning.right !== undefined
+          ? unit(positioning.right)
+          : undefined};
+        bottom: ${positioning.bottom !== undefined
+          ? unit(positioning.bottom)
+          : undefined};
+        left: ${positioning.left !== undefined
+          ? unit(positioning.left)
+          : undefined};
+      `
+    : undefined

--- a/packages/tds-ui/src/mixins/safe-area.ts
+++ b/packages/tds-ui/src/mixins/safe-area.ts
@@ -3,14 +3,16 @@ import { css } from 'styled-components'
 import { MarginPadding } from '../commons'
 import { unit } from '../utils/unit'
 
-export const safeAreaInsetMixin = css<{
+export interface SafeAreaInsetMixinProps {
   padding?: MarginPadding
-}>`
-  @supports (padding: env(safe-area-inset-bottom)) {
-    ${({ padding }) => {
-      const paddingBottom = unit(padding?.bottom || 0) || '0px' // HACK: 0 대신 0px로 넣어줘야 calc가 정상작동한다
+}
 
-      return `padding-bottom: calc(env(safe-area-inset-bottom) + ${paddingBottom});`
-    }}
-  }
-`
+export const safeAreaInsetMixin = ({ padding }: SafeAreaInsetMixinProps) => {
+  const paddingBottom = unit(padding?.bottom || '0px')
+
+  return css`
+    @supports (padding: env(safe-area-inset-bottom)) {
+      padding-bottom: calc(env(safe-area-inset-bottom) + ${paddingBottom});
+    }
+  `
+}

--- a/packages/tds-ui/src/mixins/text-style.ts
+++ b/packages/tds-ui/src/mixins/text-style.ts
@@ -2,24 +2,13 @@ import { css } from 'styled-components'
 
 import { GlobalSizes } from '../commons'
 
-const SIZES: { [key in GlobalSizes]: string } = {
-  mini: '12px',
-  tiny: '13px',
-  small: '14px',
-  medium: '15px',
-  large: '16px',
-  big: '19px',
-  huge: '21px',
-  massive: '24px',
-}
-
 /**
  * Create text style css
  * @param fontSize font-size
  * @param lineHeight line-height
  * @param letterSpacing letter-spacing
  */
-export const textStyle = (
+const textStyle = (
   fontSize: number,
   lineHeight: number,
   letterSpacing: number,
@@ -36,12 +25,23 @@ export const textStyle = (
  * @param lineHeight
  * @param letterSpacing
  */
-export const _unsafeTextStyle = (
+const _unsafeTextStyle = (
   fontSize: GlobalSizes | number = 'large',
   lineHeight: number | string = 1.2,
   letterSpacing = 0,
 ) => {
-  const size = typeof fontSize === 'string' ? SIZES[fontSize] : `${fontSize}px`
+  const sizes: { [key in GlobalSizes]: string } = {
+    mini: '12px',
+    tiny: '13px',
+    small: '14px',
+    medium: '15px',
+    large: '16px',
+    big: '19px',
+    huge: '21px',
+    massive: '24px',
+  }
+  const size = typeof fontSize === 'string' ? sizes[fontSize] : `${fontSize}px`
+
   return css`
     font-size: ${size};
     line-height: ${lineHeight};
@@ -49,7 +49,7 @@ export const _unsafeTextStyle = (
   `
 }
 
-export const TextStyleMap = {
+const textStyleMap = {
   /* 가계부 금액 */
   L6: textStyle(36, 47, -0.3),
   /* 서비스메인, 도시메인 타이틀 */
@@ -81,16 +81,15 @@ export const TextStyleMap = {
   /* 부가설명, 일정판 요일 */
   S2: textStyle(12, 22, 0),
 }
-/* eslint-enable @typescript-eslint/naming-convention */
 
 export function getTextStyle(type: KeyOfTextStyleMap) {
-  return TextStyleMap[type]
+  return textStyleMap[type]
 }
 
-export type KeyOfTextStyleMap = keyof typeof TextStyleMap
+export type KeyOfTextStyleMap = keyof typeof textStyleMap
 export type TextStyleMapType = { [key in KeyOfTextStyleMap]: string }
 
-interface Params {
+export interface TextStyleMixinProps {
   textStyle?: KeyOfTextStyleMap
   size?: GlobalSizes | number
   lineHeight?: number | string
@@ -102,7 +101,7 @@ export const textStyleMixin = ({
   size,
   lineHeight,
   letterSpacing,
-}: Params) => {
+}: TextStyleMixinProps) => {
   if (textStyle && (size || lineHeight || letterSpacing)) {
     // TODO: development 환경에서만 기록하는 logger 만들기
     // eslint-disable-next-line no-console

--- a/packages/tds-ui/src/utils/should-forward-prop.ts
+++ b/packages/tds-ui/src/utils/should-forward-prop.ts
@@ -1,0 +1,15 @@
+import isPropValid from '@emotion/is-prop-valid'
+import { ShouldForwardProp } from 'styled-components'
+
+// styled-components v5의 기본 동작을 구현합니다.
+export const shouldForwardProp: ShouldForwardProp<'web'> = (
+  propName,
+  target,
+) => {
+  if (typeof target === 'string') {
+    // HTML 요소인 경우, 유효한 HTML 속성이면 prop을 전달합니다.
+    return isPropValid(propName)
+  }
+  // 다른 요소들에 대해서는 모든 props를 전달합니다.
+  return true
+}

--- a/packages/tds-widget/src/app-installation-cta/elements.tsx
+++ b/packages/tds-widget/src/app-installation-cta/elements.tsx
@@ -164,6 +164,7 @@ interface FloatingButtonProps {
   visibility: 1 | 0
   fixed?: 1 | 0
   margin?: MarginPadding
+  padding?: MarginPadding
 }
 export const FloatingButtonContainer = styled.div<
   FloatingButtonProps & LayeringMixinProps

--- a/packages/tds-widget/src/directions-finder/ask-to-the-local.tsx
+++ b/packages/tds-widget/src/directions-finder/ask-to-the-local.tsx
@@ -10,9 +10,10 @@ import {
   Text,
   safeAreaInsetMixin,
   Popup,
+  SafeAreaInsetMixinProps,
 } from '@titicaca/tds-ui'
 
-const DrawerContentContainer = styled(Container)`
+const DrawerContentContainer = styled(Container)<SafeAreaInsetMixinProps>`
   ${safeAreaInsetMixin}
 `
 

--- a/packages/tds-widget/src/pricing/fixed-pricing-v2/index.tsx
+++ b/packages/tds-widget/src/pricing/fixed-pricing-v2/index.tsx
@@ -10,6 +10,8 @@ import {
   Skeleton,
   safeAreaInsetMixin,
   paddingMixin,
+  PaddingMixinProps,
+  SafeAreaInsetMixinProps,
 } from '@titicaca/tds-ui'
 import { formatNumber } from '@titicaca/view-utilities'
 
@@ -35,7 +37,9 @@ export interface FixedPricingV2Props {
   emptyOverride?: ReactNode
 }
 
-const FloatedFrame = styled(Container)`
+const FloatedFrame = styled(Container)<
+  PaddingMixinProps & SafeAreaInsetMixinProps
+>`
   border-top: 1px solid #efefef;
   background: #fff;
 

--- a/packages/tds-widget/src/replies/replies.tsx
+++ b/packages/tds-widget/src/replies/replies.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
-import { Container, safeAreaInsetMixin } from '@titicaca/tds-ui'
+import {
+  Container,
+  safeAreaInsetMixin,
+  SafeAreaInsetMixinProps,
+} from '@titicaca/tds-ui'
 import { styled } from 'styled-components'
 
 import { fetchReplies, fetchChildReplies } from './replies-api-client'
@@ -17,7 +21,7 @@ import {
 } from './reply-tree-manipulators'
 import { checkUniqueReply } from './utils'
 
-const FixedBottom = styled(Container).attrs({
+const FixedBottom = styled(Container).attrs<SafeAreaInsetMixinProps>({
   backgroundColor: 'white',
 })`
   position: fixed;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,6 +430,9 @@ importers:
       '@egjs/react-flicking':
         specifier: ^3.8.3
         version: 3.8.3
+      '@emotion/is-prop-valid':
+        specifier: ^1.3.0
+        version: 1.3.0
       '@floating-ui/react':
         specifier: ^0.26.20
         version: 0.26.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1679,11 +1682,17 @@ packages:
   '@emotion/is-prop-valid@1.2.2':
     resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
 
+  '@emotion/is-prop-valid@1.3.0':
+    resolution: {integrity: sha512-SHetuSLvJDzuNbOdtPVbq6yMMMlLoW5Q94uDqJZqy50gcmAjxFkVqmzqSGEFq9gT2iMuIeKV1PXVWmvUhuZLlQ==}
+
   '@emotion/memoize@0.7.4':
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
 
   '@emotion/memoize@0.8.1':
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
 
   '@emotion/unitless@0.8.1':
     resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
@@ -12077,10 +12086,16 @@ snapshots:
     dependencies:
       '@emotion/memoize': 0.8.1
 
+  '@emotion/is-prop-valid@1.3.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+
   '@emotion/memoize@0.7.4':
     optional: true
 
   '@emotion/memoize@0.8.1': {}
+
+  '@emotion/memoize@0.9.0': {}
 
   '@emotion/unitless@0.8.1': {}
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

styled-components 6 버전으로 올리면서 shouldForwardProp이 기본적으로 제거되었습니다. transient prop을 사용하지 않는 컴포넌트에서 발생하는 warning을 제거합니다. 
모듈로 export되는 styled-components에 shouldForwardProp을 추가해서 prop 이름 변경 없이 warning을 제거할 수 있게 합니다.
내부적으로만 사용되는 styled 컴포넌트는 추후에 transient prop으로 변경할 예정입니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- @emotion/is-prop-valid 추가
- shouldForwardProp util 추가
- mixin type safety 개선 
	- () => css 타입으로 통일 (layeringMixin 제외)
	- export mixin props
	- css 하이라이팅 잘 되도록 css 개선
- 모듈로 export되는 styled components에 shouldForwardProp 추가
- mixin 타입 에러 수정


## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->

chromatic diff 없음