### PR TITLE
[INTHOTEL-2407] defaultImage와 중복되는 이미지 필터링

### DIFF
--- a/packages/react-contexts/src/images-context/index.tsx
+++ b/packages/react-contexts/src/images-context/index.tsx
@@ -72,13 +72,19 @@ export function ImagesProvider({
     hasMore: true,
   })
 
+  const { addOnTotal, addOnCurrentImageLength } = {
+    addOnTotal: type === 'hotel' ? 0 : (defaultImages || []).length,
+    addOnCurrentImageLength:
+      type === 'hotel' ? (defaultImages || []).length : 0,
+  }
+
   const fetchImages = useFetchImages()
 
   const sendFetchRequest = useCallback(
     async (size = 15) => {
       const response = await fetchImages({
         target: { type, id },
-        currentImageLength: images.length - (defaultImages?.length || 0),
+        currentImageLength: images.length - addOnTotal,
         size,
         categoryOrder,
       })
@@ -102,7 +108,7 @@ export function ImagesProvider({
         next,
       } = await fetchImages({
         target: { type, id },
-        currentImageLength: 0,
+        currentImageLength: addOnCurrentImageLength,
         size: 15,
         categoryOrder,
       })
@@ -110,14 +116,14 @@ export function ImagesProvider({
       dispatch(
         reinitializeImages({
           images: [...(defaultImages || []), ...fetchedImages],
-          total: total + (defaultImages?.length || 0),
+          total: total + addOnTotal,
           hasMore: !!next,
         }),
       )
     } catch (error) {
       dispatch(loadImagesFail(error))
     }
-  }, [loading, id, type])
+  }, [loading, id, type, addOnCurrentImageLength, addOnTotal])
 
   const fetch = useCallback(
     async (onFetchAfter?: () => void, force?: boolean) => {
@@ -132,7 +138,7 @@ export function ImagesProvider({
         dispatch(
           loadImagesSuccess({
             images: fetchedImages,
-            total: total + (defaultImages?.length || 0),
+            total: total + addOnTotal,
             hasMore: !!next,
           }),
         )
@@ -142,7 +148,7 @@ export function ImagesProvider({
 
       onFetchAfter && onFetchAfter()
     },
-    [hasMore, loading, sendFetchRequest],
+    [hasMore, loading, addOnTotal, sendFetchRequest],
   )
 
   const indexOf = useCallback(

--- a/packages/react-contexts/src/images-context/index.tsx
+++ b/packages/react-contexts/src/images-context/index.tsx
@@ -148,7 +148,7 @@ export function ImagesProvider({
         const { data: fetchedImages, total, next } = await sendFetchRequest()
 
         const filteredDefaultImages =
-          uniqueDefaultImages.length === images.length
+          uniqueDefaultImages.length === images.length // 이미지 순서가 바뀌는 경우를 방지하기 위해 첫 fetch 시에만 필터링을 진행합니다.
             ? filterDefaultImages(uniqueDefaultImages, fetchedImages)
             : uniqueDefaultImages
 

--- a/packages/react-contexts/src/images-context/index.tsx
+++ b/packages/react-contexts/src/images-context/index.tsx
@@ -72,19 +72,13 @@ export function ImagesProvider({
     hasMore: true,
   })
 
-  const { addOnTotal, addOnCurrentImageLength } = {
-    addOnTotal: type === 'hotel' ? 0 : (defaultImages || []).length,
-    addOnCurrentImageLength:
-      type === 'hotel' ? (defaultImages || []).length : 0,
-  }
-
   const fetchImages = useFetchImages()
 
   const sendFetchRequest = useCallback(
     async (size = 15) => {
       const response = await fetchImages({
         target: { type, id },
-        currentImageLength: images.length - addOnTotal,
+        currentImageLength: images.length - (defaultImages?.length || 0),
         size,
         categoryOrder,
       })
@@ -108,7 +102,7 @@ export function ImagesProvider({
         next,
       } = await fetchImages({
         target: { type, id },
-        currentImageLength: addOnCurrentImageLength,
+        currentImageLength: 0,
         size: 15,
         categoryOrder,
       })
@@ -116,14 +110,14 @@ export function ImagesProvider({
       dispatch(
         reinitializeImages({
           images: [...(defaultImages || []), ...fetchedImages],
-          total: total + addOnTotal,
+          total: total + (defaultImages?.length || 0),
           hasMore: !!next,
         }),
       )
     } catch (error) {
       dispatch(loadImagesFail(error))
     }
-  }, [loading, id, type, addOnCurrentImageLength, addOnTotal])
+  }, [loading, id, type])
 
   const fetch = useCallback(
     async (onFetchAfter?: () => void, force?: boolean) => {
@@ -138,7 +132,7 @@ export function ImagesProvider({
         dispatch(
           loadImagesSuccess({
             images: fetchedImages,
-            total: total + addOnTotal,
+            total: total + (defaultImages?.length || 0),
             hasMore: !!next,
           }),
         )
@@ -148,7 +142,7 @@ export function ImagesProvider({
 
       onFetchAfter && onFetchAfter()
     },
-    [hasMore, loading, addOnTotal, sendFetchRequest],
+    [hasMore, loading, sendFetchRequest],
   )
 
   const indexOf = useCallback(

--- a/packages/react-contexts/src/images-context/index.tsx
+++ b/packages/react-contexts/src/images-context/index.tsx
@@ -152,14 +152,27 @@ export function ImagesProvider({
             ? filterDefaultImages(uniqueDefaultImages, fetchedImages)
             : uniqueDefaultImages
 
-        dispatch(
-          loadImagesSuccess({
-            images: fetchedImages,
-            total: total + filteredDefaultImages.length,
-            hasMore: !!next,
-          }),
-        )
-        setUniqueDefaultImages(filteredDefaultImages)
+        const shouldReInitImages =
+          filteredDefaultImages.length !== uniqueDefaultImages.length
+
+        if (shouldReInitImages) {
+          dispatch(
+            reinitializeImages({
+              images: [...filteredDefaultImages, ...fetchedImages],
+              total: total + filteredDefaultImages.length,
+              hasMore: !!next,
+            }),
+          )
+          setUniqueDefaultImages(filteredDefaultImages)
+        } else {
+          dispatch(
+            loadImagesSuccess({
+              images: fetchedImages,
+              total: total + filteredDefaultImages.length,
+              hasMore: !!next,
+            }),
+          )
+        }
       } catch (error) {
         dispatch(loadImagesFail(error))
       }

--- a/packages/react-contexts/src/images-context/use-fetch-images.tsx
+++ b/packages/react-contexts/src/images-context/use-fetch-images.tsx
@@ -52,7 +52,7 @@ export default function useFetchImages() {
           response.total +
           (poiReviewsResponse.total || totalPoiReviewImagesCount),
         next:
-          response.next || needReviewImages ? poiReviewsResponse.next : true,
+          response.next || (needReviewImages ? poiReviewsResponse.next : true),
       }
     }
     const response = await fetchPoiReviewImages(target, {

--- a/packages/react-contexts/src/images-context/use-fetch-images.tsx
+++ b/packages/react-contexts/src/images-context/use-fetch-images.tsx
@@ -42,7 +42,6 @@ export default function useFetchImages() {
               size: needReviewImages ? size - response.data.length : 1, // 1은 첫 fetch에 review image total을 알아오기 위함
             })
           : { data: [], next: null, total: 0 }
-
       return {
         ...response,
         data: [


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

- 호텔 POI의 경우 이미지 카테고리가 'images' 한가지로 되어있어 `category_order`가 적용되지 않아 `defaultImage`와 fetch된 이미지 일부가 중복되는 오류가 발생하고 있었습니다. 첫 호출 시 `defaultImage`와 중복되는 이미지가 필터링 될 수 있도록 수정합니다. 
- review 이미지가 존재하지 않는 경우 페이지네이션이 동작하지 않는 오류를 수정합니다. [7912983](https://github.com/titicacadev/triple-frontend/pull/3474/commits/7912983b2f31099af328e1b715207544a9eccb5a)

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주


세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->



## 스크린샷 & URL

- as-is
https://github.com/user-attachments/assets/e37e4809-cdf4-48ae-9714-90fe9ac98979


- to-be
https://github.com/user-attachments/assets/3202555c-02b7-48b0-87c6-bb9f604e9847

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
