### PR TITLE
[KLZT-663] converse에 로그인 유도 모달을 추가합니다

### DIFF
--- a/packages/modals/src/modal/modal-actions.tsx
+++ b/packages/modals/src/modal/modal-actions.tsx
@@ -10,7 +10,7 @@ export const ModalActions = styled.div<{ children?: ReactNode }>`
 
   a {
     ${({ children }) => {
-      const childrenCount = Children.count(children)
+      const childrenCount = Children.toArray(children).length
       return css`
         width: calc((100% - ${childrenCount - 1}px) / ${childrenCount});
       `

--- a/packages/standard-action-handler/src/converse.tsx
+++ b/packages/standard-action-handler/src/converse.tsx
@@ -107,7 +107,7 @@ async function fetchApi(
       type: 'error',
       title: '안내',
       description:
-        '서비스 이용이 원활하지 않습니다.\n잠시후 다시 이용해주세요.',
+        '서비스 이용이 원활하지 않습니다.\n잠시 후 다시 이용해 주세요.',
     }
   } else {
     const { title, description } = (await response.json()) as {

--- a/packages/standard-action-handler/src/converse.tsx
+++ b/packages/standard-action-handler/src/converse.tsx
@@ -6,8 +6,14 @@ import { WebActionParams } from './types'
 
 const HASH_CONVERSE_MODAL = 'hash.converse-modal'
 
+const NEED_LOGIN_CONTENT = {
+  title: '로그인이 필요합니다.',
+  description: '로그인하고 트리플을\n더 편하게 이용하세요🙂',
+}
+
 export default async function converse({
   url: { path, query } = {},
+  options: { navigate } = {},
 }: WebActionParams) {
   if (path === '/web-action/converse' && query) {
     const { path: pathFromQuery } = qs.parse(query) as { path: string }
@@ -15,6 +21,8 @@ export default async function converse({
     const { title, description } = await fetchApi(pathFromQuery)
 
     if (title && description) {
+      const isLoginModal = title === NEED_LOGIN_CONTENT.title
+
       window.history.pushState(null, '', `#${HASH_CONVERSE_MODAL}`)
 
       const container = document.createElement('div')
@@ -22,6 +30,17 @@ export default async function converse({
 
       const closeModal = () => {
         window.history.back()
+      }
+
+      const onClickLogin = () => {
+        const loginUrl = window.location.href.replace(
+          `#${HASH_CONVERSE_MODAL}`,
+          '',
+        )
+        closeModal()
+        if (navigate) {
+          navigate(`/login?returnUrl=${encodeURIComponent(loginUrl)}`)
+        }
       }
 
       const handlePopstate = () => {
@@ -37,7 +56,8 @@ export default async function converse({
         OpenModal({
           title,
           description,
-          onClose: closeModal,
+          onCancel: isLoginModal ? closeModal : undefined,
+          onConfirm: isLoginModal ? onClickLogin : closeModal,
         }),
       )
 
@@ -53,20 +73,23 @@ export default async function converse({
 export function OpenModal({
   title,
   description,
-  onClose,
+  onCancel,
+  onConfirm,
 }: {
   title: string
   description: string
-  onClose: () => void
+  onCancel?: () => void
+  onConfirm: () => void
 }) {
   return (
-    <Modal open onClose={onClose}>
+    <Modal open onClose={onCancel}>
       <Modal.Body>
         <Modal.Title>{title}</Modal.Title>
         <Modal.Description>{description}</Modal.Description>
       </Modal.Body>
       <Modal.Actions>
-        <Modal.Action color="blue" onClick={onClose}>
+        {onCancel && <Modal.Action onClick={onCancel}>취소</Modal.Action>}
+        <Modal.Action color="blue" onClick={onConfirm}>
           확인
         </Modal.Action>
       </Modal.Actions>
@@ -85,6 +108,9 @@ async function fetchApi(
   })
 
   if (!response.ok) {
+    if (response.status === 400 || response.status === 401) {
+      return NEED_LOGIN_CONTENT
+    }
     return {
       title: '안내',
       description:


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
converse에서 fetch하는 API가 400, 401 statusCode를 응답하는 경우, 로그인 유도 모달을 노출합니다. 
[관련 스레드](https://interpark.slack.com/archives/C05GCN0AYSZ/p1729488212013569?thread_ts=1728976527.666029&cid=C05GCN0AYSZ)
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- API의 response status가 400, 401일 경우 로그인 유도 모달을 노출
- `Children.count(children)`를 `Children.toArray(children).length`로 변경
  - `Children.count(children)`의 경우에는 Empty Node인 경우에도 children으로 간주해 숫자에 포함합니다. Empty Node는 children에서 제외하기 위해 `Chilren.toArray` 메소드로 변경했습니다. 
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
- [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요?

## 스크린샷 & URL
https://triple-dev.titicaca-corp.com/articles/5aa78dc9-07a6-46ec-b662-38a3fbcb7c1f

<img width="567" alt="스크린샷 2024-10-30 오전 10 00 15" src="https://github.com/user-attachments/assets/f37b1a1d-a33f-4bd4-8068-89bb25388e3f">
