### PR TITLE
[triple-web] 로그인 모달 버튼 함수 수정

### DIFF
--- a/packages/triple-web/src/modal/components/login-cta-modal.tsx
+++ b/packages/triple-web/src/modal/components/login-cta-modal.tsx
@@ -15,7 +15,10 @@ export function LoginCtaModal() {
   const { removeUriHash, uriHash } = useHashRouter()
   const open = uriHash === LOGIN_CTA_MODAL_HASH
 
-  const handleCancelOrClose = () => removeUriHash()
+  const handleCancelOrClose = () => {
+    removeUriHash()
+    return true
+  }
 
   const handleConfirm = () => {
     const triggeredEventAction =
@@ -41,7 +44,11 @@ export function LoginCtaModal() {
       }),
     })
 
+    removeUriHash()
+
     window.location.href = loginUrl
+
+    return true
   }
 
   useEffect(() => {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

AOS 브라우저에서 로그인 모달이 정상적으로 동작하지 않는 이슈를 해결합니다. `Confirm` 컴포넌트에서는 `onClose`가 있는 경우, `onConfirm`과 `onClose` 함수 실행 이후에 `onClose`를 실행합니다. [AOS에서는 `removeUriHash` 실행 시 `back`](https://github.com/titicacadev/triple-frontend/blob/main/packages/triple-web/src/hash-router/context.tsx#L65-L67)이 실행됩니다. 따라서 로그인 모달에서 아래와 같은 동작이 발생합니다.
- `취소` 클릭 시
  - `removeUriHash`가 두 번 실행되어 페이지가 뒤로 이동  

- `확인` 클릭 시
  -  `window.location.href` 동작 후 `removeUriHash`가 실행되어 페이지 이동 없음

이를 방지하고 정상적으로 동작하게 하기 위해 `return true`를 추가합니다. [`Confirm` 컴포넌트 내에서 `return false`로 간주](https://github.com/titicacadev/triple-frontend/blob/main/packages/tds-ui/src/components/confirm/confirm.tsx#L27-L33)되어 `onClose`가 동작하지 않습니다. 
## 변경 내역
- `LoginCtaModal`의 `onConfirm`과 `onCancel`에 `return true` 추가
- 위와 같이 수정 후 로그인 페이지로 이동했다가 뒤로가기로 원 페이지에 복귀 시 hash 값이 지워지지 않아 로그인 유도 모달이 노출됩니다. 이를 방지하기 위해 로그인 페이지로 이동 전 `removeUriHash`를 실행합니다. 
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 논의사항
모달에서 다른 페이지로 이동해야하는 경우, 이번 이슈/해결방안 적용 상황이 언제나 발생할 수 있습니다. 좀 더 체계적으로 이슈를 해결할 수 있는 방안을 모색해야 할 것으로 보입니다. 
<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
