### PR TITLE
앱에서 navigate 동작 수정

### DIFF
--- a/packages/router/src/links/use-open-native-link.ts
+++ b/packages/router/src/links/use-open-native-link.ts
@@ -20,7 +20,7 @@ export function useOpenNativeLink() {
     }
 
     const href = (window.location.href = `${appUrlScheme}://${path}`)
-    window.location.href = href
+    window.open(href)
   }
 
   return openNativeLink

--- a/packages/triple-web-nextjs-pages/src/providers/client-app.ts
+++ b/packages/triple-web-nextjs-pages/src/providers/client-app.ts
@@ -23,9 +23,10 @@ export function getClientApp(ctx: NextPageContext): ClientAppValue {
 
   return {
     metadata: {
-      name: (metadata[1] as keyof typeof ClientAppName)
-        ? ClientAppName.Android
-        : ClientAppName.iOS,
+      name:
+        metadata[1] === 'Triple-Android'
+          ? ClientAppName.Android
+          : ClientAppName.iOS,
       version: metadata[2],
       isMacApp: macAppRegex.test(userAgent),
     },

--- a/packages/triple-web-nextjs/src/providers/client-app.ts
+++ b/packages/triple-web-nextjs/src/providers/client-app.ts
@@ -25,9 +25,10 @@ export function getClientApp(): ClientAppValue {
 
   return {
     metadata: {
-      name: (metadata[1] as keyof typeof ClientAppName)
-        ? ClientAppName.Android
-        : ClientAppName.iOS,
+      name:
+        metadata[1] === 'Triple-Android'
+          ? ClientAppName.Android
+          : ClientAppName.iOS,
       version: metadata[2],
       isMacApp: macAppRegex.test(userAgent),
     },

--- a/packages/triple-web-utils/src/check-client-app.test.ts
+++ b/packages/triple-web-utils/src/check-client-app.test.ts
@@ -1,0 +1,26 @@
+import { checkClientApp } from './check-client-app'
+
+describe('checkClientApp', () => {
+  test('안드로이드 앱 user agent 문자열에 대해 true를 반환해야 합니다', () => {
+    const userAgent =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1 Triple-Android/7.4.2'
+    expect(checkClientApp(userAgent)).toBe(true)
+  })
+
+  test('iOS 앱 user agent 문자열에 대해 true를 반환해야 합니다', () => {
+    const userAgent =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1 Triple-iOS/7.4.2'
+    expect(checkClientApp(userAgent)).toBe(true)
+  })
+
+  test('정규식과 일치하지 않는 사용자 에이전트 문자열에 대해 false를 반환해야 합니다', () => {
+    const userAgent =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
+    expect(checkClientApp(userAgent)).toBe(false)
+  })
+
+  test('빈 사용자 에이전트 문자열에 대해 false를 반환해야 합니다', () => {
+    const userAgent = ''
+    expect(checkClientApp(userAgent)).toBe(false)
+  })
+})

--- a/packages/triple-web-utils/src/check-client-app.test.ts
+++ b/packages/triple-web-utils/src/check-client-app.test.ts
@@ -13,13 +13,13 @@ describe('checkClientApp', () => {
     expect(checkClientApp(userAgent)).toBe(true)
   })
 
-  test('정규식과 일치하지 않는 사용자 에이전트 문자열에 대해 false를 반환해야 합니다', () => {
+  test('트리플 앱 정보가 없는 user agent 문자열에 대해 false를 반환해야 합니다', () => {
     const userAgent =
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
     expect(checkClientApp(userAgent)).toBe(false)
   })
 
-  test('빈 사용자 에이전트 문자열에 대해 false를 반환해야 합니다', () => {
+  test('빈 user agent 문자열에 대해 false를 반환해야 합니다', () => {
     const userAgent = ''
     expect(checkClientApp(userAgent)).toBe(false)
   })

--- a/packages/triple-web-utils/src/regex.ts
+++ b/packages/triple-web-utils/src/regex.ts
@@ -1,3 +1,3 @@
-export const clientAppRegex = /Triple-(iOS|Android)\/([^ ]+)/g
+export const clientAppRegex = /(Triple-iOS|Triple-Android)\/([^ ]+)/g
 
 export const macAppRegex = /TripleMacApp/g

--- a/packages/triple-web-utils/src/regex.ts
+++ b/packages/triple-web-utils/src/regex.ts
@@ -1,3 +1,3 @@
-export const clientAppRegex = /(Triple-iOS|Triple-Android)\/([^ ]+)/g
+export const clientAppRegex = /(Triple-iOS|Triple-Android)\/([^ ]+)/
 
-export const macAppRegex = /TripleMacApp/g
+export const macAppRegex = /TripleMacApp/

--- a/packages/triple-web/src/i18n/context.ts
+++ b/packages/triple-web/src/i18n/context.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { createContext } from 'react'
 
 import type { I18nValue } from './types'


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

https://nol-universe.slack.com/archives/C05EUG8UYP6/p1732686467091999

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

client user agent regex 수정
- capture group을 Triple-iOS / Triple-Android로 수정합니다. 
- global modifier를 제거합니다. test 호출마다 true false를 반복했는데 일정한 결과를 반환하게 합니다. session provider에서 isClientApp 체크가 정상적으로 통과하게 됩니다.

client app provider 함수의 metadata.name 수정
- string 대신 enum이 전달되게 합니다.

open native link의 페이지 이동이 두번 호출되는 문제 수정
- 원인은 모르겠는데 self가 아니라 blank로 이동하면 해결이 됩니다.

i18n context에 `'use client'` 추가
- 	next 13에서 app router 지원