### PR TITLE
[triple-web] 모달을 띄울 때 trackScreen이 호출되는 문제를 해결합니다.

### DIFF
--- a/packages/triple-web-nextjs/src/event-tracking-provider.tsx
+++ b/packages/triple-web-nextjs/src/event-tracking-provider.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useMemo } from 'react'
 import {
   EventTrackingProvider as EventTrackingProviderBase,
   type EventTrackingProviderProps as EventTrackingProviderBaseProps,
@@ -20,11 +19,13 @@ export function EventTrackingProvider({
   onError,
 }: EventTrackingProviderProps) {
   const searchParams = useSearchParams()
-  const utm = getEventTrackingUtm(searchParams)
-  const memoizedUtm = useMemo(() => utm, [utm])
 
   return (
-    <EventTrackingProviderBase page={page} utm={memoizedUtm} onError={onError}>
+    <EventTrackingProviderBase
+      page={page}
+      utm={getEventTrackingUtm(searchParams)}
+      onError={onError}
+    >
       {children}
     </EventTrackingProviderBase>
   )

--- a/packages/triple-web-nextjs/src/event-tracking-provider.tsx
+++ b/packages/triple-web-nextjs/src/event-tracking-provider.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useMemo } from 'react'
 import {
   EventTrackingProvider as EventTrackingProviderBase,
   type EventTrackingProviderProps as EventTrackingProviderBaseProps,
@@ -19,13 +20,10 @@ export function EventTrackingProvider({
   onError,
 }: EventTrackingProviderProps) {
   const searchParams = useSearchParams()
+  const utm = useMemo(() => getEventTrackingUtm(searchParams), [searchParams])
 
   return (
-    <EventTrackingProviderBase
-      page={page}
-      utm={getEventTrackingUtm(searchParams)}
-      onError={onError}
-    >
+    <EventTrackingProviderBase page={page} utm={utm} onError={onError}>
       {children}
     </EventTrackingProviderBase>
   )

--- a/packages/triple-web-nextjs/src/event-tracking-provider.tsx
+++ b/packages/triple-web-nextjs/src/event-tracking-provider.tsx
@@ -20,10 +20,11 @@ export function EventTrackingProvider({
   onError,
 }: EventTrackingProviderProps) {
   const searchParams = useSearchParams()
-  const utm = useMemo(() => getEventTrackingUtm(searchParams), [searchParams])
+  const utm = getEventTrackingUtm(searchParams)
+  const memoizedUtm = useMemo(() => utm, [utm])
 
   return (
-    <EventTrackingProviderBase page={page} utm={utm} onError={onError}>
+    <EventTrackingProviderBase page={page} utm={memoizedUtm} onError={onError}>
       {children}
     </EventTrackingProviderBase>
   )

--- a/packages/triple-web/src/providers/event-tracking-provider.tsx
+++ b/packages/triple-web/src/providers/event-tracking-provider.tsx
@@ -28,7 +28,8 @@ export function EventTrackingProvider({
 
   useEffect(() => {
     trackScreen(page.path, page.label, { ...utm }, { page, utm, onError })
-  }, [onError, page, utm])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page])
 
   return (
     <EventTrackingContext.Provider value={{ page, utm, onError }}>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[triple-web-nextjs] 모달을 띄울 때 trackScreen이 호출되는 문제를 해결합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
hash값이 변할 때마다 next의 searchParams가 영향을 받아 trackScreen이 호출되고 있습니다.
trackScreen이 걸린 useEffect에 걸린 utm 디펜던시를 삭제합니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
