### PR TITLE
ScrapsProvider에 onScrapeFailed prop 넘길 수 있도록 추가

### DIFF
--- a/packages/tds-widget/src/scrap/provider.tsx
+++ b/packages/tds-widget/src/scrap/provider.tsx
@@ -12,11 +12,17 @@ import { ScrapContext, ScrapDispatchContext } from './context'
 interface ScrapsProviderProps {
   initialScraps?: Scraps
   beforeScrapedChange?: (target: Target, scraped: boolean) => boolean
+  onScrapeFailed?: (
+    target: Target,
+    scraped: boolean,
+    errorMessage?: string,
+  ) => void
 }
 
 export function ScrapsProvider({
   initialScraps,
   beforeScrapedChange,
+  onScrapeFailed,
   children,
 }: PropsWithChildren<ScrapsProviderProps>) {
   const [value, dispatch] = useReducer(reducer, {
@@ -39,7 +45,9 @@ export function ScrapsProvider({
   }, [dispatch])
 
   return (
-    <ScrapContext.Provider value={{ ...value, beforeScrapedChange }}>
+    <ScrapContext.Provider
+      value={{ ...value, beforeScrapedChange, onScrapeFailed }}
+    >
       <ScrapDispatchContext.Provider value={dispatch}>
         {children}
       </ScrapDispatchContext.Provider>


### PR DESCRIPTION
## PR 설명
`ScrapsProvider`에 `onScrapeFailed` prop을 넘길 수 있도록 추가합니다.
v13 변경분을 v14에 업데이트시 누락된것으로 보입니다.

- 관련 PR : https://github.com/titicacadev/triple-frontend/pull/3418/files