### PR TITLE
(chat) 트리플 앱 디펜던시 제거

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,9 @@
 # 마이그레이션 가이드
 
+## v13.41.0 to v13.42.0
+
+- [13.42.0 업그레이드 가이드](https://yanoljagroup.atlassian.net/wiki/spaces/dev/pages/1762068097/triple-frontend+13+13.42.0)
+
 ## v12 to v13
 
 - [v13 업그레이드 가이드](https://titicaca.atlassian.net/l/cp/GhNV1PUo)

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -45,7 +45,6 @@
     "@titicaca/popup": "workspace:*",
     "@titicaca/router": "workspace:*",
     "@titicaca/type-definitions": "workspace:*",
-    "@titicaca/view-utilities": "workspace:*",
     "autolinker": "^4.0.0",
     "date-fns": "^3.3.1",
     "react-intersection-observer": "^9.13.1",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -44,7 +44,6 @@
     "@titicaca/core-elements": "workspace:*",
     "@titicaca/popup": "workspace:*",
     "@titicaca/router": "workspace:*",
-    "@titicaca/triple-web-to-native-interfaces": "1.9.0",
     "@titicaca/type-definitions": "workspace:*",
     "@titicaca/view-utilities": "workspace:*",
     "autolinker": "^4.0.0",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -43,7 +43,6 @@
     "@titicaca/color-palette": "workspace:*",
     "@titicaca/core-elements": "workspace:*",
     "@titicaca/popup": "workspace:*",
-    "@titicaca/router": "workspace:*",
     "@titicaca/type-definitions": "workspace:*",
     "autolinker": "^4.0.0",
     "date-fns": "^3.3.1",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -54,14 +54,12 @@
     "@titicaca/i18n": "workspace:*",
     "@titicaca/next-i18next": "13.8.5",
     "@titicaca/react-contexts": "workspace:*",
-    "@titicaca/react-triple-client-interfaces": "workspace:*",
     "@types/isomorphic-fetch": "^0.0.38",
     "react": "^18.2.0",
     "styled-components": "^5.3.11"
   },
   "peerDependencies": {
     "@titicaca/react-contexts": "*",
-    "@titicaca/react-triple-client-interfaces": "*",
     "react": "^18.0",
     "styled-components": "^5.3.9"
   }

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -44,7 +44,6 @@
     "@titicaca/core-elements": "workspace:*",
     "@titicaca/popup": "workspace:*",
     "@titicaca/router": "workspace:*",
-    "@titicaca/triple-fallback-action": "workspace:*",
     "@titicaca/triple-web-to-native-interfaces": "1.9.0",
     "@titicaca/type-definitions": "workspace:*",
     "@titicaca/view-utilities": "workspace:*",

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -61,6 +61,9 @@ export type BubbleUIProps = (
   onParentMessageClick?: TextBubbleProp['onParentMessageClick']
   onBubbleClick?: BubbleProp['onClick']
   onImageBubbleClick?: ImageBubbleProp['onClick']
+  /**
+   * a 링크 클릭 동작으로, 정의되지 않은 경우 새창으로 열립니다.
+   */
   onTextBubbleLinkClick?: TextBubbleProp['onLinkClick']
   onBubbleLongPress?: BubbleProp['onLongPress']
   onImageBubbleLongPress?: ImageBubbleProp['onLongPress']

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -75,7 +75,6 @@ export type BubbleUIProps = (
   maxWidthOffset?: BubbleProp['maxWidthOffset']
   cloudinaryName?: string
   mediaUrlBase?: string
-  appUrlScheme?: string
   hasArrow?: boolean
   alteredTextColor?: string
   fullTextViewAvailable?: boolean
@@ -102,7 +101,6 @@ export default function BubbleUI({
   maxWidthOffset,
   cloudinaryName,
   mediaUrlBase,
-  appUrlScheme,
   hasArrow,
   alteredTextColor,
   fullTextViewAvailable = false,
@@ -150,7 +148,6 @@ export default function BubbleUI({
         <ImageBubble
           id={id}
           images={value.images}
-          appUrlScheme={appUrlScheme}
           onClick={onImageBubbleClick}
           onLongPress={onImageBubbleLongPress}
           {...props}

--- a/packages/chat/src/bubble/bubble-ui.tsx
+++ b/packages/chat/src/bubble/bubble-ui.tsx
@@ -61,6 +61,7 @@ export type BubbleUIProps = (
   onParentMessageClick?: TextBubbleProp['onParentMessageClick']
   onBubbleClick?: BubbleProp['onClick']
   onImageBubbleClick?: ImageBubbleProp['onClick']
+  onTextBubbleLinkClick?: TextBubbleProp['onLinkClick']
   onBubbleLongPress?: BubbleProp['onLongPress']
   onImageBubbleLongPress?: ImageBubbleProp['onLongPress']
   onRichBubbleBlockClick?: {
@@ -93,6 +94,7 @@ export default function BubbleUI({
   alternativeText,
   onBubbleClick,
   onImageBubbleClick,
+  onTextBubbleLinkClick,
   onBubbleLongPress,
   onImageBubbleLongPress,
   onRichBubbleBlockClick,
@@ -135,6 +137,7 @@ export default function BubbleUI({
           message={value.message}
           created={created}
           onClick={onBubbleClick}
+          onLinkClick={onTextBubbleLinkClick}
           onLongPress={onBubbleLongPress}
           onOpenMenu={onOpenMenu}
           hasArrow={hasArrow}

--- a/packages/chat/src/bubble/bubble.stories.tsx
+++ b/packages/chat/src/bubble/bubble.stories.tsx
@@ -124,7 +124,6 @@ export const Image = {
         },
       },
     ],
-    appUrlScheme: '',
   },
 }
 

--- a/packages/chat/src/bubble/image.tsx
+++ b/packages/chat/src/bubble/image.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { useLongPress } from 'use-long-press'
 
 import { MetaDataInterface } from '../types'
-import { navigateToImage } from '../utils'
 
 import { ImageItem } from './item'
 import { ImageBubbleProp } from './type'
@@ -21,7 +20,6 @@ const MAX_IMAGE_WIDTH = 247
 export function ImageBubble({
   id,
   images,
-  appUrlScheme,
   onClick,
   onLongPress,
 }: ImageBubbleProp) {
@@ -53,8 +51,6 @@ export function ImageBubble({
               onClick={(e) => {
                 if (onClick) {
                   onClick?.(e, images, image.index)
-                } else if (appUrlScheme) {
-                  navigateToImage({ appUrlScheme, images, index })
                 }
               }}
               css={

--- a/packages/chat/src/bubble/images.stories.tsx
+++ b/packages/chat/src/bubble/images.stories.tsx
@@ -86,6 +86,5 @@ export const Image = {
         },
       },
     ],
-    appUrlScheme: '',
   },
 }

--- a/packages/chat/src/bubble/text.tsx
+++ b/packages/chat/src/bubble/text.tsx
@@ -33,6 +33,7 @@ export function TextBubble({
   onOpenMenu,
   fullTextViewAvailable,
   onParentMessageClick,
+  onLinkClick,
   ...props
 }: TextBubbleProp) {
   const { back, push } = useHistoryFunctions()
@@ -40,7 +41,7 @@ export function TextBubble({
   const fullTextViewHash = `${SHOW_FULL_TEXT_VIEW}-${id}`
   const isFullTextViewOpen = uriHash === fullTextViewHash
 
-  const aTagNavigator = useATagNavigator()
+  const aTagNavigator = useATagNavigator(onLinkClick)
   const isEllipsis =
     fullTextViewAvailable && message.length > MAX_VIEWABLE_TEXT_LENGTH
 

--- a/packages/chat/src/bubble/type.ts
+++ b/packages/chat/src/bubble/type.ts
@@ -76,6 +76,7 @@ export type TextBubbleProp = {
   fullTextViewAvailable?: boolean
   onOpenMenu?: () => void
   onParentMessageClick?: (id: string) => void
+  onLinkClick?: (href: string) => void
 } & BubbleProp
 
 export type RichBubbleProp = {

--- a/packages/chat/src/bubble/type.ts
+++ b/packages/chat/src/bubble/type.ts
@@ -93,7 +93,6 @@ export type RichBubbleProp = {
 export interface ImageBubbleProp {
   id: string
   images: MetaDataInterface[]
-  appUrlScheme?: string
   onClick?: (
     e: MouseEvent,
     images: MetaDataInterface[],

--- a/packages/chat/src/chat/chat-scroll-container.tsx
+++ b/packages/chat/src/chat/chat-scroll-container.tsx
@@ -1,6 +1,5 @@
 import { PropsWithChildren, useEffect } from 'react'
 import { InView } from 'react-intersection-observer'
-import { closeKeyboard } from '@titicaca/triple-web-to-native-interfaces'
 import { useUserAgentContext } from '@titicaca/react-contexts'
 import { Container } from '@titicaca/core-elements'
 
@@ -9,6 +8,12 @@ import { useScroll } from './scroll-context'
 export interface ChatScrollContainerProps {
   onTopIntersecting?: (entry: IntersectionObserverEntry) => void
   onBottomIntersecting?: (entry: IntersectionObserverEntry) => void
+  /**
+   * ios에서 스크롤 시 실행되는 리스너입니다.
+   * 키보드가 내려가도록 closeKeyboard interface를 전달하여 사용할 수 있습니다.
+   * ref: https://github.com/titicacadev/triple-chat-web/pull/37
+   */
+  onIosTouchMove?: () => void
 }
 
 /** 
@@ -18,6 +23,7 @@ export interface ChatScrollContainerProps {
 export function ChatScrollContainer({
   onTopIntersecting,
   onBottomIntersecting,
+  onIosTouchMove,
   children,
   ...props
 }: PropsWithChildren<ChatScrollContainerProps>) {
@@ -25,16 +31,12 @@ export function ChatScrollContainer({
   const { os } = useUserAgentContext()
 
   useEffect(() => {
-    /**
-     * ios에서 스크롤 시 키보드가 내려가도록 설정합니다.
-     * ref: https://github.com/titicacadev/triple-chat-web/pull/37
-     */
     const chatContainerElement = chatContainerRef.current
 
-    if (chatContainerElement && os.name === 'iOS') {
-      chatContainerElement.addEventListener('touchmove', closeKeyboard)
+    if (chatContainerElement && os.name === 'iOS' && onIosTouchMove) {
+      chatContainerElement.addEventListener('touchmove', onIosTouchMove)
       return () => {
-        chatContainerElement.removeEventListener('touchmove', closeKeyboard)
+        chatContainerElement.removeEventListener('touchmove', onIosTouchMove)
       }
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/chat/src/utils/a-tag-navigator.ts
+++ b/packages/chat/src/utils/a-tag-navigator.ts
@@ -1,14 +1,10 @@
 import { MouseEvent } from 'react'
-import { useEnv } from '@titicaca/react-contexts'
-import { useExternalRouter, useHrefToProps } from '@titicaca/router'
-import { useTripleClientMetadata } from '@titicaca/react-triple-client-interfaces'
 
-export default function useATagNavigator() {
-  const routeExternally = useExternalRouter()
-  const { webUrlBase } = useEnv()
-  const convertHrefToProps = useHrefToProps()
-  const app = useTripleClientMetadata()
+import { TextBubbleProp } from '../bubble/type'
 
+export default function useATagNavigator(
+  onLinkClick?: TextBubbleProp['onLinkClick'],
+) {
   const aTagNavigator = (event: MouseEvent) => {
     event.preventDefault()
     event.stopPropagation()
@@ -16,19 +12,14 @@ export default function useATagNavigator() {
     const eventTarget = event.target as HTMLElement
 
     if (eventTarget.tagName === 'A') {
-      const originHref = eventTarget.getAttribute('href') ?? ''
-
-      const href =
-        originHref.includes(webUrlBase) && app
-          ? convertHrefToProps(originHref).href
-          : originHref
+      const href = eventTarget.getAttribute('href') ?? ''
 
       if (href) {
-        routeExternally({
-          href,
-          target: 'browser',
-          noNavbar: true,
-        })
+        if (onLinkClick) {
+          onLinkClick(href)
+        } else {
+          window.open(href, '_blank', 'noopener')
+        }
       }
     }
   }

--- a/packages/chat/src/utils/image.ts
+++ b/packages/chat/src/utils/image.ts
@@ -1,7 +1,3 @@
-import qs from 'querystring'
-
-import { generateUrl } from '@titicaca/view-utilities'
-
 import { UserInterface, MetaDataInterface } from '../types'
 
 export function getProfileImageUrl(user: UserInterface) {
@@ -40,20 +36,4 @@ export function generatePreviewImage({
     width,
     customWidth,
   )},q_auto,f_auto/${cloudinaryId}.jpeg`
-}
-
-export function navigateToImage({
-  appUrlScheme,
-  images,
-  index = 0,
-}: {
-  appUrlScheme: string
-  images: MetaDataInterface[]
-  index?: number
-}) {
-  window.location.href = generateUrl({
-    scheme: appUrlScheme,
-    path: '/images',
-    query: qs.stringify({ images: JSON.stringify(images), index }),
-  })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,9 +418,6 @@ importers:
       '@titicaca/router':
         specifier: workspace:*
         version: link:../router
-      '@titicaca/triple-fallback-action':
-        specifier: workspace:*
-        version: link:../triple-fallback-action
       '@titicaca/triple-web-to-native-interfaces':
         specifier: 1.9.0
         version: 1.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,9 +421,6 @@ importers:
       '@titicaca/type-definitions':
         specifier: workspace:*
         version: link:../type-definitions
-      '@titicaca/view-utilities':
-        specifier: workspace:*
-        version: link:../view-utilities
       autolinker:
         specifier: ^4.0.0
         version: 4.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,9 +418,6 @@ importers:
       '@titicaca/router':
         specifier: workspace:*
         version: link:../router
-      '@titicaca/triple-web-to-native-interfaces':
-        specifier: 1.9.0
-        version: 1.9.0
       '@titicaca/type-definitions':
         specifier: workspace:*
         version: link:../type-definitions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,9 +443,6 @@ importers:
       '@titicaca/react-contexts':
         specifier: workspace:*
         version: link:../react-contexts
-      '@titicaca/react-triple-client-interfaces':
-        specifier: workspace:*
-        version: link:../react-triple-client-interfaces
       '@types/isomorphic-fetch':
         specifier: ^0.0.38
         version: 0.0.38

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,9 +415,6 @@ importers:
       '@titicaca/popup':
         specifier: workspace:*
         version: link:../popup
-      '@titicaca/router':
-        specifier: workspace:*
-        version: link:../router
       '@titicaca/type-definitions':
         specifier: workspace:*
         version: link:../type-definitions


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

chat 패키지 내부의 트리플 앱 기반 동작을 제거하고 외부에서 주입하도록 합니다.

### 배경
현재 chat 패키지는 트리플 앱 기반의 서비스(triple-chat-web) 뿐만 아니라 파트너센터에서도 사용되고 있으며, 
triple-chat-web은 타 도메인(ex. 인터파크)에서도 사용될 수 있도록 확장하는 작업을 진행중입니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

- ChatScrollContainer 내부에서 트리플-iOS 앱인 경우 스크롤 시 키보드를 닫아주는 동작 => [onIosTouchMove](https://github.com/titicacadev/triple-frontend/pull/3554/files#diff-beb4ce88859ddfa26624b02913bccd91864058351412b2d9b490be9fc38d5ba4R16) 프롭스로 전환 
- TextBubble 내부에서 a 링크 이동시 사용하는 @titicaca/router 동작 => `onTextBubbleLinkClick` 프롭스로 전환하고, 해당 프롭이 없는 경우 `window.open` 실행
- ImageBubble 클릭 시 이미지 뷰어로 이동하는 동작 => `onImageBubbleClick`로 전환

- [마이그레이션 가이드](https://yanoljagroup.atlassian.net/wiki/spaces/dev/pages/1762068097/triple-frontend+13+13.42.0) 
## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
