### PR TITLE
[footer] 푸터에 트리플 코리아 링크를 추가합니다.

### DIFF
--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -8,6 +8,7 @@ import {
   FooterFrame,
 } from './default-footer'
 import { CompanyInfo } from './company-info'
+import { TripleKoreaLink } from './triple-korea-link'
 
 const AWARD_INFO = [
   {
@@ -62,6 +63,7 @@ const AwardFlexBox = styled(FlexBox).attrs({
 
 export function AwardFooter({
   hideAppDownloadButton = false,
+  tripleKoreaLinkVisible = false,
   ...props
 }: AwardFooterProps) {
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
@@ -92,6 +94,8 @@ export function AwardFooter({
           <br /> 상품 거래정보 및 거래등에 대해 책임을 지지 않습니다.
         </Text>
         <Info />
+
+        {tripleKoreaLinkVisible ? <TripleKoreaLink /> : null}
       </Container>
     </FooterFrame>
   )

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -63,7 +63,6 @@ const AwardFlexBox = styled(FlexBox).attrs({
 
 export function AwardFooter({
   hideAppDownloadButton = false,
-  tripleKoreaLinkVisible = false,
   ...props
 }: AwardFooterProps) {
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
@@ -93,20 +92,17 @@ export function AwardFooter({
           &#12828;인터파크트리플은 통신판매중개로서 통신판매의 당사자가 아니며
           <br /> 상품 거래정보 및 거래등에 대해 책임을 지지 않습니다.
         </Text>
-        <Info />
 
-        {tripleKoreaLinkVisible ? <TripleKoreaLink /> : null}
+        <InfoFlexBox>
+          <Container>
+            <LinkGroupBase />
+            <TripleKoreaLink />
+          </Container>
+
+          <AwardGroup />
+        </InfoFlexBox>
       </Container>
     </FooterFrame>
-  )
-}
-
-function Info() {
-  return (
-    <InfoFlexBox>
-      <LinkGroupBase />
-      <AwardGroup />
-    </InfoFlexBox>
   )
 }
 

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -4,6 +4,7 @@ import { Text, Container } from '@titicaca/core-elements'
 
 import { LinkGroup } from './link-group'
 import { CompanyInfo } from './company-info'
+import { TripleKoreaLink } from './triple-korea-link'
 
 export const FooterFrame = styled.footer`
   background-color: rgba(250, 250, 250, 1);
@@ -11,10 +12,12 @@ export const FooterFrame = styled.footer`
 
 export interface DefaultFooterProps {
   hideAppDownloadButton?: boolean
+  hideTripleKoreaLink?: boolean
 }
 
 function DefaultFooter({
   hideAppDownloadButton = false,
+  hideTripleKoreaLink = true,
   ...props
 }: DefaultFooterProps) {
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
@@ -45,6 +48,8 @@ function DefaultFooter({
         </Text>
 
         <LinkGroup />
+
+        {!hideTripleKoreaLink ? <TripleKoreaLink /> : null}
       </Container>
     </FooterFrame>
   )

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -12,12 +12,12 @@ export const FooterFrame = styled.footer`
 
 export interface DefaultFooterProps {
   hideAppDownloadButton?: boolean
-  hideTripleKoreaLink?: boolean
+  tripleKoreaLinkVisible?: boolean
 }
 
 function DefaultFooter({
   hideAppDownloadButton = false,
-  hideTripleKoreaLink = true,
+  tripleKoreaLinkVisible = false,
   ...props
 }: DefaultFooterProps) {
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
@@ -49,7 +49,7 @@ function DefaultFooter({
 
         <LinkGroup />
 
-        {!hideTripleKoreaLink ? <TripleKoreaLink /> : null}
+        {tripleKoreaLinkVisible ? <TripleKoreaLink /> : null}
       </Container>
     </FooterFrame>
   )

--- a/packages/footer/src/triple-korea-link.tsx
+++ b/packages/footer/src/triple-korea-link.tsx
@@ -5,7 +5,6 @@ const Link = styled.a`
   font-size: 10px;
   text-decoration-line: underline;
   cursor: pointer;
-
   margin-top: 20px;
 `
 

--- a/packages/footer/src/triple-korea-link.tsx
+++ b/packages/footer/src/triple-korea-link.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components'
+
+const Link = styled.a`
+  color: var(--color-gray500);
+  font-size: 10px;
+  text-decoration-line: underline;
+  cursor: pointer;
+
+  margin-top: 20px;
+`
+
+export function TripleKoreaLink() {
+  return (
+    <Link href="https://triple.global" target="_blank" rel="noreferrer">
+      TRIPLE Korea for foreign travelers
+    </Link>
+  )
+}

--- a/packages/footer/src/triple-korea-link.tsx
+++ b/packages/footer/src/triple-korea-link.tsx
@@ -12,7 +12,7 @@ const Link = styled.a`
 export function TripleKoreaLink() {
   return (
     <Link href="https://triple.global" target="_blank" rel="noreferrer">
-      TRIPLE Korea for foreign travelers
+      TRIPLE Korea for Foreign Travelers
     </Link>
   )
 }

--- a/packages/footer/src/triple-korea-link.tsx
+++ b/packages/footer/src/triple-korea-link.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 
 const Link = styled.a`
+  display: block;
   color: var(--color-gray500);
   font-size: 10px;
   text-decoration-line: underline;


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[footer] 푸터에 트리플 코리아 링크를 추가합니다. ([관련 스레드](https://interpark.slack.com/archives/C06FLC344Q0/p1725240597158199))
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- 인트로용 AwardFooter에는 트리플 코리아 링크 상시 노출, 이외 DefaultFooter는 props로 노출 여부를 선택할 수 있도록 작성했습니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
