### PR TITLE
[triple-email-template] default 링크 스타일을 추가하고, 스크롤 포커싱 이슈를 해결합니다.

### DIFF
--- a/packages/triple-email-document/src/elements/heading.tsx
+++ b/packages/triple-email-document/src/elements/heading.tsx
@@ -70,12 +70,14 @@ const H4Container = styled.h4`
 `
 
 export function Heading1View({
+  id,
   value: { text, headline },
 }: {
+  id?: string
   value: Heading1Document['value']
 }) {
   return (
-    <FluidTable>
+    <FluidTable id={id}>
       <tbody>
         <tr>
           <Box padding={{ top: 25, bottom: 20, left: 30, right: 30 }}>
@@ -89,12 +91,14 @@ export function Heading1View({
 }
 
 export function Heading2View({
+  id,
   value: { text },
 }: {
+  id?: string
   value: Heading2Document['value']
 }) {
   return (
-    <FluidTable>
+    <FluidTable id={id}>
       <tbody>
         <tr>
           <Box padding={{ top: 20, bottom: 20, left: 30, right: 30 }}>
@@ -107,12 +111,14 @@ export function Heading2View({
 }
 
 export function Heading3View({
+  id,
   value: { text },
 }: {
+  id?: string
   value: Heading3Document['value']
 }) {
   return (
-    <FluidTable>
+    <FluidTable id={id}>
       <tbody>
         <tr>
           <Box padding={{ top: 20, left: 30, right: 30 }}>
@@ -125,12 +131,14 @@ export function Heading3View({
 }
 
 export function Heading4View({
+  id,
   value: { text },
 }: {
+  id?: string
   value: Heading4Document['value']
 }) {
   return (
-    <FluidTable>
+    <FluidTable id={id}>
       <tbody>
         <tr>
           <Box padding={{ top: 20, left: 30, right: 30 }}>

--- a/packages/triple-email-document/src/elements/index.ts
+++ b/packages/triple-email-document/src/elements/index.ts
@@ -57,6 +57,7 @@ export type GetValue<Key extends TripleEmailElementType> = Extract<
 
 const ELEMENTS: {
   [key in TripleEmailElementType]: ComponentType<{
+    id?: string
     value: GetValue<key>
   }>
 } = {

--- a/packages/triple-email-document/src/elements/links.test.tsx
+++ b/packages/triple-email-document/src/elements/links.test.tsx
@@ -2,6 +2,26 @@ import { render, screen } from '@testing-library/react'
 
 import { ELEMENTS } from '../index'
 
+test('디폴트형 링크 Element를 렌더링합니다.', () => {
+  const Links = ELEMENTS.links
+
+  render(
+    <Links
+      value={{
+        links: [{ id: '', label: 'Default Styled Link', href: 'Test Href' }],
+        display: 'default',
+      }}
+    />,
+  )
+
+  const anchorElement = screen.getByRole('link')
+
+  expect(anchorElement).toHaveAttribute('href', 'Test Href')
+  expect(anchorElement).toHaveStyleRule('color', '#2987f0')
+  expect(anchorElement).toHaveStyleRule('text-decoration', 'underline')
+  expect(anchorElement).toHaveTextContent('Default Styled Link')
+})
+
 test('버튼형 링크 Element를 렌더링합니다.', () => {
   const Links = ELEMENTS.links
 

--- a/packages/triple-email-document/src/elements/links.tsx
+++ b/packages/triple-email-document/src/elements/links.tsx
@@ -33,6 +33,11 @@ const DefaultLink = styled.a`
   text-decoration: underline;
   overflow-wrap: break-word;
   white-space: pre-line;
+
+  &:hover {
+    color: #2987f0;
+    text-decoration: underline;
+  }
 `
 
 const ButtonLink = styled.a`

--- a/packages/triple-email-document/src/elements/links.tsx
+++ b/packages/triple-email-document/src/elements/links.tsx
@@ -15,9 +15,25 @@ export interface LinksDocument {
   type: 'links'
   value: {
     links: Link[]
-    display: 'button' | 'block' | 'largeButton' | 'largeCompactButton'
+    display:
+      | 'default'
+      | 'button'
+      | 'block'
+      | 'largeButton'
+      | 'largeCompactButton'
   }
 }
+
+const DefaultLink = styled.a`
+  display: inline-block;
+  margin-right: 20px;
+  font-size: 15px;
+  font-weight: bold;
+  color: #2987f0;
+  text-decoration: underline;
+  overflow-wrap: break-word;
+  white-space: pre-line;
+`
 
 const ButtonLink = styled.a`
   padding: 13px 25px;
@@ -77,6 +93,7 @@ declare module 'react' {
 }
 
 const LINK_BOXES = {
+  default: DefaultLinkBox,
   button: ButtonBox,
   block: BlockBox,
   largeButton: LargeBox,
@@ -84,6 +101,7 @@ const LINK_BOXES = {
 }
 
 const LINK_ELEMENTS = {
+  default: DefaultLink,
   button: ButtonLink,
   block: BlockLink,
   largeButton: LargeLink,
@@ -120,6 +138,14 @@ export default function LinksView({
         })}
       </tbody>
     </FluidTable>
+  )
+}
+
+function DefaultLinkBox({ children }: PropsWithChildren<unknown>) {
+  return (
+    <DefaultBox padding={{ top: 10, left: 30, right: 30 }}>
+      {children}
+    </DefaultBox>
   )
 }
 

--- a/packages/triple-email-document/src/links.stories.tsx
+++ b/packages/triple-email-document/src/links.stories.tsx
@@ -30,6 +30,11 @@ export default {
   },
 } as Meta
 
+export const StyledDefaultLinkElement: StoryObj = {
+  name: '디폴트',
+  args: generateSampleData('default'),
+}
+
 export const StyledButtonLinkElement: StoryObj = {
   name: '버튼',
   args: generateSampleData('button'),
@@ -50,7 +55,12 @@ export const StyledCompactLargeButtonLinkElement: StoryObj = {
   args: generateSampleData('largeCompactButton'),
 }
 
-type LinkDisplay = 'button' | 'block' | 'largeButton' | 'largeCompactButton'
+type LinkDisplay =
+  | 'default'
+  | 'button'
+  | 'block'
+  | 'largeButton'
+  | 'largeCompactButton'
 
 function generateSampleData(type: LinkDisplay) {
   return {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
컨텐츠 어드민 개선사항으로 다음과 같은 작업을 진행합니다.
- default 링크 스타일을 추가합니다. ([관련 스레드](https://nol-universe.slack.com/archives/C05ES3E2VL2/p1734679277134149))
  - triple-document의 default 링크 스타일을 triple-email-document에도 추가합니다. 스타일 외 기능은 동일합니다.
- 스크롤 포커싱 이슈를 해결합니다.
  - triple-email-document의 element로 id값이 주입되지 않는 문제를 해결합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
