### PR TITLE
[react-contexts] ScrapProvider에서 스크랩 실패 시 콜백함수를 props로 받습니다.

### DIFF
--- a/packages/react-contexts/src/scraps-context/api-client.ts
+++ b/packages/react-contexts/src/scraps-context/api-client.ts
@@ -13,10 +13,20 @@ function mapTypes(type: unknown) {
   }
 }
 
+interface ScrapSuccessResponse {
+  id: string
+}
+
+interface ScrapFailResponse {
+  message: string
+}
+
 export function scrape({ id, type }: Target) {
-  return post(`/api/scraps/${mapTypes(type)}/${id}`)
+  return post<ScrapSuccessResponse, ScrapFailResponse>(
+    `/api/scraps/${mapTypes(type)}/${id}`,
+  )
 }
 
 export function unscrape({ id, type }: Target) {
-  return del(`/api/scraps/${mapTypes(type)}/${id}`)
+  return del<unknown, ScrapFailResponse>(`/api/scraps/${mapTypes(type)}/${id}`)
 }

--- a/packages/react-contexts/src/scraps-context/scraps-context.tsx
+++ b/packages/react-contexts/src/scraps-context/scraps-context.tsx
@@ -93,6 +93,11 @@ interface ScrapsProviderProps {
   enableTrackEvent?: boolean
   beforeScrapedChange?: (target: Target, scraped: boolean) => boolean
   afterScrapedChange?: (target: Target, scraped: boolean) => void
+  onScrapeFailed?: (
+    target: Target,
+    scraped: boolean,
+    errorMessage?: string,
+  ) => void
 }
 
 export function ScrapsProvider({
@@ -100,6 +105,7 @@ export function ScrapsProvider({
   enableTrackEvent,
   beforeScrapedChange,
   afterScrapedChange,
+  onScrapeFailed,
   children,
 }: PropsWithChildren<ScrapsProviderProps>) {
   const parentScrapsReducer = useContext(ScrapsReducerContext)
@@ -160,10 +166,17 @@ export function ScrapsProvider({
 
         dispatch({ type: SCRAPE, id })
       } else {
+        onScrapeFailed?.({ id, type }, true, response.parsedBody.message)
         dispatch({ type: SCRAPE_FAILED, id })
       }
     },
-    [updating, beforeScrapedChange, dispatch, afterScrapedChange],
+    [
+      updating,
+      beforeScrapedChange,
+      dispatch,
+      afterScrapedChange,
+      onScrapeFailed,
+    ],
   )
 
   const unscrape = useCallback(
@@ -190,10 +203,17 @@ export function ScrapsProvider({
 
         dispatch({ type: UNSCRAPE, id })
       } else {
+        onScrapeFailed?.({ id, type }, true, response.parsedBody.message)
         dispatch({ type: UNSCRAPE_FAILED, id })
       }
     },
-    [updating, beforeScrapedChange, dispatch, afterScrapedChange],
+    [
+      updating,
+      beforeScrapedChange,
+      dispatch,
+      afterScrapedChange,
+      onScrapeFailed,
+    ],
   )
 
   useEffect(() => {

--- a/packages/react-contexts/src/scraps-context/scraps-context.tsx
+++ b/packages/react-contexts/src/scraps-context/scraps-context.tsx
@@ -166,7 +166,7 @@ export function ScrapsProvider({
 
         dispatch({ type: SCRAPE, id })
       } else {
-        onScrapeFailed?.({ id, type }, true, response.parsedBody.message)
+        onScrapeFailed?.({ id, type }, false, response.parsedBody.message)
         dispatch({ type: SCRAPE_FAILED, id })
       }
     },


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[react-contexts] ScrapProvider에서 스크랩 실패 시 콜백함수를 props로 받습니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
