### PR TITLE
KLZT-766 영상기본음소거

### DIFF
--- a/packages/triple-media/src/triple-media.tsx
+++ b/packages/triple-media/src/triple-media.tsx
@@ -47,6 +47,7 @@ export default function Media({
     sourceUrl,
     title,
     description,
+    videoInitiallyMuted,
   } = media
 
   if (type && type === 'video' && video) {
@@ -60,6 +61,7 @@ export default function Media({
         cloudinaryId={cloudinaryId}
         autoPlay={autoPlay}
         loop={loop}
+        muted={videoInitiallyMuted}
         hideControls={!!hideControls}
         showNativeControls={showNativeControls}
       />

--- a/packages/type-definitions/src/image.ts
+++ b/packages/type-definitions/src/image.ts
@@ -62,4 +62,6 @@ export interface ImageMeta {
     href: string
     label?: string
   }
+  /* 어드민에서 설정하는 값으로 영상 재생시 소리를 음소거 해주는 기능 */
+  videoInitiallyMuted?: boolean
 }


### PR DESCRIPTION
## PR 설명

컨텐츠 어드민 (POI, Article)에서 영상 업로드시 "videoInitiallyMuted"라는 상태값을 추가하는 변경을 작업하는 중입니다.
각 도메인의 payload의 이미지들이 이제 영상일 경우 선택적으로 "videoInitiallyMuted"라는 플래그를 갖게 되며, 만약 이 플래그가 
True일 경우 영상재생시 기본 음소거 상태가 되어야합니다. 

[요구사항 링크](https://docs.google.com/spreadsheets/d/154kcdWRellyrPQbsAC8WXreJgV0fVaRtlXnQdR6C20g/edit?gid=0#gid=0)

필드가 옵셔널이기 때문에, API의 동작여부와 별개로 영향도가 존재하지 않습니다.

## 변경 내역

tds-widget의 Media Component에서 initiallyMuted 플래그가 있을 시 영상을 재생해도 기본 음소거가 되어야합니다.
tds-widget은 리뷰/트리플도큐먼트에서 모두 사용하는 것으로 확인되었습니다.

현재 기준으로 이 음소거는 유저의 행동에 의해 해제될 수 있습니다.
