### PR TITLE
[triple-web] firebaseAnalytics 인스턴스를 가져오지 못하는 이슈를 해결합니다.

### DIFF
--- a/packages/triple-web/README.md
+++ b/packages/triple-web/README.md
@@ -1,3 +1,29 @@
+# EventTrackingContext
+
+ga, fa, facebookPixel, tiktokPixel 이벤트를 로깅할 수 있는 메서드를 제공하는 context입니다.
+
+## 주의사항
+
+page_view 이벤트의 경우, fa에서 자동으로 page_view 이벤트를 기록하지 않도록 설정해야 합니다. 각 레포에서 firebase의 앱을 초기화할 때, firebase analytics 인스턴스도 초기화해야 page_view 이벤트가 중복으로 로깅되지 않습니다.
+
+```
+// firebase app 초기화 설정
+
+import { initializeFirebaseApp } from 'firebase/app'
+import { initializeAnalytics } from 'firebase/analytics'
+
+function initializeFirebase() {
+  const firebaseApp = initializeApp(config)
+
+  // page_view 이벤트 중복 로깅을 위해 다음과 같이 analytics를 초기화합니다.
+  initializeAnalytics(firebaseApp, {
+    config: {
+      send_page_view: false,
+    },
+  })
+}
+```
+
 # HashRouterContext
 
 hash를 사용하여 모달을 여닫을 수 있도록 필요한 값과 메서드를 제공하는 context입니다.

--- a/packages/triple-web/src/event-tracking/libs/firebase-analytics.ts
+++ b/packages/triple-web/src/event-tracking/libs/firebase-analytics.ts
@@ -1,13 +1,15 @@
 import { getApp } from 'firebase/app'
-import { type Analytics, initializeAnalytics } from 'firebase/analytics'
+import { getAnalytics, initializeAnalytics } from 'firebase/analytics'
 
-export let firebaseAnalytics: Analytics
+export function getFirebaseAnalytics() {
+  try {
+    const app = getApp()
+    const analytics =
+      getAnalytics(app) ??
+      initializeAnalytics(app, {
+        config: { send_page_view: false },
+      })
 
-try {
-  const app = getApp()
-  const analytics = initializeAnalytics(app, {
-    config: { send_page_view: false },
-  })
-
-  firebaseAnalytics = analytics
-} catch (error) {}
+    return analytics
+  } catch (error) {}
+}

--- a/packages/triple-web/src/event-tracking/libs/firebase-analytics.ts
+++ b/packages/triple-web/src/event-tracking/libs/firebase-analytics.ts
@@ -1,14 +1,10 @@
 import { getApp } from 'firebase/app'
-import { getAnalytics, initializeAnalytics } from 'firebase/analytics'
+import { getAnalytics } from 'firebase/analytics'
 
 export function getFirebaseAnalytics() {
   try {
     const app = getApp()
-    const analytics =
-      getAnalytics(app) ??
-      initializeAnalytics(app, {
-        config: { send_page_view: false },
-      })
+    const analytics = getAnalytics(app)
 
     return analytics
   } catch (error) {}

--- a/packages/triple-web/src/event-tracking/use-set-firebase-user-id.ts
+++ b/packages/triple-web/src/event-tracking/use-set-firebase-user-id.ts
@@ -1,13 +1,14 @@
 import { setUserId } from 'firebase/analytics'
 import { useCallback } from 'react'
 
-import { firebaseAnalytics } from './libs/firebase-analytics'
+import { getFirebaseAnalytics } from './libs/firebase-analytics'
 
 /**
  * Firebase user ID 설정.
  */
 export function useSetFirebaseUserId() {
   return useCallback((userId: string | null) => {
+    const firebaseAnalytics = getFirebaseAnalytics()
     if (firebaseAnalytics) {
       setUserId(firebaseAnalytics, userId || '')
     }

--- a/packages/triple-web/src/event-tracking/utils/track-event.ts
+++ b/packages/triple-web/src/event-tracking/utils/track-event.ts
@@ -1,7 +1,7 @@
 import { trackEvent as nativeTrackEvent } from '@titicaca/triple-web-to-native-interfaces'
 import { logEvent as firebaseLogEvent } from 'firebase/analytics'
 
-import { firebaseAnalytics } from '../libs/firebase-analytics'
+import { getFirebaseAnalytics } from '../libs/firebase-analytics'
 import type { EventTrackingValue } from '../types'
 
 declare const window: {
@@ -137,6 +137,8 @@ export function trackEvent(
     if (window.ttq && tiktokPixel) {
       window.ttq.track(tiktokPixel.type, tiktokPixel.params)
     }
+
+    const firebaseAnalytics = getFirebaseAnalytics()
 
     if (firebaseAnalytics && fa) {
       firebaseLogEvent(firebaseAnalytics, 'web_user_interaction', {

--- a/packages/triple-web/src/event-tracking/utils/track-screen.ts
+++ b/packages/triple-web/src/event-tracking/utils/track-screen.ts
@@ -1,7 +1,7 @@
 import { trackScreen as nativeTrackScreen } from '@titicaca/triple-web-to-native-interfaces'
 import { logEvent as firebaseLogEvent } from 'firebase/analytics'
 
-import { firebaseAnalytics } from '../libs/firebase-analytics'
+import { getFirebaseAnalytics } from '../libs/firebase-analytics'
 import type { EventTrackingValue } from '../types'
 
 declare const window: {
@@ -32,6 +32,8 @@ export function trackScreen(
     if (window.fbq && label) {
       window.fbq('trackCustom', `PageView_${label}`, { path })
     }
+
+    const firebaseAnalytics = getFirebaseAnalytics()
 
     if (firebaseAnalytics) {
       firebaseLogEvent(firebaseAnalytics, 'page_view', {

--- a/packages/triple-web/src/providers/event-tracking-provider.tsx
+++ b/packages/triple-web/src/providers/event-tracking-provider.tsx
@@ -5,7 +5,7 @@ import { setUserId } from 'firebase/analytics'
 
 import { EventTrackingContext } from '../event-tracking/context'
 import type { EventTrackingValue } from '../event-tracking/types'
-import { firebaseAnalytics } from '../event-tracking/libs/firebase-analytics'
+import { getFirebaseAnalytics } from '../event-tracking/libs/firebase-analytics'
 import { trackScreen } from '../event-tracking/utils/track-screen'
 import { useSession } from '../session/use-session'
 
@@ -20,6 +20,7 @@ export function EventTrackingProvider({
   const { user } = useSession()
 
   useEffect(() => {
+    const firebaseAnalytics = getFirebaseAnalytics()
     if (firebaseAnalytics) {
       setUserId(firebaseAnalytics, user?.uid ?? null)
     }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[triple-web] firebaseAnalytics 인스턴스를 가져오지 못하는 이슈를 해결합니다. ([관련 스레드](https://nol-universe.slack.com/archives/C05EUG8UYP6/p1733205629592129))
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- trackEvent에서 firebaseAnalytics 인스턴스를 가져오지 못해 FA 이벤트를 로깅하지 못하는 이슈를 해결합니다.
- getFirebaseAnalytics 함수를 만들어 trackEvent 시 인스턴스를 get 혹은 initialize하도록 수정했습니다.
- **각 레포에서 initializeApp(firebase)과 initializeAnalytics를 같이 해주어야합니다.**
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

