### PR TITLE
RecommendedArticles의 carousel이 circular하지 않도록 수정

### DIFF
--- a/packages/tds-ui/src/components/carousel/flicking-carousel-content.tsx
+++ b/packages/tds-ui/src/components/carousel/flicking-carousel-content.tsx
@@ -12,29 +12,10 @@ const FlickingContainer = styled.div`
 `
 
 const FLICKING_OPTIONS: Partial<FlickingOptions> = {
-  deceleration: 0.0075,
-  horizontal: true,
   circular: true,
-  infinite: false,
-  infiniteThreshold: 0,
-  lastIndex: Infinity,
-  threshold: 40,
-  duration: 100,
-  panelEffect: (x: number) => 1 - Math.pow(1 - x, 3),
-  defaultIndex: 0,
-  thresholdAngle: 45,
-  bounce: 10,
-  autoResize: false,
-  adaptive: false,
-  bound: false,
-  overflow: false,
-  hanger: '50%',
-  anchor: '50%',
   gap: 10,
-  moveType: { type: 'snap', count: 1 },
   collectStatistics: false,
   zIndex: 1,
-  classPrefix: 'eg-flick',
 }
 
 export function FlickingCarouselContent({
@@ -43,8 +24,10 @@ export function FlickingCarouselContent({
   const { flickingRef, options, handleMoveStart, handleMove, handleMoveEnd } =
     useFlickingCarousel()
 
-  const flickingOptions =
-    Object.keys(options).length === 0 ? FLICKING_OPTIONS : options
+  const mergedOptions = {
+    ...FLICKING_OPTIONS,
+    ...options,
+  }
 
   return (
     <FlickingContainer>
@@ -53,7 +36,7 @@ export function FlickingCarouselContent({
         onMoveStart={handleMoveStart}
         onMove={handleMove}
         onMoveEnd={handleMoveEnd}
-        {...flickingOptions}
+        {...mergedOptions}
       >
         {children}
       </Flicking>

--- a/packages/tds-ui/src/components/carousel/flicking-carousel.stories.tsx
+++ b/packages/tds-ui/src/components/carousel/flicking-carousel.stories.tsx
@@ -38,8 +38,8 @@ export default meta
 type Story = StoryObj<typeof FlickingCarousel>
 
 export const Default: Story = {
-  args: {
-    children: (
+  render: () => (
+    <FlickingCarousel>
       <FlickingCarousel.Content>
         {IMAGES.map((image, key) => (
           <img
@@ -51,101 +51,87 @@ export const Default: Story = {
           />
         ))}
       </FlickingCarousel.Content>
-    ),
-  },
+    </FlickingCarousel>
+  ),
 }
 
 export const PageLabel: Story = {
-  args: {
-    children: (
-      <>
-        <FlickingCarousel.PageLabel
-          labelElement={
-            <Text color="red" bold>
-              10
-            </Text>
-          }
-        />
-
-        <FlickingCarousel.Content>
-          {IMAGES.map((image, key) => (
-            <FlickingCarousel.Item key={key} size="large">
-              <img
-                src={image.sizes.large.url}
-                alt="test"
-                width={400}
-                height={400}
-              />
-            </FlickingCarousel.Item>
-          ))}
-        </FlickingCarousel.Content>
-      </>
-    ),
-  },
+  render: () => (
+    <FlickingCarousel>
+      <FlickingCarousel.PageLabel labelElement={<Text>10</Text>} />
+      <FlickingCarousel.Content>
+        {IMAGES.map((image, key) => (
+          <img
+            key={key}
+            src={image.sizes.large.url}
+            alt="test"
+            width={400}
+            height={400}
+          />
+        ))}
+      </FlickingCarousel.Content>
+    </FlickingCarousel>
+  ),
 }
 
 export const ArrowControl: Story = {
-  args: {
-    children: (
-      <>
-        <FlickingCarousel.Controls
-          onPrevClick={() => {}}
-          onNextClick={() => {}}
-        />
-        <FlickingCarousel.Content>
-          {IMAGES.map((image, key) => (
-            <FlickingCarousel.Item key={key} size="large">
-              <img
-                key={key}
-                src={image.sizes.large.url}
-                alt="test"
-                width={400}
-                height={400}
-              />
-            </FlickingCarousel.Item>
-          ))}
-        </FlickingCarousel.Content>
-      </>
-    ),
-  },
+  render: () => (
+    <FlickingCarousel>
+      <FlickingCarousel.Content>
+        {IMAGES.map((image, key) => (
+          <FlickingCarousel.Item key={key} size="large">
+            <img
+              key={key}
+              src={image.sizes.large.url}
+              alt="test"
+              width={400}
+              height={400}
+            />
+          </FlickingCarousel.Item>
+        ))}
+      </FlickingCarousel.Content>
+      <FlickingCarousel.Controls
+        onPrevClick={() => {}}
+        onNextClick={() => {}}
+      />
+    </FlickingCarousel>
+  ),
 }
 
 export const CustomArrowControl: Story = {
-  args: {
-    children: (
-      <>
-        <FlickingCarousel.Controls
-          prevButton={
-            <FlickingScrollButton direction="left">
-              <Text color="blue" bold>
-                Prev
-              </Text>
-            </FlickingScrollButton>
-          }
-          nextButton={
-            <FlickingScrollButton direction="right">
-              <Text color="blue" bold>
-                Next
-              </Text>
-            </FlickingScrollButton>
-          }
-          onPrevClick={() => {}}
-          onNextClick={() => {}}
-        />
-        <FlickingCarousel.Content>
-          {IMAGES.map((image, key) => (
-            <FlickingCarousel.Item key={key} size="large">
-              <img
-                key={key}
-                src={image.sizes.large.url}
-                alt="test"
-                width={400}
-                height={400}
-              />
-            </FlickingCarousel.Item>
-          ))}
-        </FlickingCarousel.Content>
-      </>
-    ),
-  },
+  render: () => (
+    <FlickingCarousel>
+      <FlickingCarousel.Content>
+        {IMAGES.map((image, key) => (
+          <FlickingCarousel.Item key={key} size="large">
+            <img
+              key={key}
+              src={image.sizes.large.url}
+              alt="test"
+              width={400}
+              height={400}
+            />
+          </FlickingCarousel.Item>
+        ))}
+      </FlickingCarousel.Content>
+      <FlickingCarousel.Controls
+        prevButton={
+          <FlickingScrollButton direction="left">
+            <Text color="blue" bold>
+              Prev
+            </Text>
+          </FlickingScrollButton>
+        }
+        nextButton={
+          <FlickingScrollButton direction="right">
+            <Text color="blue" bold>
+              Next
+            </Text>
+          </FlickingScrollButton>
+        }
+        onPrevClick={() => {}}
+        onNextClick={() => {}}
+      />
+    </FlickingCarousel>
+  ),
 }

--- a/packages/tds-widget/src/poi-detail/recommended-articles/recommended-articles.tsx
+++ b/packages/tds-widget/src/poi-detail/recommended-articles/recommended-articles.tsx
@@ -143,6 +143,12 @@ export function PoiDetailRecommendedArticles({
         </H1>
 
         <FlickingCarousel
+          options={{
+            circular: false,
+            bound: true,
+            hanger: 0,
+            anchor: 0,
+          }}
           css={{
             marginTop: 20,
             paddingLeft: deskTopPadding?.left || 110,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

RecommendedArticles의 carousel이 circular하지 않도록 수정

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- FlickingCarousel의 options가 기본값에 merge될 수 있도록 수정
- RecommendedArticles의 carousel이 circular하지 않도록 수정
	- 캐러셀에 아이템 개수가 적어도 arrow가 표시되는건 egjs/flicking 3 버전이 arrow 지원이 안좋아서 이건 감안해야 할 것 같습니다. 넘길 게 있을 때만 arrow 보여주려면 4 업데이트나 다른 라이브러리 교체 수준 작업이 필요할 것 같습니다.

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->

<img width="739" alt="image" src="https://github.com/user-attachments/assets/4ed8ca8f-0daf-4b37-8b2b-fa27ecf6bf2d">
