### PR TITLE
[KLZT-655] 리뷰 정렬 옵션 변경 시 무관한 element로 포커싱이 되는 버그를 수정합니다. 

### DIFF
--- a/packages/review/src/components/sorting-options.tsx
+++ b/packages/review/src/components/sorting-options.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import styled from 'styled-components'
-import { FlexBox, Text } from '@titicaca/core-elements'
+import { Text } from '@titicaca/core-elements'
 import { useHistoryFunctions } from '@titicaca/react-contexts'
 
 import { useReviewSortingOptions } from './sorting-context'
@@ -9,6 +9,12 @@ import {
   HASH_SORTING_OPTIONS_ACTION_SHEET,
 } from './sorting-options-action-sheet'
 
+const SortingOption = styled.button`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  gap: 4px;
+`
 const ArrowIcon = styled.div`
   width: 12px;
   height: 12px;
@@ -29,21 +35,13 @@ export function SortingOptions() {
 
   return (
     <>
-      <FlexBox
-        flex
-        alignItems="center"
-        gap="4px"
-        css={{
-          cursor: 'pointer',
-        }}
-        onClick={handleActionSheetOpen}
-      >
+      <SortingOption onClick={handleActionSheetOpen}>
         <Text size={14} color="gray">
           {text}
         </Text>
 
         <ArrowIcon />
-      </FlexBox>
+      </SortingOption>
 
       <SortingOptionsActionSheet />
     </>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

리뷰 정렬 옵션을 변경하면 focusable한 첫번째 element로 포커싱이 되어 outline이 보이는 버그가 있었습니다. 이는 리뷰 정렬 옵션 모달을 여는 클릭커블 element가 focusable하지 않아 모달이 닫혔을 때 모달이 열리기 전 포커싱이 되었던 target (FocusEvent의 relatedTarget)을 찾을 수 없기 때문에 발생한 현상입니다. 

위의 현상을 해결하기 위해서는 `SortingOptions` 컴포넌트에 `tabindex`를 설정하거나, `SortingOptions`를 focusable한 element로 변경하는 두 가지 방법이 있습니다. 
`SortingOptions`는 버튼의 역할을 하고 있기 때문에 후자의 방법을 선택했습니다. 

## 변경 내역
- `SortingOptions` 컴포넌트 최상위 element를 `button`으로 변경
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

https://github.com/user-attachments/assets/1d340da4-8322-4f7e-a2d8-32ed8da1f6f1


https://github.com/user-attachments/assets/15d16c88-cc02-4735-bbd4-199dfb93fc3b



<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
