### PR TITLE
[v14] POI 대표 이미지 오류 수정

### DIFF
--- a/packages/tds-widget/src/image-carousel/video-content.tsx
+++ b/packages/tds-widget/src/image-carousel/video-content.tsx
@@ -98,7 +98,8 @@ export function VideoContent({
   const clientApp = useClientApp()
 
   const [videoAutoplay, setVideoAutoPlay] = useState(
-    clientApp?.device.autoplay === 'always' ||
+    !clientApp ||
+      clientApp?.device.autoplay === 'always' ||
       (clientApp?.device.autoplay === 'wifi_only' &&
         clientApp?.device.networkType === 'wifi'),
   )

--- a/packages/tds-widget/src/location-properties/location-properties.tsx
+++ b/packages/tds-widget/src/location-properties/location-properties.tsx
@@ -36,7 +36,7 @@ export function LocationProperties({
   extraProperties?: ExtraProperty[]
   onExtraPropertyClick?: (extraProperty: ExtraProperty) => void
   onCopy: (value: string) => void
-} & Parameters<typeof Segment>['0']) {
+} & Omit<Parameters<typeof Segment>['0'], 'onCopy'>) {
   const { t } = useTranslation('triple-frontend')
 
   const { uriHash, removeUriHash } = useHashRouter()

--- a/packages/tds-widget/src/poi-detail/image-carousel/carousel.tsx
+++ b/packages/tds-widget/src/poi-detail/image-carousel/carousel.tsx
@@ -170,14 +170,13 @@ export function Carousel({
         >
           <ImageCarousel
             images={visibleImages}
-            displayedTotalCount={totalImagesCount}
             currentPage={currentPage}
-            options={{
-              size: 'large',
-              optimized,
-            }}
+            displayedTotalCount={totalImagesCount}
+            borderRadius={borderRadius}
+            size="large"
             onImageClick={handleImageClick}
             onMoveEnd={handlePageChange}
+            ImageSource={ImageSource}
             showMoreRenderer={CTA}
             optimized={optimized}
           />


### PR DESCRIPTION
## 변경 내역
### 대표 이미지 컴포넌트
- `ImageCarousel`관련 prop type이 수정되었다가 원상복구되었는데, 그 때 원복되지 않은 prop 부분을 원복합니다(이미지 height가 적용되지 않고 있었음).
- PC 웹 환경에서 비디오가 autoplay 되도록 설정합니다.

### 기타 변경
`LocationProperties`의 prop 타입 중 `onCopy`가 html div element의 prop 타입과 중복되어 제대로 추론되지 않는 부분을 수정합니다.
