### PR TITLE
[router] openNativeLink에서 href가 아닌 path를 param으로 넘겨주도록 수정

### DIFF
--- a/packages/router/src/navigate/use-navigate.ts
+++ b/packages/router/src/navigate/use-navigate.ts
@@ -78,12 +78,13 @@ export function useNavigate({
         return
       }
 
-      const { scheme } = parseUrl(rawHref)
+      const { scheme, path, query, hash } = parseUrl(rawHref)
 
       if (scheme === 'http' || scheme === 'https') {
         openOutlink(rawHref, options)
       } else {
-        openNativeLink(rawHref)
+        const appPath = generateUrl({ path, query, hash })
+        openNativeLink(appPath)
       }
     },
     [


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[openNativeLink](https://github.com/titicacadev/triple-frontend/blob/main/packages/router/src/links/use-open-native-link.ts#L13-L16)는 인자로 href가 아닌 path를 받고, 내부에서 appUrlScheme을 추가해주고 있습니다.
반면 이를 사용하는 useNavigate 내의 navigateInApp에서는 openNativeLink에 appUrlScheme을 포함하는 href를 인자로 넣어주고 있어 appUrlScheme이 중복해서 들어가는 이슈가 있습니다. 
openNativeLink에서 href가 아닌 path를 param으로 넘겨주도록 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
