### PR TITLE
 [react-contexts] images-api v2 적용

### DIFF
--- a/packages/react-contexts/src/images-context/index.tsx
+++ b/packages/react-contexts/src/images-context/index.tsx
@@ -12,7 +12,7 @@ import {
 import qs from 'qs'
 import { ImageMeta } from '@titicaca/type-definitions'
 import { DeepPartial } from 'utility-types'
-import { get } from '@titicaca/fetcher'
+import { captureHttpError, get } from '@titicaca/fetcher'
 
 import reducer, {
   loadImagesRequest,
@@ -280,7 +280,8 @@ async function fetchPoiImages(
     const { parsedBody } = response
     return parsedBody
   } else {
-    throw new Error(`Failed to fetch poi images ${response.parsedBody.message}`)
+    captureHttpError(response)
+    return { data: [], total: 0 }
   }
 }
 
@@ -304,9 +305,8 @@ async function fetchPoiReviewImages(
     const { parsedBody } = response
     return parsedBody
   } else {
-    throw new Error(
-      `Failed to fetch poi review images: ${response.parsedBody.message}`,
-    )
+    captureHttpError(response)
+    return { data: [], total: 0 }
   }
 }
 

--- a/packages/react-contexts/src/images-context/index.tsx
+++ b/packages/react-contexts/src/images-context/index.tsx
@@ -52,12 +52,6 @@ const Context = createContext<ImagesContext>({
   },
 })
 
