### PR TITLE
useClientAppCallback의 fn, appInstallCtaModalOptions 파라미터 순서 변경

### DIFF
--- a/packages/triple-web/src/client-app/use-client-app-callback.mdx
+++ b/packages/triple-web/src/client-app/use-client-app-callback.mdx
@@ -5,27 +5,29 @@ import { Meta, ArgTypes } from '@storybook/blocks'
 # useClientApp
 
 User Agent가 앱 환경일 때만 주어진 콜백을 실행하는 함수를 반환하는 훅.
-앱이 아닐 때는 transition 모달을 띄웁니다.
+앱이 아닐 때는 AppInstallCta 모달을 띄웁니다.
 
 ## Usage
 
 ```tsx
-const clientApp = useClientAppCallback(TransitionType.General, callback)
+const clientApp = useClientAppCallback(
+  fn,
+  appInstalCtaModalOptions,
+  returnValue,
+)
 ```
 
 ## Parameters
-
-### transitionType
-
-`TransitionType`
-
-**Required**
 
 ### fn
 
 `T extends (...args: any[] => any)`
 
 **Required**
+
+### appInstallCtaModalOptions
+
+`AppInstallCtaModalRef`
 
 ### returnValue
 

--- a/packages/triple-web/src/client-app/use-client-app-callback.test.tsx
+++ b/packages/triple-web/src/client-app/use-client-app-callback.test.tsx
@@ -24,7 +24,7 @@ afterEach(() => {
 })
 
 test('일반 브라우저에서 앱 전환 모달 표시 함수를 호출합니다.', () => {
-  const { result } = renderHook(() => useClientAppCallback({}, mockFn), {
+  const { result } = renderHook(() => useClientAppCallback(mockFn), {
     wrapper: ({ children }) => (
       <ClientAppContext.Provider value={null}>
         <UserAgentContext.Provider
@@ -52,7 +52,7 @@ test('일반 브라우저에서 앱 전환 모달 표시 함수를 호출합니�
 })
 
 test('앱에서 앱 전환 모달 표시 함수를 호출하지 않습니다.', () => {
-  const { result } = renderHook(() => useClientAppCallback({}, mockFn), {
+  const { result } = renderHook(() => useClientAppCallback(mockFn), {
     wrapper: ({ children }) => (
       <ClientAppContext.Provider
         value={{

--- a/packages/triple-web/src/client-app/use-client-app-callback.ts
+++ b/packages/triple-web/src/client-app/use-client-app-callback.ts
@@ -12,11 +12,11 @@ import { useClientApp } from './use-client-app'
  *
  * Usage
  *
- * const invokeNativeFn= useClientAppCallback(appInstallCtaModalRef, () => {})
+ * const invokeNativeFn = useClientAppCallback(() => {}, appInstallCtaModalOptions)
  */
 export function useClientAppCallback<T extends (...args: any[]) => any, V>(
-  appInstallCtaModalOptions: AppInstallCtaModalRef = {},
   fn: T,
+  appInstallCtaModalOptions: AppInstallCtaModalRef = {},
   returnValue?: V,
 ): (...args: Parameters<T>) => ReturnType<T> {
   const clientApp = useClientApp()


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

useClientAppCallback의 fn, appInstallCtaModalOptions 파라미터 순서 변경

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

[triple-web]

useClientAppCallback의 fn 파라미터는 필수고, appInstallCtaModalOptions 파라미터는 optional이므로 서로 순서를 바꿉니다.