### PR TITLE
[KLZT-103] 리뷰 컴포넌트 렌더링 버그를 수정합니다.

### DIFF
--- a/packages/review/src/components/infinite-list/services.ts
+++ b/packages/review/src/components/infinite-list/services.ts
@@ -34,6 +34,7 @@ export function useInfinitePopularReviews(
         pages: pages.map((item) => item.popularReviews),
       }),
       keepPreviousData: true,
+      refetchOnWindowFocus: false,
     },
   )
 }
@@ -64,6 +65,7 @@ export function useInfiniteLatestReviews(
         pages: pages.map((item) => item.latestReviews),
       }),
       keepPreviousData: true,
+      refetchOnWindowFocus: false,
     },
   )
 }
@@ -94,6 +96,7 @@ export function useInfiniteRatingReviews(
         pages: pages.map((item) => item.ratingReviews),
       }),
       keepPreviousData: true,
+      refetchOnWindowFocus: false,
     },
   )
 }

--- a/packages/review/src/components/reviews-shorten.tsx
+++ b/packages/review/src/components/reviews-shorten.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, useEffect, useMemo } from 'react'
+import { ComponentType, useEffect } from 'react'
 import styled from 'styled-components'
 import { FlexBox, Section, Text } from '@titicaca/core-elements'
 import { LoginCtaModalProvider } from '@titicaca/modals'
@@ -141,31 +141,17 @@ function ReviewsShortenComponent({
   ] as ComponentType<{ value: ShortenReviewValue }>
   const isRatingOption = selectedOption.startsWith('star-rating')
 
-  const value = useMemo(
-    () => ({
-      resourceId,
-      resourceType,
-      regionId,
-      recentTrip: isRecentTrip,
-      hasMedia: isMediaCollection,
-      placeholderText,
-      reviewsCount: reviewsCountData?.reviewsCount,
-      sortingType,
-      ...(isRatingOption && { sortingLabel: selectedOption }),
-    }),
-    [
-      resourceId,
-      resourceType,
-      regionId,
-      isRecentTrip,
-      isMediaCollection,
-      placeholderText,
-      reviewsCountData,
-      sortingType,
-      isRatingOption,
-      selectedOption,
-    ],
-  )
+  const value = {
+    resourceId,
+    resourceType,
+    regionId,
+    recentTrip: isRecentTrip,
+    hasMedia: isMediaCollection,
+    placeholderText,
+    reviewsCount: reviewsCountData?.reviewsCount,
+    sortingType,
+    ...(isRatingOption && { sortingLabel: selectedOption }),
+  }
 
   const showCustomizedScheduleBanner = [
     'article',

--- a/packages/review/src/components/reviews-shorten.tsx
+++ b/packages/review/src/components/reviews-shorten.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, useEffect } from 'react'
+import { ComponentType, useEffect, useMemo } from 'react'
 import styled from 'styled-components'
 import { FlexBox, Section, Text } from '@titicaca/core-elements'
 import { LoginCtaModalProvider } from '@titicaca/modals'
@@ -141,17 +141,31 @@ function ReviewsShortenComponent({
   ] as ComponentType<{ value: ShortenReviewValue }>
   const isRatingOption = selectedOption.startsWith('star-rating')
 
-  const value = {
-    resourceId,
-    resourceType,
-    regionId,
-    recentTrip: isRecentTrip,
-    hasMedia: isMediaCollection,
-    placeholderText,
-    reviewsCount: reviewsCountData?.reviewsCount,
-    sortingType,
-    ...(isRatingOption && { sortingLabel: selectedOption }),
-  }
+  const value = useMemo(
+    () => ({
+      resourceId,
+      resourceType,
+      regionId,
+      recentTrip: isRecentTrip,
+      hasMedia: isMediaCollection,
+      placeholderText,
+      reviewsCount: reviewsCountData?.reviewsCount,
+      sortingType,
+      ...(isRatingOption && { sortingLabel: selectedOption }),
+    }),
+    [
+      resourceId,
+      resourceType,
+      regionId,
+      isRecentTrip,
+      isMediaCollection,
+      placeholderText,
+      reviewsCountData,
+      sortingType,
+      isRatingOption,
+      selectedOption,
+    ],
+  )
 
   const showCustomizedScheduleBanner = [
     'article',

--- a/packages/review/src/components/shorten-list/services.ts
+++ b/packages/review/src/components/shorten-list/services.ts
@@ -21,6 +21,7 @@ export function usePopularReviews(
         ...params,
         size: SHORTENED_REVIEWS_COUNT_PER_PAGE,
       }),
+    { refetchOnWindowFocus: false },
   )
 }
 
