### PR TITLE
Carousel containerPadding, margin prop 복구

### DIFF
--- a/packages/tds-ui/src/components/carousel/carousel.stories.tsx
+++ b/packages/tds-ui/src/components/carousel/carousel.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 import { Carousel } from './carousel'
 import IMAGES from './mocks/carousel.sample.json'
+import { CarouselItem } from './carousel-item'
 
 const meta: Meta<typeof Carousel> = {
   title: 'tds-ui (Carousel) / Carousel ',
@@ -24,13 +25,9 @@ export const Default: Story = {
     children: (
       <>
         {IMAGES.map((image, key) => (
-          <img
-            key={key}
-            src={image.sizes.large.url}
-            alt="test"
-            width={400}
-            height={400}
-          />
+          <CarouselItem key={key} size="big">
+            <img src={image.sizes.large.url} alt="test" />
+          </CarouselItem>
         ))}
       </>
     ),

--- a/packages/tds-ui/src/components/carousel/carousel.tsx
+++ b/packages/tds-ui/src/components/carousel/carousel.tsx
@@ -1,10 +1,17 @@
-import { styled } from 'styled-components'
+import { css, styled } from 'styled-components'
 import { PropsWithChildren, useRef } from 'react'
+
+import { marginMixin, MarginMixinProps } from '../../mixins'
 
 import { CarouselItem } from './carousel-item'
 
-const CarouselBase = styled.ul`
+interface CarouselBaseProps extends MarginMixinProps {
+  containerPadding?: { left: number; right: number }
+}
+
+const CarouselBase = styled.ul<CarouselBaseProps>`
   padding-bottom: 10px;
+  ${marginMixin}
   white-space: nowrap;
   overflow: scroll hidden;
   -webkit-overflow-scrolling: touch;
@@ -12,16 +19,37 @@ const CarouselBase = styled.ul`
   &::-webkit-scrollbar {
     display: none;
   }
+
+  ${({ containerPadding }) =>
+    containerPadding &&
+    css`
+      li:first-child {
+        margin-left: ${containerPadding.left || 0}px;
+      }
+
+      li:last-child {
+        margin-right: ${containerPadding.right || 0}px;
+      }
+    `};
 `
+
+export type CarouselProps = PropsWithChildren<CarouselBaseProps>
 
 export function Carousel({
   children,
-  ...cssProps
-}: PropsWithChildren<unknown>) {
+  margin,
+  containerPadding,
+  ...props
+}: PropsWithChildren<CarouselProps>) {
   const carouselRef = useRef<HTMLUListElement>(null)
 
   return (
-    <CarouselBase ref={carouselRef} {...cssProps}>
+    <CarouselBase
+      ref={carouselRef}
+      margin={margin}
+      containerPadding={containerPadding}
+      {...props}
+    >
       {children}
     </CarouselBase>
   )


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

tds-ui의 Carousel 컴포넌트도 tds-widget의 FlickingCarousel과 동일하게 containerPadding, margin prop을 받도록 합니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

[tds-ui]

- Carousel containerPadding, margin prop 복구