-const TYPE_MAPPING = {
-  attraction: 'poi',
-  restaurant: 'poi',
-  hotel: 'hotel',
-}
-
 export function ImagesProvider({
   images: defaultImages,
   total: initialTotal,
@@ -83,7 +77,7 @@ export function ImagesProvider({
   const sendFetchRequest = useCallback(
     async (size = 15) => {
       const response = await fetchImages({
-        target: { type: TYPE_MAPPING[type] || type, id },
+        target: { type, id },
         currentImageLength: images.length - (defaultImages?.length || 0),
         size,
         categoryOrder,
@@ -107,7 +101,7 @@ export function ImagesProvider({
         total,
         next,
       } = await fetchImages({
-        target: { type: TYPE_MAPPING[type] || type, id },
+        target: { type, id },
         currentImageLength: 0,
         size: 15,
         categoryOrder,

--- a/packages/react-contexts/src/images-context/index.tsx
+++ b/packages/react-contexts/src/images-context/index.tsx
@@ -264,8 +264,8 @@ async function fetchPoiImages(
   query: { from: number; size: number; categoryOrder: string },
 ) {
   const querystring = qs.stringify({
-    resourceType: target.type,
-    resourceId: target.id,
+    resource_type: target.type,
+    resource_id: target.id,
     from: query.from,
     size: query.size,
     category_order: query.categoryOrder,
@@ -290,8 +290,8 @@ async function fetchPoiReviewImages(
   query: { from: number; size: number; categoryOrder: string },
 ) {
   const querystring = qs.stringify({
-    resourceType: target.type,
-    resourceId: target.id,
+    resource_type: target.type,
+    resource_id: target.id,
     from: query.from,
     size: query.size,
     category_order: query.categoryOrder,

--- a/packages/react-contexts/src/images-context/index.tsx
+++ b/packages/react-contexts/src/images-context/index.tsx
@@ -93,7 +93,7 @@ export function ImagesProvider({
     async (size = 15) => {
       const response = await fetchImages({
         target: { type: TYPE_MAPPING[type] || type, id },
-        currentImageLength: images.length,
+        currentImageLength: images.length - (initialImages?.length || 0),
         size,
         categoryOrder,
       })

--- a/packages/react-contexts/src/images-context/index.tsx
+++ b/packages/react-contexts/src/images-context/index.tsx
@@ -7,12 +7,9 @@ import {
   ComponentType,
   useReducer,
   useEffect,
-  useState,
 } from 'react'
-import qs from 'qs'
 import { ImageMeta } from '@titicaca/type-definitions'
 import { DeepPartial } from 'utility-types'
-import { captureHttpError, get } from '@titicaca/fetcher'
 
 import reducer, {
   loadImagesRequest,
@@ -20,6 +17,8 @@ import reducer, {
   loadImagesFail,
   reinitializeImages,
 } from './reducer'
+import { ImageCategoryOrder } from './types'
+import useFetchImages from './use-fetch-images'
 
 interface ImagesContext {
   images: ImageMeta[]
@@ -31,14 +30,6 @@ interface ImagesContext {
     indexOf: (target: { id: string }) => Promise<number>
   }
 }
-
-export type ImageCategoryOrder =
-  | 'image' // 대표 이미지
-  | 'recommendation'
-  | 'menuItem' // 대표 메뉴 이미지
-  | 'menuBoard' // 메뉴판 이미지
-  | 'featuredContent'
-  | 'images' // 어드민에 등록된 이미지들 가운데 대표 이미지를 제외한 나머지 이미지
 
 interface ImagesProviderProps {
   source: {
@@ -139,12 +130,7 @@ export function ImagesProvider({
 
       try {
         const { data: fetchedImages, total } = await sendFetchRequest()
-
-        if (fetchedImages) {
-          dispatch(loadImagesSuccess({ images: fetchedImages, total }))
-        } else {
-          throw new Error('Response has no data property')
-        }
+        dispatch(loadImagesSuccess({ images: fetchedImages, total }))
       } catch (error) {
         dispatch(loadImagesFail(error))
       }
@@ -191,119 +177,6 @@ export function ImagesProvider({
   )
 
   return <Context.Provider value={value}>{children}</Context.Provider>
-}
-
-function useFetchImages() {
-  const [totalPoiImagesCount, setTotalPoiImagesCount] = useState(0)
-  const [totalPoiReviewImagesCount, setTotalPoiReviewImagesCount] = useState(0)
-
-  async function fetchImages({
-    target,
-    currentImageLength,
-    size,
-    categoryOrder: categoryOrderArray,
-  }: {
-    target: { type: string; id: string }
-    currentImageLength: number
-    size: number
-    categoryOrder: Array<ImageCategoryOrder>
-  }) {
-    const categoryOrder = categoryOrderArray.join(',')
-    if (currentImageLength === 0) {
-      const poiResponse = await fetchPoiImages(target, {
-        from: currentImageLength,
-        size,
-        categoryOrder,
-      })
-      const poiReviewsResponse = await fetchPoiReviewImages(target, {
-        from: currentImageLength - totalPoiImagesCount,
-        size,
-        categoryOrder,
-      })
-      setTotalPoiImagesCount(poiResponse.total)
-      setTotalPoiReviewImagesCount(poiReviewsResponse.total)
-      return {
-        ...poiResponse,
-        total: poiResponse.total + poiReviewsResponse.total,
-      }
-    }
-    if (currentImageLength < totalPoiImagesCount) {
-      const response = await fetchPoiImages(target, {
-        from: currentImageLength,
-        size,
-        categoryOrder,
-      })
-      setTotalPoiImagesCount(response.total)
-      const poiReviewsResponse =
-        response.data.length < size
-          ? await fetchPoiReviewImages(target, {
-              from: 0,
-              size: size - response.data.length,
-              categoryOrder,
-            })
-          : { data: [], total: totalPoiReviewImagesCount }
-      return {
-        data: [...response.data, ...poiReviewsResponse.data],
-        total: response.total + poiReviewsResponse.total,
-      }
-    }
-    const response = await fetchPoiReviewImages(target, {
-      from: currentImageLength - totalPoiImagesCount,
-      size,
-      categoryOrder,
-    })
-    setTotalPoiReviewImagesCount(response.total)
-    return { ...response, total: response.total + totalPoiImagesCount }
-  }
-
-  return fetchImages
-}
-
-async function sendFetchImages(
-  target: { type: string; id: string },
-  query: { from: number; size: number; categoryOrder: string },
-  endpoint: 'content' | 'reviews',
-) {
-  const querystring = qs.stringify({
-    resource_type: target.type,
-    resource_id: target.id,
-    from: query.from,
-    size: query.size,
-    category_order: query.categoryOrder,
-  })
-
-  const response = await get<
-    {
-      data: ImageMeta[]
-      total: number
-      next: string | null
-      prev: string | null
-      count: number
-    },
-    { message: string }
-  >(`/api/${endpoint}/v2/images?${querystring}`)
-
-  if (response.ok === true) {
-    const { parsedBody } = response
-    return parsedBody
-  } else {
-    captureHttpError(response)
-    throw new Error(`Fail to fetch ${endpoint} images`)
-  }
-}
-
-async function fetchPoiImages(
-  target: { type: string; id: string },
-  query: { from: number; size: number; categoryOrder: string },
-) {
-  return sendFetchImages(target, query, 'content')
-}
-
-async function fetchPoiReviewImages(
-  target: { type: string; id: string },
-  query: { from: number; size: number; categoryOrder: string },
-) {
-  return sendFetchImages(target, query, 'reviews')
 }
 
 export function useImagesContext() {

--- a/packages/react-contexts/src/images-context/index.tsx
+++ b/packages/react-contexts/src/images-context/index.tsx
@@ -7,6 +7,7 @@ import {
   ComponentType,
   useReducer,
   useEffect,
+  useState,
 } from 'react'
 import qs from 'qs'
 import { ImageMeta } from '@titicaca/type-definitions'
@@ -31,11 +32,20 @@ interface ImagesContext {
   }
 }
 
+export type ImageCategoryOrder =
+  | 'image' // 대표 이미지
+  | 'recommendation'
+  | 'menuItem' // 대표 메뉴 이미지
+  | 'menuBoard' // 메뉴판 이미지
+  | 'featuredContent'
+  | 'images' // 어드민에 등록된 이미지들 가운데 대표 이미지를 제외한 나머지 이미지
+
 interface ImagesProviderProps {
   source: {
     id: string
     type: 'attraction' | 'restaurant' | 'hotel'
   }
+  categoryOrder?: Array<ImageCategoryOrder>
   images?: ImageMeta[]
   total?: number
 }
@@ -60,6 +70,13 @@ const TYPE_MAPPING = {
 export function ImagesProvider({
   images: initialImages,
   total: initialTotal,
+  categoryOrder = [
+    'recommendation',
+    'menuBoard',
+    'menuItem',
+    'featuredContent',
+    'images',
+  ],
   source: { id, type },
   children,
 }: PropsWithChildren<ImagesProviderProps>) {
@@ -70,12 +87,16 @@ export function ImagesProvider({
     hasMore: true,
   })
 
+  const fetchImages = useFetchImages()
+
   const sendFetchRequest = useCallback(
     async (size = 15) => {
-      const response = await fetchImages(
-        { type: TYPE_MAPPING[type] || type, id },
-        { from: images.length, size },
-      )
+      const response = await fetchImages({
+        target: { type: TYPE_MAPPING[type] || type, id },
+        currentImageLength: images.length,
+        size,
+        categoryOrder,
+      })
 
       return response
     },
@@ -90,10 +111,12 @@ export function ImagesProvider({
     dispatch(loadImagesRequest())
 
     try {
-      const { data: fetchedImages, total } = await fetchImages(
-        { type: TYPE_MAPPING[type] || type, id },
-        { from: 0, size: 15 },
-      )
+      const { data: fetchedImages, total } = await fetchImages({
+        target: { type: TYPE_MAPPING[type] || type, id },
+        currentImageLength: 0,
+        size: 15,
+        categoryOrder,
+      })
 
       dispatch(
         reinitializeImages({
@@ -170,26 +193,120 @@ export function ImagesProvider({
   return <Context.Provider value={value}>{children}</Context.Provider>
 }
 
-async function fetchImages(
+function useFetchImages() {
+  const [totalPoiImagesCount, setTotalPoiImagesCount] = useState(0)
+  const [totalPoiReviewImagesCount, setTotalPoiReviewImagesCount] = useState(0)
+
+  async function fetchImages({
+    target,
+    currentImageLength,
+    size,
+    categoryOrder: categoryOrderArray,
+  }: {
+    target: { type: string; id: string }
+    currentImageLength: number
+    size: number
+    categoryOrder: Array<ImageCategoryOrder>
+  }) {
+    const categoryOrder = categoryOrderArray.join(',')
+    if (currentImageLength === 0) {
+      const poiResponse = await fetchPoiImages(target, {
+        from: currentImageLength,
+        size,
+        categoryOrder,
+      })
+      const poiReviewsResponse = await fetchPoiReviewImages(target, {
+        from: currentImageLength - totalPoiImagesCount,
+        size,
+        categoryOrder,
+      })
+      setTotalPoiImagesCount(poiResponse.total)
+      setTotalPoiReviewImagesCount(poiReviewsResponse.total)
+      return {
+        ...poiResponse,
+        total: poiResponse.total + poiReviewsResponse.total,
+      }
+    }
+    if (currentImageLength < totalPoiImagesCount) {
+      const response = await fetchPoiImages(target, {
+        from: currentImageLength,
+        size,
+        categoryOrder,
+      })
+      setTotalPoiImagesCount(response.total)
+      const poiReviewsResponse =
+        response.data.length < size
+          ? await fetchPoiReviewImages(target, {
+              from: 0,
+              size: size - response.data.length,
+              categoryOrder,
+            })
+          : { data: [], total: totalPoiReviewImagesCount }
+      return {
+        data: [...response.data, ...poiReviewsResponse.data],
+        total: response.total + poiReviewsResponse.total,
+      }
+    }
+    const response = await fetchPoiReviewImages(target, {
+      from: currentImageLength - totalPoiImagesCount,
+      size,
+      categoryOrder,
+    })
+    setTotalPoiReviewImagesCount(response.total)
+    return { ...response, total: response.total + totalPoiImagesCount }
+  }
+
+  return fetchImages
+}
+
+async function fetchPoiImages(
   target: { type: string; id: string },
-  query: { from: number; size: number },
+  query: { from: number; size: number; categoryOrder: string },
 ) {
   const querystring = qs.stringify({
     resourceType: target.type,
     resourceId: target.id,
     from: query.from,
     size: query.size,
+    category_order: query.categoryOrder,
   })
 
-  const response = await get<{ data: ImageMeta[]; total: number }>(
-    `/api/content/images?${querystring}`,
-  )
+  const response = await get<
+    { data: ImageMeta[]; total: number },
+    { message: string }
+  >(`/api/content/v2/images?${querystring}`)
 
   if (response.ok === true) {
     const { parsedBody } = response
     return parsedBody
   } else {
-    throw new Error(`Failed to fetch images`)
+    throw new Error(`Failed to fetch poi images ${response.parsedBody.message}`)
+  }
+}
+
+async function fetchPoiReviewImages(
+  target: { type: string; id: string },
+  query: { from: number; size: number; categoryOrder: string },
+) {
+  const querystring = qs.stringify({
+    resourceType: target.type,
+    resourceId: target.id,
+    from: query.from,
+    size: query.size,
+    category_order: query.categoryOrder,
+  })
+  const response = await get<
+    { data: ImageMeta[]; total: number },
+    { message: string }
+  >(`/api/reviews/v2/images?${querystring}`)
+
+  if (response.ok === true) {
+    const { parsedBody } = response
+    return parsedBody
+  } else {
+    throw new Error(
+      `Failed to fetch poi review images: ${response.parsedBody.message}`,
+    )
   }
 }
 

--- a/packages/react-contexts/src/images-context/reducer.ts
+++ b/packages/react-contexts/src/images-context/reducer.ts
@@ -21,6 +21,7 @@ export function loadImagesRequest() {
 export function loadImagesSuccess(payload: {
   images: ImageMeta[]
   total: number
+  hasMore: boolean
 }) {
   return {
     type: LOAD_IMAGES_SUCCESS,
@@ -39,6 +40,7 @@ export function loadImagesFail(error: unknown) {
 export function reinitializeImages(payload: {
   images: ImageMeta[]
   total: number
+  hasMore: boolean
 }) {
   return {
     type: REINITIALIZE_IMAGES,
@@ -61,7 +63,7 @@ export default function reducer(
         loading: !action.payload.images,
         images: action.payload.images,
         total: action.payload.total,
-        hasMore: true,
+        hasMore: action.payload.hasMore,
       }
     case LOAD_IMAGES_REQUEST:
       return {
@@ -73,7 +75,7 @@ export default function reducer(
         loading: false,
         images: state.images.concat(action.payload.images),
         total: action.payload.total,
-        hasMore: action.payload.images.length > 0,
+        hasMore: action.payload.hasMore,
       }
     case LOAD_IMAGES_FAIL:
       return {

--- a/packages/react-contexts/src/images-context/types.ts
+++ b/packages/react-contexts/src/images-context/types.ts
@@ -1,0 +1,7 @@
+export type ImageCategoryOrder =
+  | 'image' // 대표 이미지
+  | 'recommendation'
+  | 'menuItem' // 대표 메뉴 이미지
+  | 'menuBoard' // 메뉴판 이미지
+  | 'featuredContent'
+  | 'images' // 어드민에 등록된 이미지들 가운데 대표 이미지를 제외한 나머지 이미지

--- a/packages/react-contexts/src/images-context/use-fetch-images.tsx
+++ b/packages/react-contexts/src/images-context/use-fetch-images.tsx
@@ -56,6 +56,7 @@ export default function useFetchImages() {
             })
           : { data: [], total: totalPoiReviewImagesCount }
       return {
+        ...response,
         data: [...response.data, ...poiReviewsResponse.data],
         total: response.total + poiReviewsResponse.total,
       }

--- a/packages/react-contexts/src/images-context/use-fetch-images.tsx
+++ b/packages/react-contexts/src/images-context/use-fetch-images.tsx
@@ -38,6 +38,7 @@ export default function useFetchImages() {
       return {
         ...poiResponse,
         total: poiResponse.total + poiReviewsResponse.total,
+        next: poiResponse.next || poiReviewsResponse.next,
       }
     }
     if (currentImageLength < totalContentImagesCount) {

--- a/packages/react-contexts/src/images-context/use-fetch-images.tsx
+++ b/packages/react-contexts/src/images-context/use-fetch-images.tsx
@@ -40,7 +40,6 @@ export default function useFetchImages() {
           ? await fetchPoiReviewImages(target, {
               from: 0,
               size: needReviewImages ? size - response.data.length : 1, // 1은 첫 fetch에 review image total을 알아오기 위함
-              categoryOrder,
             })
           : { data: [], next: null, total: 0 }
 
@@ -60,7 +59,6 @@ export default function useFetchImages() {
     const response = await fetchPoiReviewImages(target, {
       from: currentImageLength - totalContentImagesCount,
       size,
-      categoryOrder,
     })
     setTotalPoiReviewImagesCount(response.total)
     return {
@@ -73,19 +71,11 @@ export default function useFetchImages() {
   return fetchImages
 }
 
+/** API 문서 : https://inpk.atlassian.net/wiki/spaces/dev/pages/480903530/API */
 async function sendFetchImages(
-  target: { type: string; id: string },
-  query: { from: number; size: number; categoryOrder: string },
+  querystring: string,
   endpoint: 'content' | 'reviews',
 ) {
-  const querystring = qs.stringify({
-    resource_type: target.type,
-    resource_id: target.id,
-    from: query.from,
-    size: query.size,
-    category_order: query.categoryOrder,
-  })
-
   const response = await get<
     {
       data: ImageMeta[]
@@ -110,12 +100,24 @@ async function fetchContentImages(
   target: { type: string; id: string },
   query: { from: number; size: number; categoryOrder: string },
 ) {
-  return sendFetchImages(target, query, 'content')
+  const querystring = qs.stringify({
+    resource_type: target.type,
+    resource_id: target.id,
+    from: query.from,
+    size: query.size,
+    category_order: query.categoryOrder,
+  })
+  return sendFetchImages(querystring, 'content')
 }
 
 async function fetchPoiReviewImages(
-  target: { type: string; id: string },
-  query: { from: number; size: number; categoryOrder: string },
+  target: { id: string },
+  query: { from: number; size: number },
 ) {
-  return sendFetchImages(target, query, 'reviews')
+  const querystring = qs.stringify({
+    resource_id: target.id,
+    from: query.from,
+    size: query.size,
+  })
+  return sendFetchImages(querystring, 'reviews')
 }

--- a/packages/react-contexts/src/images-context/use-fetch-images.tsx
+++ b/packages/react-contexts/src/images-context/use-fetch-images.tsx
@@ -1,0 +1,120 @@
+import qs from 'querystring'
+
+import { useState } from 'react'
+import { ImageMeta } from '@titicaca/type-definitions'
+import { captureHttpError, get } from '@titicaca/fetcher'
+
+import { ImageCategoryOrder } from './types'
+
+export default function useFetchImages() {
+  const [totalContentImagesCount, setTotalContentImagesCount] = useState(0)
+  const [totalPoiReviewImagesCount, setTotalPoiReviewImagesCount] = useState(0)
+
+  async function fetchImages({
+    target,
+    currentImageLength,
+    size,
+    categoryOrder: categoryOrderArray,
+  }: {
+    target: { type: string; id: string }
+    currentImageLength: number
+    size: number
+    categoryOrder: Array<ImageCategoryOrder>
+  }) {
+    const categoryOrder = categoryOrderArray.join(',')
+    if (currentImageLength === 0) {
+      const poiResponse = await fetchContentImages(target, {
+        from: currentImageLength,
+        size,
+        categoryOrder,
+      })
+      const poiReviewsResponse = await fetchPoiReviewImages(target, {
+        from: currentImageLength - totalContentImagesCount,
+        size,
+        categoryOrder,
+      })
+      setTotalContentImagesCount(poiResponse.total)
+      setTotalPoiReviewImagesCount(poiReviewsResponse.total)
+      return {
+        ...poiResponse,
+        total: poiResponse.total + poiReviewsResponse.total,
+      }
+    }
+    if (currentImageLength < totalContentImagesCount) {
+      const response = await fetchContentImages(target, {
+        from: currentImageLength,
+        size,
+        categoryOrder,
+      })
+      setTotalContentImagesCount(response.total)
+      const poiReviewsResponse =
+        response.data.length < size
+          ? await fetchPoiReviewImages(target, {
+              from: 0,
+              size: size - response.data.length,
+              categoryOrder,
+            })
+          : { data: [], total: totalPoiReviewImagesCount }
+      return {
+        data: [...response.data, ...poiReviewsResponse.data],
+        total: response.total + poiReviewsResponse.total,
+      }
+    }
+    const response = await fetchPoiReviewImages(target, {
+      from: currentImageLength - totalContentImagesCount,
+      size,
+      categoryOrder,
+    })
+    setTotalPoiReviewImagesCount(response.total)
+    return { ...response, total: response.total + totalContentImagesCount }
+  }
+
+  return fetchImages
+}
+
+async function sendFetchImages(
+  target: { type: string; id: string },
+  query: { from: number; size: number; categoryOrder: string },
+  endpoint: 'content' | 'reviews',
+) {
+  const querystring = qs.stringify({
+    resource_type: target.type,
+    resource_id: target.id,
+    from: query.from,
+    size: query.size,
+    category_order: query.categoryOrder,
+  })
+
+  const response = await get<
+    {
+      data: ImageMeta[]
+      total: number
+      next: string | null
+      prev: string | null
+      count: number
+    },
+    { message: string }
+  >(`/api/${endpoint}/v2/images?${querystring}`)
+
+  if (response.ok === true) {
+    const { parsedBody } = response
+    return parsedBody
+  } else {
+    captureHttpError(response)
+    throw new Error(`Fail to fetch ${endpoint} images`)
+  }
+}
+
+async function fetchContentImages(
+  target: { type: string; id: string },
+  query: { from: number; size: number; categoryOrder: string },
+) {
+  return sendFetchImages(target, query, 'content')
+}
+
+async function fetchPoiReviewImages(
+  target: { type: string; id: string },
+  query: { from: number; size: number; categoryOrder: string },
+) {
+  return sendFetchImages(target, query, 'reviews')
+}

--- a/packages/react-contexts/src/images-context/use-fetch-images.tsx
+++ b/packages/react-contexts/src/images-context/use-fetch-images.tsx
@@ -30,7 +30,7 @@ export default function useFetchImages() {
       })
       const poiReviewsResponse = await fetchPoiReviewImages(target, {
         from: currentImageLength - totalContentImagesCount,
-        size,
+        size: 1,
         categoryOrder,
       })
       setTotalContentImagesCount(poiResponse.total)

--- a/packages/react-contexts/src/images-context/use-fetch-images.tsx
+++ b/packages/react-contexts/src/images-context/use-fetch-images.tsx
@@ -54,11 +54,15 @@ export default function useFetchImages() {
               size: size - response.data.length,
               categoryOrder,
             })
-          : { data: [], total: totalPoiReviewImagesCount }
+          : { data: [], total: totalPoiReviewImagesCount, next: null }
       return {
         ...response,
         data: [...response.data, ...poiReviewsResponse.data],
         total: response.total + poiReviewsResponse.total,
+        next:
+          poiReviewsResponse.data.length > 0
+            ? poiReviewsResponse.next
+            : response.next,
       }
     }
     const response = await fetchPoiReviewImages(target, {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
images-api v2를 `ImagesContext`에 적용합니다. v2에서는 컨텐츠 이미지 API와 리뷰 이미지 API가 분리됨에 따라 상황에 맞게 엔드포인트를 설정해 fetch 합니다. [API 문서](https://inpk.atlassian.net/wiki/spaces/dev/pages/480903530/API)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- `defaultImages` 설정
  - 현재 대부분의 사용부에서는 `ImagesProvider`의 `images` prop에 대표 이미지를 넣어주고 있습니다. 기존에는 API에 `categoryOrder` 쿼리가 없었기 때문에 모든 카테고리의 이미지를 불러왔었습니다. 따라서 `ImagesProvider`에 대표 이미지를 `images`에 넣어주어도 provider 내에서 실행되는 fetch의 응답에 포함되는 것을 막을 방법이 없었습니다. 하지만 V2에서는 `categoryOrder`을 설정할 수 있게 되었습니다. 따라서 기존 사용부의 코드를 변경하지 않으며 대표 이미지는 다시 fetch 하지 않을 수 있도록 기본 `categoryOrder`에는 대표 이미지를 제외하였습니다. 
- `useFetchImages` hook 분리
  - 데이터를 fetch해오는 부분을 hook으로 분리하여 이미지를 다루는 부분과 fetch하는 부분의 관심사를 나누었습니다. 따라서 Provider 내부에서는 fetch end point를 신경 쓸 필요 없이 `fetchImages` 함수를 사용하면 됩니다. 
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