@@ -37,6 +38,7 @@ export function useLatestReviews(
         ...params,
         size: SHORTENED_REVIEWS_COUNT_PER_PAGE,
       }),
+    { refetchOnWindowFocus: false },
   )
 }
 
@@ -53,5 +55,6 @@ export function useRatingReviews(
         ...params,
         size: SHORTENED_REVIEWS_COUNT_PER_PAGE,
       }),
+    { refetchOnWindowFocus: false },
   )
 }

--- a/packages/review/src/services/use-reviews.ts
+++ b/packages/review/src/services/use-reviews.ts
@@ -29,6 +29,7 @@ export function useReviewCount(
     ['reviews/getReviewCount', { ...params }],
     () => client.GetReviewsCount(params),
     {
+      refetchOnWindowFocus: false,
       initialData: initialValue
         ? {
             __typename: 'Query',
@@ -40,14 +41,18 @@ export function useReviewCount(
 }
 
 export function useDescriptions(params: GetReviewSpecificationQueryVariables) {
-  return useQuery(['review/getReviewSpecification', params], () =>
-    client.GetReviewSpecification(params),
+  return useQuery(
+    ['review/getReviewSpecification', params],
+    () => client.GetReviewSpecification(params),
+    { refetchOnWindowFocus: false },
   )
 }
 
 export function useMyReview(params: GetMyReviewQueryVariables) {
-  return useQuery(['review/getMyReview', params], () =>
-    client.GetMyReview(params),
+  return useQuery(
+    ['review/getMyReview', params],
+    () => client.GetMyReview(params),
+    { refetchOnWindowFocus: false },
   )
 }
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
`react-query`에서는 새 데이터를 보장하기 위해 화면에 포커싱이 되면 refetch를 하는 `refetchOnWindowFocus`를 기본으로 `true`로 설정합니다. 화면이 렌더링된 이후 화면을 누르면 해당 옵션이 실행되어 gql 쿼리가 새로 실행됩니다. 각 상세 페이지들의 리뷰 컴포넌트에서는 항상 새로운 리뷰를 보장할 필요는 없으므로 해당 옵션을 `false`로 설정하여 refetch를 방지합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
`Review-Shorten` 컴포넌트 내에서 사용되는 쿼리들에 `refetchOnWindowFocus` 옵션을 `false`로 설정합니다.
`Review-Infinite` 컴포넌트 내에서 사용되는 쿼리들에 `refetchOnWindowFocust` 옵션을 `false`로 설정합니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 논의사항
- [X] 리뷰 목록 페이지 (`reviews/list?~~`)에서도 해당 옵션을 적용하는 것이 좋을까요?? 
  - 적용했습니다.
<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL
https://triple-dev.titicaca-corp.com/attractions/37cd28e1-ef29-4ac5-8821-3bbdc8d52908
https://triple-dev.titicaca-corp.com/reviews/list?_triple_no_navbar&region_id=71476976-cf9a-4ae8-a60f-76e6fb26900d&resource_id=37cd28e1-ef29-4ac5-8821-3bbdc8d52908&resource_type=attraction&recent_trip=false&sorting_type=poi&sorting_option=recommendation&has_media=false
<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
