### PR TITLE
앱 외부에서도 스크랩이 가능하도록 옵션 추가

### DIFF
--- a/packages/tds-widget/src/scrap/use-scrap.ts
+++ b/packages/tds-widget/src/scrap/use-scrap.ts
@@ -66,8 +66,8 @@ export function useScrap() {
           scraped === currentState
             ? scrapsCount
             : currentState
-              ? scrapsCount + 1
-              : scrapsCount - 1,
+            ? scrapsCount + 1
+            : scrapsCount - 1,
       }
     },
     [scraps, updating],
@@ -85,7 +85,8 @@ export function useScrap() {
           content_type: type,
         },
       },
-    }: Target) => {
+      scrapableInApp = true,
+    }: Target & { scrapableInApp?: boolean }) => {
       if (
         beforeScrapedChange &&
         beforeScrapedChange({ id, type }, true) === false
@@ -97,7 +98,7 @@ export function useScrap() {
         return
       }
 
-      if (!app) {
+      if (scrapableInApp && !app) {
         return showAppInstallCtaModal({ triggeredEventAction: 'POI저장' })
       }
 
@@ -144,7 +145,8 @@ export function useScrap() {
           content_type: type,
         },
       },
-    }: Target) => {
+      scrapableInApp = true,
+    }: Target & { scrapableInApp?: boolean }) => {
       if (
         beforeScrapedChange &&
         beforeScrapedChange({ id, type }, true) === false
@@ -156,7 +158,7 @@ export function useScrap() {
         return
       }
 
-      if (!app) {
+      if (scrapableInApp && !app) {
         return showAppInstallCtaModal({ triggeredEventAction: 'POI저장' })
       }
 

--- a/packages/tds-widget/src/scrap/use-scrap.ts
+++ b/packages/tds-widget/src/scrap/use-scrap.ts
@@ -38,7 +38,8 @@ export function useScrap(param?: { scrapableInApp?: boolean }) {
   const { show: showAppInstallCtaModal } = useAppInstallCtaModal()
   const trackEventWithMetadata = useTrackEventWithMetadata()
 
-  const scrapableInApp = param?.scrapableInApp ? param.scrapableInApp : true
+  const scrapableInApp =
+    param?.scrapableInApp !== undefined ? param.scrapableInApp : true
 
   const deriveCurrentStateAndCount = useCallback(
     ({

--- a/packages/tds-widget/src/scrap/use-scrap.ts
+++ b/packages/tds-widget/src/scrap/use-scrap.ts
@@ -20,7 +20,7 @@ import {
 } from './constants'
 import { ScrapContext, ScrapDispatchContext } from './context'
 
-export function useScrap() {
+export function useScrap(param?: { scrapableInApp?: boolean }) {
   const scrapsContext = useContext(ScrapContext)
   const dispatch = useContext(ScrapDispatchContext)
 
@@ -37,6 +37,8 @@ export function useScrap() {
   const { show: showLoginCta } = useLoginCtaModal()
   const { show: showAppInstallCtaModal } = useAppInstallCtaModal()
   const trackEventWithMetadata = useTrackEventWithMetadata()
+
+  const scrapableInApp = param?.scrapableInApp ? param.scrapableInApp : true
 
   const deriveCurrentStateAndCount = useCallback(
     ({
@@ -85,8 +87,7 @@ export function useScrap() {
           content_type: type,
         },
       },
-      scrapableInApp = true,
-    }: Target & { scrapableInApp?: boolean }) => {
+    }: Target) => {
       if (
         beforeScrapedChange &&
         beforeScrapedChange({ id, type }, true) === false
@@ -122,6 +123,7 @@ export function useScrap() {
     [
       beforeScrapedChange,
       updating,
+      scrapableInApp,
       app,
       sessionAvailable,
       dispatch,
@@ -145,8 +147,7 @@ export function useScrap() {
           content_type: type,
         },
       },
-      scrapableInApp = true,
-    }: Target & { scrapableInApp?: boolean }) => {
+    }: Target) => {
       if (
         beforeScrapedChange &&
         beforeScrapedChange({ id, type }, true) === false
@@ -182,6 +183,7 @@ export function useScrap() {
     [
       beforeScrapedChange,
       updating,
+      scrapableInApp,
       app,
       sessionAvailable,
       dispatch,

--- a/packages/tds-widget/src/scrap/use-scrap.ts
+++ b/packages/tds-widget/src/scrap/use-scrap.ts
@@ -66,8 +66,8 @@ export function useScrap() {
           scraped === currentState
             ? scrapsCount
             : currentState
-            ? scrapsCount + 1
-            : scrapsCount - 1,
+              ? scrapsCount + 1
+              : scrapsCount - 1,
       }
     },
     [scraps, updating],


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[관련 스레드](https://nol-universe.slack.com/archives/C05EUG8UYP6/p1732856084450209) 기존에 `content-web`에서 앱 외부에서도 스크랩할 수 있는 기능이 있었으므로 앱 외부에서도 스크랩이 가능하도록 수정합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

앱 외부에서도 스크랩이 가능하도록 `onScrape`과 `onUnscrape`에 `scrapableInApp` 옵션을 추가합니다.