### PR TITLE
[middleware] 세션 쿠키 리프레시 로직을 수정합니다. 

### DIFF
--- a/packages/middlewares/README.md
+++ b/packages/middlewares/README.md
@@ -42,7 +42,7 @@ import {
 
 export default chain([
   oldIosCookiesMiddleware,
-  sessionCookieMiddleware(['/test']),
+  sessionCookieMiddleware([/^\/test$/]),
 ])
 ```
 

--- a/packages/middlewares/src/constants.ts
+++ b/packages/middlewares/src/constants.ts
@@ -1,3 +1,7 @@
 export const NEED_LOGIN_IDENTIFIER = 'NEED_LOGIN'
 
 export const X_AUTH_STATUS = 'x-auth-status'
+
+export const TP_TK = 'TP_TK'
+export const TP_SE = 'TP_SE'
+export const X_SOTO_SESSION = 'x-soto-session'

--- a/packages/middlewares/src/session-cookie.ts
+++ b/packages/middlewares/src/session-cookie.ts
@@ -3,7 +3,13 @@ import { get, post } from '@titicaca/fetcher'
 import { splitCookiesString, parseString } from 'set-cookie-parser'
 
 import { CustomMiddleware } from './chain'
-import { X_AUTH_STATUS, NEED_LOGIN_IDENTIFIER } from './constants'
+import {
+  X_AUTH_STATUS,
+  NEED_LOGIN_IDENTIFIER,
+  X_SOTO_SESSION,
+  TP_TK,
+  TP_SE,
+} from './constants'
 
 /**
  * 해당 미들웨어에서는 다음 순서로 사용자 인증 여부를 확인합니다.
@@ -27,6 +33,16 @@ export function sessionCookieMiddleware(paths: string[]) {
       }
 
       const cookies = deriveAllCookies(request.cookies.getAll())
+
+      const isSessionExisted =
+        cookies.includes(X_SOTO_SESSION) ||
+        cookies.includes(TP_TK) ||
+        cookies.includes(TP_SE)
+
+      if (!isSessionExisted) {
+        return customMiddleware(request, event, NextResponse.next())
+      }
+
       const options = {
         cookie: cookies,
         withApiUriBase: true,

--- a/packages/middlewares/src/session-cookie.ts
+++ b/packages/middlewares/src/session-cookie.ts
@@ -32,12 +32,14 @@ export function sessionCookieMiddleware(paths: RegExp[]) {
         return customMiddleware(request, event, NextResponse.next())
       }
 
-      const cookies = deriveAllCookies(request.cookies.getAll())
+      const allCookies = request.cookies.getAll()
 
-      const isSessionExisted =
-        cookies.includes(X_SOTO_SESSION) ||
-        cookies.includes(TP_TK) ||
-        cookies.includes(TP_SE)
+      const isSessionExisted = allCookies.some(
+        ({ name }) =>
+          name === X_SOTO_SESSION || name === TP_TK || name === TP_SE,
+      )
+
+      const cookies = deriveAllCookies(request.cookies.getAll())
 
       if (!isSessionExisted) {
         return customMiddleware(request, event, NextResponse.next())

--- a/packages/middlewares/src/session-cookie.ts
+++ b/packages/middlewares/src/session-cookie.ts
@@ -19,14 +19,14 @@ import {
  * 3. 갱신된 토큰을 response의 _set-cookie_ header와 set-cookie와 request의 _cookie_ header에 전달합니다.
  * 4. 브라우저는 response의 _set-cookie_ 를 통해 브라우저 쿠키값을 갱신합니다.
  */
-export function sessionCookieMiddleware(paths: string[]) {
+export function sessionCookieMiddleware(paths: RegExp[]) {
   return function withMiddleware(customMiddleware: CustomMiddleware) {
     return async function middleware(
       request: NextRequest,
       event: NextFetchEvent,
     ) {
       const isPathMismatched = !paths.some((path) =>
-        request.nextUrl.pathname.startsWith(path),
+        request.nextUrl.pathname.match(path),
       )
       if (isPathMismatched) {
         return customMiddleware(request, event, NextResponse.next())


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
`/users/me`와 `/session/token`은 관련 쿠키가 없는 경우에도 401 응답을 반환합니다. 따라서 세션과 관련한 쿠키가 있는 경우에만 sessionCookieMiddleware 로직이 실행되도록 수정합니다. 


path type을 regex로 변경합니다 .
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
