### PR TITLE
(Chat) 채팅 버블 부가 정보 커스텀 스타일 프롭스 추가

### DIFF
--- a/packages/tds-widget/src/chat/bubble-container/bubble-container.tsx
+++ b/packages/tds-widget/src/chat/bubble-container/bubble-container.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren } from 'react'
+import { css, CSSProp } from 'styled-components'
 import { Container } from '@titicaca/tds-ui'
 
 import { DEFAULT_MESSAGE_ID_PREFIX } from '../chat/constants'
@@ -41,6 +42,14 @@ interface ContainerBaseProp {
   onReplyClick?: () => void
   /** 메세지 ref에 주입되는 callback 함수 */
   messageRefCallback?: (id: string) => void
+  /** 메세지 부가 정보 (날짜, 프로필 등) 커스텀 스타일 */
+  bubbleInfoStyle?: {
+    dateDivider?: { css?: CSSProp }
+    unreadCount?: { css?: CSSProp }
+    dateTime?: { css?: CSSProp }
+    profile?: { css?: CSSProp }
+    thanks?: { css?: CSSProp }
+  }
 }
 
 type SentBubbleContainerProp = PropsWithChildren<
@@ -66,6 +75,7 @@ function SentBubbleContainer({
   onReplyClick,
   messageRefCallback,
   children,
+  bubbleInfoStyle,
   ...props
 }: SentBubbleContainerProp) {
   return (
@@ -96,6 +106,8 @@ function SentBubbleContainer({
             showTimeInfo={showTimeInfo}
             onReplyClick={onReplyClick}
             css={{ marginRight: 4, textAlign: 'right' }}
+            dateTimeStyle={bubbleInfoStyle?.dateTime}
+            unreadCountStyle={bubbleInfoStyle?.unreadCount}
           />
         ) : null}
 
@@ -107,7 +119,13 @@ function SentBubbleContainer({
           count={thanks.count}
           haveMine={thanks.haveMine}
           onClick={onThanksClick}
-          css={{ display: 'inline-flex', marginTop: 6, marginRight: 10 }}
+          css={css`
+            display: inline-flex;
+            margin-top: 6px;
+            margin-right: 10px;
+
+            ${bubbleInfoStyle?.thanks?.css}
+          `}
         />
       ) : null}
     </Container>
@@ -145,6 +163,7 @@ function ReceivedBubbleContainer({
   messageRefCallback,
   onUserClick,
   children,
+  bubbleInfoStyle,
   ...props
 }: ReceivedBubbleContainerProp) {
   return (
@@ -170,7 +189,12 @@ function ReceivedBubbleContainer({
       ) : null}
       <Container css={{ marginLeft: 40 }}>
         {showProfile ? (
-          <ProfileName size="mini" alpha={0.8} margin={{ bottom: 5 }}>
+          <ProfileName
+            size="mini"
+            alpha={0.8}
+            margin={{ bottom: 5 }}
+            css={bubbleInfoStyle?.profile?.css}
+          >
             {user
               ? formatUsername({
                   name: user?.name,
@@ -192,6 +216,8 @@ function ReceivedBubbleContainer({
             onReplyClick={onReplyClick}
             date={createdAt}
             css={{ marginLeft: 4, textAlign: 'left' }}
+            dateTimeStyle={bubbleInfoStyle?.dateTime}
+            unreadCountStyle={bubbleInfoStyle?.unreadCount}
           />
         ) : null}
 

--- a/packages/tds-widget/src/chat/bubble-container/bubble-info.tsx
+++ b/packages/tds-widget/src/chat/bubble-container/bubble-info.tsx
@@ -1,5 +1,5 @@
 import { Container, Text } from '@titicaca/tds-ui'
-import { styled } from 'styled-components'
+import styled, { CSSProp } from 'styled-components'
 import { format, setDefaultOptions } from 'date-fns'
 import { ko } from 'date-fns/locale'
 
@@ -36,6 +36,8 @@ export function BubbleInfo({
   showTimeInfo = true,
   showDateInfo = false,
   onReplyClick,
+  dateTimeStyle,
+  unreadCountStyle,
   ...props
 }: {
   align: 'left' | 'right'
@@ -44,6 +46,8 @@ export function BubbleInfo({
   showTimeInfo?: boolean
   showDateInfo?: boolean
   onReplyClick?: () => void
+  dateTimeStyle?: { css?: CSSProp }
+  unreadCountStyle?: { css?: CSSProp }
 }) {
   return (
     <BubbleInfoContainer position="relative" display="inline-block" {...props}>
@@ -58,17 +62,19 @@ export function BubbleInfo({
       ) : null}
 
       {unreadCount ? (
-        <UnreadMessageCountText>{unreadCount}</UnreadMessageCountText>
+        <UnreadMessageCountText css={unreadCountStyle?.css}>
+          {unreadCount}
+        </UnreadMessageCountText>
       ) : null}
 
       {showDateInfo ? (
-        <Text size={10} alpha={0.51}>
+        <Text size={10} alpha={0.51} css={dateTimeStyle?.css}>
           {format(new Date(date), 'MM.dd')}
         </Text>
       ) : null}
 
       {showTimeInfo ? (
-        <Text size={10} alpha={0.51}>
+        <Text size={10} alpha={0.51} css={dateTimeStyle?.css}>
           {format(new Date(date), 'a h:mm')}
         </Text>
       ) : null}

--- a/packages/tds-widget/src/chat/messages/date-divider.tsx
+++ b/packages/tds-widget/src/chat/messages/date-divider.tsx
@@ -1,9 +1,15 @@
 import { Text } from '@titicaca/tds-ui'
 import { format } from 'date-fns'
 
-export function DateDivider({ date }: { date: Date }) {
+export function DateDivider({ date, ...props }: { date: Date }) {
   return (
-    <Text textAlign="center" size={11} color="gray700" margin={{ top: 30 }}>
+    <Text
+      textAlign="center"
+      size={11}
+      color="gray700"
+      margin={{ top: 30 }}
+      {...props}
+    >
       {format(date, 'yyyy년 MM월 dd일')}
     </Text>
   )

--- a/packages/tds-widget/src/chat/messages/index.tsx
+++ b/packages/tds-widget/src/chat/messages/index.tsx
@@ -2,7 +2,9 @@ import { ComponentType, Fragment } from 'react'
 import { CSSProp } from 'styled-components'
 import { InView } from 'react-intersection-observer'
 
-import BubbleContainer from '../bubble-container/bubble-container'
+import BubbleContainer, {
+  BubbleContainerProp,
+} from '../bubble-container/bubble-container'
 import BubbleUI, { BubbleUIProps } from '../bubble/bubble-ui'
 import { UserInterface } from '../types'
 import AlteredBubble from '../bubble/altered'
@@ -15,7 +17,7 @@ import { DateDivider } from './date-divider'
 interface MessagesProp<
   Message extends MessageBase<User>,
   User extends UserInterface,
-> {
+> extends Pick<BubbleContainerProp, 'bubbleInfoStyle'> {
   messages: MessageInterface<Message, User>[]
   pendingMessages: MessageInterface<Message, User>[]
   failedMessages: MessageInterface<Message, User>[]
@@ -68,6 +70,7 @@ export default function Messages<
   onOpenMenu,
   onParentMessageClick,
   onUserClick,
+  bubbleInfoStyle,
   ...bubbleProps
 }: MessagesProp<Message, User> &
   Omit<
@@ -200,6 +203,7 @@ export default function Messages<
                   ? new Date()
                   : new Date(message.createdAt)
               }
+              css={bubbleInfoStyle?.dateDivider?.css}
             />
           ) : null}
 
@@ -249,6 +253,7 @@ export default function Messages<
                 marginTop: isFirstMessageOfDate ? 20 : showProfile ? 16 : 5,
               }}
               onUserClick={onUserClick}
+              bubbleInfoStyle={bubbleInfoStyle}
             >
               {getBubble({ message, my, hasArrow: showProfile })}
             </BubbleContainer>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

- 채팅 버블 부가정보(dateDivider, unreadCount, dateTime, profile, thanks)의 스타일을 커스텀할 수 있도록 합니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

|기본|커스텀|
|---|---|
|![스크린샷 2025-03-10 오후 1 56 50](https://github.com/user-attachments/assets/507b199f-1a29-4ad8-b903-0b6a0cc5767b)|![스크린샷 2025-03-10 오후 1 43 23](https://github.com/user-attachments/assets/02ecf801-97db-4a85-a46e-96864b9e906e)|




<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
