### PR TITLE
[footer, react-contexts] 푸터 정보를 footer.json으로 관리하도록 수정합니다.

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -30,7 +30,7 @@ export function envProviderDecorator(Story) {
       afOnelinkId=""
       afOnelinkPid=""
       afOnelinkSubdomain=""
-      webAssetUrl="https://assets.triple-dev.titicaca-corp.com"
+      webAssetsUrl="https://assets.triple-dev.titicaca-corp.com"
     >
       <Story />
     </EnvProvider>

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -30,6 +30,7 @@ export function envProviderDecorator(Story) {
       afOnelinkId=""
       afOnelinkPid=""
       afOnelinkSubdomain=""
+      webAssetUrl="https://assets.triple-dev.titicaca-corp.com"
     >
       <Story />
     </EnvProvider>

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,8 +3,11 @@ import type { StorybookConfig } from '@storybook/nextjs'
 
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin')
 
+const EXCEPT_PACKAGES = ['middlewares']
+
 const stories = fs
   .readdirSync('packages')
+  .filter((pkg) => !EXCEPT_PACKAGES.includes(pkg))
   .map((pkg) => `../packages/${pkg}/src/**/*.stories.@(mdx,js|jsx|ts|tsx)`)
 
 const config: StorybookConfig = {
@@ -36,6 +39,7 @@ const config: StorybookConfig = {
           configFile: 'tsconfig.test.json',
         }),
       ]
+      config.resolve.fallback = { fs: false }
     }
 
     return config

--- a/packages/footer/src/award-footer.stories.tsx
+++ b/packages/footer/src/award-footer.stories.tsx
@@ -1,10 +1,25 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { rest } from 'msw'
 
 import { AwardFooter } from './award-footer'
+import { CompanyInfo } from './company-info'
 
 export default {
   title: 'footer / AwardFooter',
   component: AwardFooter,
 } as Meta<typeof AwardFooter>
 
-export const Basic: StoryObj<typeof AwardFooter> = {}
+export const Basic: StoryObj<typeof AwardFooter> = {
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get(
+          'https://assets.triple-dev.titicaca-corp.com/footer/footer.json',
+          async (req, res, ctx) => {
+            return res(ctx.json(CompanyInfo))
+          },
+        ),
+      ],
+    },
+  },
+}

--- a/packages/footer/src/award-footer.stories.tsx
+++ b/packages/footer/src/award-footer.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { rest } from 'msw'
 
 import { AwardFooter } from './award-footer'
-import { CompanyInfo } from './company-info'
+import MockFooterInfo from './footer.json'
 
 export default {
   title: 'footer / AwardFooter',
@@ -16,7 +16,7 @@ export const Basic: StoryObj<typeof AwardFooter> = {
         rest.get(
           'https://assets.triple-dev.titicaca-corp.com/footer/footer.json',
           async (req, res, ctx) => {
-            return res(ctx.json(CompanyInfo))
+            return res(ctx.json(MockFooterInfo))
           },
         ),
       ],

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -61,6 +61,10 @@ export function AwardFooter({
   const footerInfo = useFooterInfo()
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
+  if (!footerInfo) {
+    return null
+  }
+
   return (
     <FooterFrame {...props}>
       <Container

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -8,7 +8,7 @@ import {
   FooterFrame,
 } from './default-footer'
 import { CompanyInfo } from './company-info'
-import { ExtraLink } from './extra-link'
+import { ExtraLinkGroup } from './extra-link-group'
 import { useFooterInfo } from './use-footer-info'
 import { FooterAward } from './type'
 
@@ -95,11 +95,7 @@ export function AwardFooter({
         <InfoFlexBox>
           <Container>
             <LinkGroupBase links={footerInfo.links} />
-            {footerInfo.extraLinks.length
-              ? footerInfo.extraLinks.map((link, index) => (
-                  <ExtraLink key={`extra-link-${index}`} {...link} />
-                ))
-              : null}
+            <ExtraLinkGroup extraLinks={footerInfo.extraLinks} />
           </Container>
 
           <AwardGroup awards={footerInfo.awards} />

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -8,17 +8,9 @@ import {
   FooterFrame,
 } from './default-footer'
 import { CompanyInfo } from './company-info'
-import { TripleKoreaLink } from './triple-korea-link'
-
-const AWARD_INFO = [
-  {
-    id: 1,
-    imageUrl:
-      'https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/1060b728-6ef3-477d-a64a-0a38f5c3250e.jpeg',
-    alt: '국제표준 정보보호 인증마크 ISO27001, ISO 27701',
-    text: '국제표준 정보보호 인증 취득\nISO 27001, ISO 27701',
-  },
-]
+import { ExtraLink } from './extra-link'
+import { useCompanyInfo } from './use-company-info'
+import { Award } from './type'
 
 const InfoFlexBox = styled(FlexBox).attrs({
   flex: true,
@@ -65,6 +57,7 @@ export function AwardFooter({
   hideAppDownloadButton = false,
   ...props
 }: AwardFooterProps) {
+  const companyInfo = useCompanyInfo()
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
   return (
@@ -78,6 +71,7 @@ export function AwardFooter({
         }}
       >
         <CompanyInfo
+          company={companyInfo.company}
           hideAppDownloadButton={hideAppDownloadButton}
           businessExpanded={businessExpanded}
           setBusinessExpanded={setBusinessExpanded}
@@ -89,28 +83,31 @@ export function AwardFooter({
           color="gray500"
           margin={{ top: businessExpanded ? 15 : 18, bottom: 5 }}
         >
-          &#12828;놀유니버스는 통신판매중개로서 통신판매의 당사자가 아니며
-          <br /> 상품 거래정보 및 거래 등에 대해 책임을 지지 않습니다.
+          {companyInfo.disclaimer}
         </Text>
 
         <InfoFlexBox>
           <Container>
-            <LinkGroupBase />
-            <TripleKoreaLink />
+            <LinkGroupBase links={companyInfo.links} />
+            {companyInfo.extraLinks.length
+              ? companyInfo.extraLinks.map((link, index) => (
+                  <ExtraLink key={`extra-link-${index}`} {...link} />
+                ))
+              : null}
           </Container>
 
-          <AwardGroup />
+          <AwardGroup awards={companyInfo.awards} />
         </InfoFlexBox>
       </Container>
     </FooterFrame>
   )
 }
 
-function AwardGroup() {
+function AwardGroup({ awards }: { awards: Award[] }) {
   return (
     <AwardFlexBox>
-      {AWARD_INFO.map(({ id, imageUrl, alt, text }) => (
-        <Fragment key={id}>
+      {awards.map(({ imageUrl, alt, text }, index) => (
+        <Fragment key={`award-${index}`}>
           <AwardImg src={imageUrl} alt={alt} />
           <Tooltip>{text}</Tooltip>
         </Fragment>

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -10,7 +10,7 @@ import {
 import { CompanyInfo } from './company-info'
 import { ExtraLink } from './extra-link'
 import { useFooterInfo } from './use-footer-info'
-import { Award } from './type'
+import { FooterAward } from './type'
 
 const InfoFlexBox = styled(FlexBox).attrs({
   flex: true,
@@ -71,7 +71,7 @@ export function AwardFooter({
         }}
       >
         <CompanyInfo
-          company={footerInfo.company}
+          companyTexts={footerInfo.companyTexts}
           hideAppDownloadButton={hideAppDownloadButton}
           businessExpanded={businessExpanded}
           setBusinessExpanded={setBusinessExpanded}
@@ -103,7 +103,7 @@ export function AwardFooter({
   )
 }
 
-function AwardGroup({ awards }: { awards: Award[] }) {
+function AwardGroup({ awards }: { awards: FooterAward[] }) {
   return (
     <AwardFlexBox>
       {awards.map(({ imageUrl, alt, text }, index) => (

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -9,7 +9,7 @@ import {
 } from './default-footer'
 import { CompanyInfo } from './company-info'
 import { ExtraLink } from './extra-link'
-import { useCompanyInfo } from './use-company-info'
+import { useFooterInfo } from './use-footer-info'
 import { Award } from './type'
 
 const InfoFlexBox = styled(FlexBox).attrs({
@@ -57,7 +57,7 @@ export function AwardFooter({
   hideAppDownloadButton = false,
   ...props
 }: AwardFooterProps) {
-  const companyInfo = useCompanyInfo()
+  const footerInfo = useFooterInfo()
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
   return (
@@ -71,7 +71,7 @@ export function AwardFooter({
         }}
       >
         <CompanyInfo
-          company={companyInfo.company}
+          company={footerInfo.company}
           hideAppDownloadButton={hideAppDownloadButton}
           businessExpanded={businessExpanded}
           setBusinessExpanded={setBusinessExpanded}
@@ -83,20 +83,20 @@ export function AwardFooter({
           color="gray500"
           margin={{ top: businessExpanded ? 15 : 18, bottom: 5 }}
         >
-          {companyInfo.disclaimer}
+          {footerInfo.disclaimer}
         </Text>
 
         <InfoFlexBox>
           <Container>
-            <LinkGroupBase links={companyInfo.links} />
-            {companyInfo.extraLinks.length
-              ? companyInfo.extraLinks.map((link, index) => (
+            <LinkGroupBase links={footerInfo.links} />
+            {footerInfo.extraLinks.length
+              ? footerInfo.extraLinks.map((link, index) => (
                   <ExtraLink key={`extra-link-${index}`} {...link} />
                 ))
               : null}
           </Container>
 
-          <AwardGroup awards={companyInfo.awards} />
+          <AwardGroup awards={footerInfo.awards} />
         </InfoFlexBox>
       </Container>
     </FooterFrame>

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -47,6 +47,7 @@ const AwardFlexBox = styled(FlexBox).attrs({
   position: 'relative',
   flex: true,
   gap: 7,
+  flexShrink: 0,
 })`
   ${AwardImg}:hover + ${Tooltip} {
     display: block;
@@ -82,6 +83,7 @@ export function AwardFooter({
           lineHeight="17px"
           color="gray500"
           margin={{ top: businessExpanded ? 15 : 18, bottom: 5 }}
+          css={{ maxWidth: 280, wordBreak: 'break-word' }}
         >
           {footerInfo.disclaimer}
         </Text>

--- a/packages/footer/src/company-info.tsx
+++ b/packages/footer/src/company-info.tsx
@@ -13,6 +13,8 @@ import {
 } from '@titicaca/react-contexts'
 import { Dispatch, SetStateAction } from 'react'
 
+import { Company } from './type'
+
 const MAX_PHONE_WIDTH = 360
 
 const AccordionHeader = styled(FlexBox)`
@@ -76,12 +78,14 @@ const ButtonContainer = styled(FlexBox)`
 `
 
 interface CompanyInfoProps {
+  company: Company
   hideAppDownloadButton?: boolean
   businessExpanded: boolean
   setBusinessExpanded: Dispatch<SetStateAction<boolean>>
 }
 
 export function CompanyInfo({
+  company,
   hideAppDownloadButton = false,
   businessExpanded,
   setBusinessExpanded,
@@ -89,6 +93,15 @@ export function CompanyInfo({
   const sessionAvailable = useSessionAvailability()
   const { login, logout } = useSessionControllers()
   const { trackEvent } = useEventTrackingContext()
+
+  const {
+    name,
+    ceo,
+    businessRegistrationNumber,
+    salesReportNumber,
+    address,
+    contact,
+  } = company
 
   return (
     <Accordion
@@ -155,15 +168,17 @@ export function CompanyInfo({
 
       <AccordionContent>
         <Text size={11} lineHeight="17px" color="gray500" padding={{ top: 20 }}>
-          &#12828;놀유니버스 | 대표이사 배보찬, 최휘영 <br />
-          사업자 등록번호 824-81-02515
+          {`${name} | ${ceo.label} ${ceo.names.join(' ')}`}
           <br />
-          통신판매업 신고번호 2024-성남수정-0912
+          {`${businessRegistrationNumber.label} ${businessRegistrationNumber.value}`}
           <br />
-          경기도 성남시 수정구 금토로 70 (금토동, 텐엑스타워)
+          {`${salesReportNumber.label} ${salesReportNumber.value}`}
           <br />
-          항공, 숙소 및 투어·티켓 문의 1588-2539 <br />
-          help.triple@nol-universe.com
+          {`${address.value}`}
+          <br />
+          {`${contact.label} ${contact.phone}`}
+          <br />
+          {`${contact.email}`}
         </Text>
       </AccordionContent>
     </Accordion>

--- a/packages/footer/src/company-info.tsx
+++ b/packages/footer/src/company-info.tsx
@@ -11,9 +11,9 @@ import {
   useSessionAvailability,
   useSessionControllers,
 } from '@titicaca/react-contexts'
-import { Dispatch, SetStateAction } from 'react'
+import { Dispatch, Fragment, SetStateAction } from 'react'
 
-import { Company } from './type'
+import { FooterText } from './type'
 
 const MAX_PHONE_WIDTH = 360
 
@@ -77,15 +77,19 @@ const ButtonContainer = styled(FlexBox)`
   }
 `
 
+const LinkContainer = styled.a`
+  text-decoration: underline;
+`
+
 interface CompanyInfoProps {
-  company: Company
+  companyTexts: Array<FooterText[]>
   hideAppDownloadButton?: boolean
   businessExpanded: boolean
   setBusinessExpanded: Dispatch<SetStateAction<boolean>>
 }
 
 export function CompanyInfo({
-  company,
+  companyTexts,
   hideAppDownloadButton = false,
   businessExpanded,
   setBusinessExpanded,
@@ -93,15 +97,6 @@ export function CompanyInfo({
   const sessionAvailable = useSessionAvailability()
   const { login, logout } = useSessionControllers()
   const { trackEvent } = useEventTrackingContext()
-
-  const {
-    name,
-    ceo,
-    businessRegistrationNumber,
-    salesReportNumber,
-    address,
-    contact,
-  } = company
 
   return (
     <Accordion
@@ -168,17 +163,27 @@ export function CompanyInfo({
 
       <AccordionContent>
         <Text size={11} lineHeight="17px" color="gray500" padding={{ top: 20 }}>
-          {`${name} | ${ceo.label} ${ceo.names.join(' ')}`}
-          <br />
-          {`${businessRegistrationNumber.label} ${businessRegistrationNumber.value}`}
-          <br />
-          {`${salesReportNumber.label} ${salesReportNumber.value}`}
-          <br />
-          {`${address.value}`}
-          <br />
-          {`${contact.label} ${contact.phone}`}
-          <br />
-          {`${contact.email}`}
+          {companyTexts.map((texts, index) => (
+            <Fragment key={`company-text-line-${index}`}>
+              {texts.map(({ text, url, faEventAction }, index) => (
+                <Fragment key={`company-text-${index}`}>
+                  {url ? (
+                    <LinkContainer
+                      onClick={() =>
+                        trackEvent({ fa: { action: faEventAction } })
+                      }
+                    >
+                      {text}
+                    </LinkContainer>
+                  ) : (
+                    text
+                  )}
+                  {index !== texts.length - 1 ? ' ' : null}
+                </Fragment>
+              ))}
+              {index !== companyTexts.length - 1 ? <br /> : null}
+            </Fragment>
+          ))}
         </Text>
       </AccordionContent>
     </Accordion>

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -4,7 +4,8 @@ import { Text, Container } from '@titicaca/core-elements'
 
 import { LinkGroup } from './link-group'
 import { CompanyInfo } from './company-info'
-import { TripleKoreaLink } from './triple-korea-link'
+import { ExtraLink } from './extra-link'
+import { useCompanyInfo } from './use-company-info'
 
 export const FooterFrame = styled.footer`
   background-color: rgba(250, 250, 250, 1);
@@ -12,14 +13,15 @@ export const FooterFrame = styled.footer`
 
 export interface DefaultFooterProps {
   hideAppDownloadButton?: boolean
-  tripleKoreaLinkVisible?: boolean
+  extraLinkVisible?: boolean
 }
 
 function DefaultFooter({
   hideAppDownloadButton = false,
-  tripleKoreaLinkVisible = false,
+  extraLinkVisible = false,
   ...props
 }: DefaultFooterProps) {
+  const companyInfo = useCompanyInfo()
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
   return (
@@ -33,6 +35,7 @@ function DefaultFooter({
         }}
       >
         <CompanyInfo
+          company={companyInfo.company}
           hideAppDownloadButton={hideAppDownloadButton}
           businessExpanded={businessExpanded}
           setBusinessExpanded={setBusinessExpanded}
@@ -43,13 +46,16 @@ function DefaultFooter({
           color="gray500"
           margin={{ top: businessExpanded ? 10 : 25, bottom: 20 }}
         >
-          &#12828;놀유니버스는 통신판매중개로서 통신판매의 당사자가 아니며 상품
-          거래정보 및 거래 등에 대해 책임을 지지 않습니다.
+          {companyInfo.disclaimer.replace(/\\n/g, '')}
         </Text>
 
-        <LinkGroup />
+        <LinkGroup links={companyInfo.links} />
 
-        {tripleKoreaLinkVisible ? <TripleKoreaLink /> : null}
+        {extraLinkVisible && companyInfo.extraLinks.length
+          ? companyInfo.extraLinks.map((link, index) => (
+              <ExtraLink key={`extra-link-${index}`} {...link} />
+            ))
+          : null}
       </Container>
     </FooterFrame>
   )

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -4,7 +4,7 @@ import { Text, Container } from '@titicaca/core-elements'
 
 import { LinkGroup } from './link-group'
 import { CompanyInfo } from './company-info'
-import { ExtraLink } from './extra-link'
+import { ExtraLinkGroup } from './extra-link-group'
 import { useFooterInfo } from './use-footer-info'
 
 export const FooterFrame = styled.footer`
@@ -55,11 +55,9 @@ function DefaultFooter({
 
         <LinkGroup links={footerInfo.links} />
 
-        {extraLinkVisible && !!footerInfo.extraLinks.length
-          ? footerInfo.extraLinks.map((link, index) => (
-              <ExtraLink key={`extra-link-${index}`} {...link} />
-            ))
-          : null}
+        {extraLinkVisible ? (
+          <ExtraLinkGroup extraLinks={footerInfo.extraLinks} />
+        ) : null}
       </Container>
     </FooterFrame>
   )

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -46,12 +46,12 @@ function DefaultFooter({
           color="gray500"
           margin={{ top: businessExpanded ? 10 : 25, bottom: 20 }}
         >
-          {footerInfo.disclaimer.replace(/\\n/g, '')}
+          {footerInfo.disclaimer.replace('\n', '')}
         </Text>
 
         <LinkGroup links={footerInfo.links} />
 
-        {extraLinkVisible && footerInfo.extraLinks.length
+        {extraLinkVisible && !!footerInfo.extraLinks.length
           ? footerInfo.extraLinks.map((link, index) => (
               <ExtraLink key={`extra-link-${index}`} {...link} />
             ))

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -24,6 +24,10 @@ function DefaultFooter({
   const footerInfo = useFooterInfo()
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
+  if (!footerInfo) {
+    return null
+  }
+
   return (
     <FooterFrame {...props}>
       <Container

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -5,7 +5,7 @@ import { Text, Container } from '@titicaca/core-elements'
 import { LinkGroup } from './link-group'
 import { CompanyInfo } from './company-info'
 import { ExtraLink } from './extra-link'
-import { useCompanyInfo } from './use-company-info'
+import { useFooterInfo } from './use-footer-info'
 
 export const FooterFrame = styled.footer`
   background-color: rgba(250, 250, 250, 1);
@@ -21,7 +21,7 @@ function DefaultFooter({
   extraLinkVisible = false,
   ...props
 }: DefaultFooterProps) {
-  const companyInfo = useCompanyInfo()
+  const footerInfo = useFooterInfo()
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
   return (
@@ -35,7 +35,7 @@ function DefaultFooter({
         }}
       >
         <CompanyInfo
-          company={companyInfo.company}
+          company={footerInfo.company}
           hideAppDownloadButton={hideAppDownloadButton}
           businessExpanded={businessExpanded}
           setBusinessExpanded={setBusinessExpanded}
@@ -46,13 +46,13 @@ function DefaultFooter({
           color="gray500"
           margin={{ top: businessExpanded ? 10 : 25, bottom: 20 }}
         >
-          {companyInfo.disclaimer.replace(/\\n/g, '')}
+          {footerInfo.disclaimer.replace(/\\n/g, '')}
         </Text>
 
-        <LinkGroup links={companyInfo.links} />
+        <LinkGroup links={footerInfo.links} />
 
-        {extraLinkVisible && companyInfo.extraLinks.length
-          ? companyInfo.extraLinks.map((link, index) => (
+        {extraLinkVisible && footerInfo.extraLinks.length
+          ? footerInfo.extraLinks.map((link, index) => (
               <ExtraLink key={`extra-link-${index}`} {...link} />
             ))
           : null}

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -46,7 +46,7 @@ function DefaultFooter({
           color="gray500"
           margin={{ top: businessExpanded ? 10 : 25, bottom: 20 }}
         >
-          {footerInfo.disclaimer.replace('\n', '')}
+          {footerInfo.disclaimer}
         </Text>
 
         <LinkGroup links={footerInfo.links} />

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -35,7 +35,7 @@ function DefaultFooter({
         }}
       >
         <CompanyInfo
-          company={footerInfo.company}
+          companyTexts={footerInfo.companyTexts}
           hideAppDownloadButton={hideAppDownloadButton}
           businessExpanded={businessExpanded}
           setBusinessExpanded={setBusinessExpanded}

--- a/packages/footer/src/extra-link-group.tsx
+++ b/packages/footer/src/extra-link-group.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import styled from 'styled-components'
 
@@ -12,7 +13,16 @@ const Link = styled.a`
   margin-top: 20px;
 `
 
-export function ExtraLink({ label, url, faEventAction }: FooterLink) {
+export function ExtraLinkGroup({ extraLinks }: { extraLinks: FooterLink[] }) {
+  return extraLinks.map((link, index) => (
+    <Fragment key={`extra-link-${index}`}>
+      <ExtraLink {...link} />
+      {index !== extraLinks.length - 1 ? <br /> : null}
+    </Fragment>
+  ))
+}
+
+function ExtraLink({ label, url, faEventAction }: FooterLink) {
   const { trackEvent } = useEventTrackingContext()
 
   return (

--- a/packages/footer/src/extra-link.tsx
+++ b/packages/footer/src/extra-link.tsx
@@ -1,6 +1,8 @@
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import styled from 'styled-components'
 
+import { Link } from './type'
+
 const Link = styled.a`
   display: block;
   color: var(--color-gray500);
@@ -10,17 +12,17 @@ const Link = styled.a`
   margin-top: 20px;
 `
 
-export function TripleKoreaLink() {
+export function ExtraLink({ label, url, faEventAction }: Link) {
   const { trackEvent } = useEventTrackingContext()
 
   return (
     <Link
-      href="https://triple.global"
+      href={url}
       target="_blank"
       rel="noreferrer"
-      onClick={() => trackEvent({ fa: { action: '푸터_트리플코리아링크' } })}
+      onClick={() => trackEvent({ fa: { action: faEventAction } })}
     >
-      TRIPLE Korea for Foreign Travelers
+      {label}
     </Link>
   )
 }

--- a/packages/footer/src/extra-link.tsx
+++ b/packages/footer/src/extra-link.tsx
@@ -1,7 +1,7 @@
 import { useEventTrackingContext } from '@titicaca/react-contexts'
 import styled from 'styled-components'
 
-import { Link } from './type'
+import { FooterLink } from './type'
 
 const Link = styled.a`
   display: block;
@@ -12,7 +12,7 @@ const Link = styled.a`
   margin-top: 20px;
 `
 
-export function ExtraLink({ label, url, faEventAction }: Link) {
+export function ExtraLink({ label, url, faEventAction }: FooterLink) {
   const { trackEvent } = useEventTrackingContext()
 
   return (

--- a/packages/footer/src/footer.json
+++ b/packages/footer/src/footer.json
@@ -1,28 +1,12 @@
 {
-  "company": {
-    "name": "㈜놀유니버스",
-    "ceo": {
-      "label": "대표이사",
-      "names": ["배보찬", "최휘영"]
-    },
-    "businessRegistrationNumber": {
-      "label": "사업자 등록번호",
-      "value": "824-81-02515"
-    },
-    "salesReportNumber": {
-      "label": "통신판매업 신고번호",
-      "value": "2024-성남수정-0912"
-    },
-    "address": {
-      "label": "주소",
-      "value": "경기도 성남시 수정구 금토로 70 (금토동, 텐엑스타워)"
-    },
-    "contact": {
-      "label": "항공, 숙소 및 투어·티켓 문의",
-      "phone": "1588-2539",
-      "email": "help.triple@nol-universe.com"
-    }
-  },
+  "companyTexts": [
+    [{ "text": "㈜놀유니버스 | 대표이사 배보찬, 최휘영" }],
+    [{ "text": "사업자 등록번호 824-81-02515" }],
+    [{ "text": "통신판매업 신고번호 2024-성남수정-0912" }],
+    [{ "text": "경기도 성남시 수정구 금토로 70 (금토동, 텐엑스타워)" }],
+    [{ "text": "항공, 숙소 및 투어·티켓 문의 1588-2539" }],
+    [{ "text": "help.triple@nol-universe.com" }]
+  ],
   "disclaimer": "㈜놀유니버스는 통신판매중개로서 통신판매의 당사자가 아니며\n 상품 거래정보 및 거래 등에 대해 책임을 지지 않습니다.",
   "links": [
     {

--- a/packages/footer/src/footer.json
+++ b/packages/footer/src/footer.json
@@ -1,0 +1,55 @@
+{
+  "company": {
+    "name": "㈜놀유니버스",
+    "ceo": {
+      "label": "대표이사",
+      "names": ["배보찬", "최휘영"]
+    },
+    "businessRegistrationNumber": {
+      "label": "사업자 등록번호",
+      "value": "824-81-02515"
+    },
+    "salesReportNumber": {
+      "label": "통신판매업 신고번호",
+      "value": "2024-성남수정-0912"
+    },
+    "address": {
+      "label": "주소",
+      "value": "경기도 성남시 수정구 금토로 70 (금토동, 텐엑스타워)"
+    },
+    "contact": {
+      "label": "항공, 숙소 및 투어·티켓 문의",
+      "phone": "1588-2539",
+      "email": "help.triple@nol-universe.com"
+    }
+  },
+  "disclaimer": "㈜놀유니버스는 통신판매중개로서 통신판매의 당사자가 아니며\n 상품 거래정보 및 거래 등에 대해 책임을 지지 않습니다.",
+  "links": [
+    {
+      "label": "서비스 이용약관",
+      "url": "/pages/tos.html"
+    },
+    {
+      "label": "개인정보 처리방침",
+      "url": "/pages/privacy-policy.html"
+    },
+    {
+      "label": "고객센터",
+      "url": "/cs-bridge/entry"
+    }
+  ],
+  "extraLinks": [
+    {
+      "label": "Interpark Global for Overseas Travelers",
+      "url": "https://triple.global",
+      "faEventAction": "푸터_트리플코리아링크"
+    }
+  ],
+  "awards": [
+    {
+      "text": "국제표준 정보보호 인증 취득\nISO 27001, ISO 27701",
+      "alt": "국제표준 정보보호 인증마크 ISO27001, ISO 27701",
+      "imageUrl": "https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/1060b728-6ef3-477d-a64a-0a38f5c3250e.jpeg"
+    }
+  ]
+}

--- a/packages/footer/src/footer.json
+++ b/packages/footer/src/footer.json
@@ -7,7 +7,7 @@
     [{ "text": "항공, 숙소 및 투어·티켓 문의 1588-2539" }],
     [{ "text": "help.triple@nol-universe.com" }]
   ],
-  "disclaimer": "㈜놀유니버스는 통신판매중개로서 통신판매의 당사자가 아니며\n 상품 거래정보 및 거래 등에 대해 책임을 지지 않습니다.",
+  "disclaimer": "㈜놀유니버스는 통신판매중개로서 통신판매의 당사자가 아니며 상품 거래정보 및 거래 등에 대해 책임을 지지 않습니다.",
   "links": [
     {
       "label": "서비스 이용약관",
@@ -15,6 +15,14 @@
     },
     {
       "label": "개인정보 처리방침",
+      "url": "/pages/privacy-policy.html"
+    },
+    {
+      "label": "위치정보 이용약관",
+      "url": "/pages/privacy-policy.html"
+    },
+    {
+      "label": "서비스 운영정책",
       "url": "/pages/privacy-policy.html"
     },
     {

--- a/packages/footer/src/footer.stories.tsx
+++ b/packages/footer/src/footer.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { rest } from 'msw'
 
 import Footer from './default-footer'
+import CompanyInfo from './footer.json'
 
 export default {
   title: 'footer / Footer',
@@ -12,5 +14,17 @@ export const Basic: StoryObj<typeof Footer> = {}
 export const NoButtons: StoryObj<typeof Footer> = {
   args: {
     hideAppDownloadButton: true,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get(
+          'https://assets.triple-dev.titicaca-corp.com/footer/footer.json',
+          async (req, res, ctx) => {
+            return res(ctx.json(CompanyInfo))
+          },
+        ),
+      ],
+    },
   },
 }

--- a/packages/footer/src/footer.stories.tsx
+++ b/packages/footer/src/footer.stories.tsx
@@ -2,14 +2,27 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { rest } from 'msw'
 
 import Footer from './default-footer'
-import CompanyInfo from './footer.json'
+import MockFooterInfo from './footer.json'
 
 export default {
   title: 'footer / Footer',
   component: Footer,
 } as Meta<typeof Footer>
 
-export const Basic: StoryObj<typeof Footer> = {}
+export const Basic: StoryObj<typeof Footer> = {
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get(
+          'https://assets.triple-dev.titicaca-corp.com/footer/footer.json',
+          async (req, res, ctx) => {
+            return res(ctx.json(MockFooterInfo))
+          },
+        ),
+      ],
+    },
+  },
+}
 
 export const NoButtons: StoryObj<typeof Footer> = {
   args: {
@@ -21,7 +34,7 @@ export const NoButtons: StoryObj<typeof Footer> = {
         rest.get(
           'https://assets.triple-dev.titicaca-corp.com/footer/footer.json',
           async (req, res, ctx) => {
-            return res(ctx.json(CompanyInfo))
+            return res(ctx.json(MockFooterInfo))
           },
         ),
       ],

--- a/packages/footer/src/link-group.tsx
+++ b/packages/footer/src/link-group.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react'
 import styled from 'styled-components'
 import { Container } from '@titicaca/core-elements'
 
-import { Link } from './type'
+import { FooterLink } from './type'
 
 const LinksContainer = styled(Container)`
   font-size: 11px;
@@ -20,7 +20,7 @@ const LinksContainer = styled(Container)`
     margin-left: 0;
   }
 `
-export function LinkGroup({ links }: { links: Link[] }) {
+export function LinkGroup({ links }: { links: FooterLink[] }) {
   return (
     <LinksContainer>
       {links.map((link, index) => (

--- a/packages/footer/src/link-group.tsx
+++ b/packages/footer/src/link-group.tsx
@@ -5,6 +5,9 @@ import { Container } from '@titicaca/core-elements'
 import { FooterLink } from './type'
 
 const LinksContainer = styled(Container)`
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
   font-size: 11px;
   font-weight: bold;
   line-height: 20px;
@@ -13,13 +16,18 @@ const LinksContainer = styled(Container)`
   a {
     color: var(--color-gray);
     text-decoration: none;
-    margin: 6px;
-  }
-
-  a:first-child {
-    margin-left: 0;
+    word-break: keep-all;
+    flex-shrink: 0;
   }
 `
+
+const Divider = styled.div`
+  width: 1px;
+  height: 8px;
+  margin: 0 6px;
+  background: var(--color-gray);
+`
+
 export function LinkGroup({ links }: { links: FooterLink[] }) {
   return (
     <LinksContainer>
@@ -33,7 +41,7 @@ export function LinkGroup({ links }: { links: FooterLink[] }) {
           >
             {link.label}
           </a>
-          {index < links.length - 1 && '|'}
+          {index < links.length - 1 ? <Divider /> : null}
         </Fragment>
       ))}
     </LinksContainer>

--- a/packages/footer/src/link-group.tsx
+++ b/packages/footer/src/link-group.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react'
 import styled from 'styled-components'
 import { Container } from '@titicaca/core-elements'
+import { useEventTrackingContext } from '@titicaca/react-contexts'
 
 import { FooterLink } from './type'
 
@@ -29,6 +30,8 @@ const Divider = styled.div`
 `
 
 export function LinkGroup({ links }: { links: FooterLink[] }) {
+  const { trackEvent } = useEventTrackingContext()
+
   return (
     <LinksContainer>
       {links.map((link, index) => (
@@ -38,6 +41,11 @@ export function LinkGroup({ links }: { links: FooterLink[] }) {
             href={link.url}
             target="_blank"
             rel="noreferrer"
+            onClick={
+              link.faEventAction
+                ? () => trackEvent({ fa: { action: link.faEventAction } })
+                : undefined
+            }
           >
             {link.label}
           </a>

--- a/packages/footer/src/link-group.tsx
+++ b/packages/footer/src/link-group.tsx
@@ -1,5 +1,8 @@
+import { Fragment } from 'react'
 import styled from 'styled-components'
 import { Container } from '@titicaca/core-elements'
+
+import { Link } from './type'
 
 const LinksContainer = styled(Container)`
   font-size: 11px;
@@ -17,20 +20,22 @@ const LinksContainer = styled(Container)`
     margin-left: 0;
   }
 `
-export function LinkGroup() {
+export function LinkGroup({ links }: { links: Link[] }) {
   return (
     <LinksContainer>
-      <a href="/pages/tos.html" target="_blank" rel="noreferrer">
-        서비스 이용약관
-      </a>
-      |
-      <a href="/pages/privacy-policy.html" target="_blank" rel="noreferrer">
-        개인정보 처리방침
-      </a>
-      |
-      <a href="/cs-bridge/entry" target="_blank" rel="noreferrer">
-        고객센터
-      </a>
+      {links.map((link, index) => (
+        <Fragment key={`link-${index}`}>
+          <a
+            key={`link-${index}`}
+            href={link.url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {link.label}
+          </a>
+          {index < links.length - 1 && '|'}
+        </Fragment>
+      ))}
     </LinksContainer>
   )
 }

--- a/packages/footer/src/type.ts
+++ b/packages/footer/src/type.ts
@@ -1,30 +1,25 @@
 export interface FooterInfo {
-  company: Company
+  companyTexts: Array<FooterText[]>
   disclaimer: string
-  links: Link[]
-  extraLinks: Link[]
-  awards: Award[]
+  links: FooterLink[]
+  extraLinks: FooterLink[]
+  awards: FooterAward[]
 }
 
-export interface Company {
-  name: string
-  ceo: WithLabel<{ names: string[] }>
-  businessRegistrationNumber: WithLabel<{ value: string }>
-  salesReportNumber: WithLabel<{ value: string }>
-  address: WithLabel<{ value: string }>
-  contact: WithLabel<{ phone: string; email: string }>
+export interface FooterText {
+  text: string
+  url?: string
+  faEventAction?: string
 }
 
-export interface Link {
+export interface FooterLink {
   label: string
   url: string
   faEventAction?: string
 }
 
-export interface Award {
+export interface FooterAward {
   text: string
   alt: string
   imageUrl: string
 }
-
-type WithLabel<T> = T & { label: string }

--- a/packages/footer/src/type.ts
+++ b/packages/footer/src/type.ts
@@ -1,0 +1,30 @@
+export interface CompanyInfo {
+  company: Company
+  disclaimer: string
+  links: Link[]
+  extraLinks: Link[]
+  awards: Award[]
+}
+
+export interface Company {
+  name: string
+  ceo: WithLabel<{ names: string[] }>
+  businessRegistrationNumber: WithLabel<{ value: string }>
+  salesReportNumber: WithLabel<{ value: string }>
+  address: WithLabel<{ value: string }>
+  contact: WithLabel<{ phone: string; email: string }>
+}
+
+export interface Link {
+  label: string
+  url: string
+  faEventAction?: string
+}
+
+export interface Award {
+  text: string
+  alt: string
+  imageUrl: string
+}
+
+type WithLabel<T> = T & { label: string }

--- a/packages/footer/src/type.ts
+++ b/packages/footer/src/type.ts
@@ -1,4 +1,4 @@
-export interface CompanyInfo {
+export interface FooterInfo {
   company: Company
   disclaimer: string
   links: Link[]

--- a/packages/footer/src/use-company-info.tsx
+++ b/packages/footer/src/use-company-info.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+
+import { CompanyInfo } from './type'
+
+const initialCompanyInfo: CompanyInfo = {
+  company: {
+    name: '',
+    ceo: { label: '대표이사', names: [] },
+    businessRegistrationNumber: { label: '사업자 등록번호', value: '' },
+    salesReportNumber: { label: '통신판매업 신고번호', value: '' },
+    address: { label: '주소', value: '' },
+    contact: { label: '항공, 숙소 및 투어·티켓 문의', phone: '', email: '' },
+  },
+  disclaimer: '',
+  links: [],
+  extraLinks: [],
+  awards: [],
+}
+
+const companyInfoUrl = 'https://assets.triple.guide/footer/footer.json'
+
+export function useCompanyInfo() {
+  const [companyInfo, setCompanyInfo] =
+    useState<CompanyInfo>(initialCompanyInfo)
+
+  useEffect(() => {
+    const getCompanyInfo = async () => {
+      try {
+        const response = await fetch(companyInfoUrl)
+        const data = await response.json()
+        setCompanyInfo(data)
+      } catch (error) {
+        // do nothing
+      }
+    }
+
+    getCompanyInfo()
+  }, [])
+
+  return companyInfo
+}

--- a/packages/footer/src/use-footer-info.tsx
+++ b/packages/footer/src/use-footer-info.tsx
@@ -36,7 +36,8 @@ export function useFooterInfo() {
     }
 
     getFooterInfo()
-  }, [webAssetUrl])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return footerInfo
 }

--- a/packages/footer/src/use-footer-info.tsx
+++ b/packages/footer/src/use-footer-info.tsx
@@ -4,14 +4,7 @@ import { useEnv } from '@titicaca/react-contexts'
 import { FooterInfo } from './type'
 
 const initialFooterInfo: FooterInfo = {
-  company: {
-    name: '',
-    ceo: { label: '대표이사', names: [] },
-    businessRegistrationNumber: { label: '사업자 등록번호', value: '' },
-    salesReportNumber: { label: '통신판매업 신고번호', value: '' },
-    address: { label: '주소', value: '' },
-    contact: { label: '항공, 숙소 및 투어·티켓 문의', phone: '', email: '' },
-  },
+  companyTexts: [[]],
   disclaimer: '',
   links: [],
   extraLinks: [],

--- a/packages/footer/src/use-footer-info.tsx
+++ b/packages/footer/src/use-footer-info.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react'
+import { useEnv } from '@titicaca/react-contexts'
 
-import { CompanyInfo } from './type'
+import { FooterInfo } from './type'
 
-const initialCompanyInfo: CompanyInfo = {
+const initialFooterInfo: FooterInfo = {
   company: {
     name: '',
     ceo: { label: '대표이사', names: [] },
@@ -17,25 +18,25 @@ const initialCompanyInfo: CompanyInfo = {
   awards: [],
 }
 
-const companyInfoUrl = 'https://assets.triple.guide/footer/footer.json'
+const companyInfoUrlPath = '/footer/footer.json'
 
-export function useCompanyInfo() {
-  const [companyInfo, setCompanyInfo] =
-    useState<CompanyInfo>(initialCompanyInfo)
+export function useFooterInfo() {
+  const [footerInfo, setFooterInfo] = useState<FooterInfo>(initialFooterInfo)
+  const { webAssetUrl } = useEnv()
 
   useEffect(() => {
-    const getCompanyInfo = async () => {
+    const getFooterInfo = async () => {
       try {
-        const response = await fetch(companyInfoUrl)
+        const response = await fetch(webAssetUrl + companyInfoUrlPath)
         const data = await response.json()
-        setCompanyInfo(data)
+        setFooterInfo(data)
       } catch (error) {
         // do nothing
       }
     }
 
-    getCompanyInfo()
-  }, [])
+    getFooterInfo()
+  }, [webAssetUrl])
 
-  return companyInfo
+  return footerInfo
 }

--- a/packages/footer/src/use-footer-info.tsx
+++ b/packages/footer/src/use-footer-info.tsx
@@ -3,23 +3,15 @@ import { useEnv } from '@titicaca/react-contexts'
 
 import { FooterInfo } from './type'
 
-const initialFooterInfo: FooterInfo = {
-  companyTexts: [[]],
-  disclaimer: '',
-  links: [],
-  extraLinks: [],
-  awards: [],
-}
-
 const companyInfoUrlPath = '/footer/footer.json'
 
 export function useFooterInfo() {
-  const [footerInfo, setFooterInfo] = useState<FooterInfo>(initialFooterInfo)
+  const [footerInfo, setFooterInfo] = useState<FooterInfo | null>(null)
   const { webAssetsUrl } = useEnv()
 
   useEffect(() => {
     if (!webAssetsUrl) {
-      throw new Error('webAssetsUrl is not defined')
+      throw new Error('webAssetsUrl is not defined in EnvContext')
     }
 
     const getFooterInfo = async () => {

--- a/packages/footer/src/use-footer-info.tsx
+++ b/packages/footer/src/use-footer-info.tsx
@@ -3,7 +3,7 @@ import { useEnv } from '@titicaca/react-contexts'
 
 import { FooterInfo } from './type'
 
-const companyInfoUrlPath = '/footer/footer.json'
+const FOOTER_INFO_ASSET_FILE_PATH = '/footer/footer.json'
 
 export function useFooterInfo() {
   const [footerInfo, setFooterInfo] = useState<FooterInfo | null>(null)
@@ -16,7 +16,7 @@ export function useFooterInfo() {
 
     const getFooterInfo = async () => {
       try {
-        const response = await fetch(webAssetsUrl + companyInfoUrlPath)
+        const response = await fetch(webAssetsUrl + FOOTER_INFO_ASSET_FILE_PATH)
         const data = await response.json()
         setFooterInfo(data)
       } catch (error) {

--- a/packages/footer/src/use-footer-info.tsx
+++ b/packages/footer/src/use-footer-info.tsx
@@ -22,12 +22,12 @@ const companyInfoUrlPath = '/footer/footer.json'
 
 export function useFooterInfo() {
   const [footerInfo, setFooterInfo] = useState<FooterInfo>(initialFooterInfo)
-  const { webAssetUrl } = useEnv()
+  const { webAssetsUrl } = useEnv()
 
   useEffect(() => {
     const getFooterInfo = async () => {
       try {
-        const response = await fetch(webAssetUrl + companyInfoUrlPath)
+        const response = await fetch(webAssetsUrl + companyInfoUrlPath)
         const data = await response.json()
         setFooterInfo(data)
       } catch (error) {

--- a/packages/footer/src/use-footer-info.tsx
+++ b/packages/footer/src/use-footer-info.tsx
@@ -18,6 +18,10 @@ export function useFooterInfo() {
   const { webAssetsUrl } = useEnv()
 
   useEffect(() => {
+    if (!webAssetsUrl) {
+      throw new Error('webAssetsUrl is not defined')
+    }
+
     const getFooterInfo = async () => {
       try {
         const response = await fetch(webAssetsUrl + companyInfoUrlPath)

--- a/packages/react-contexts/src/env-context/index.tsx
+++ b/packages/react-contexts/src/env-context/index.tsx
@@ -41,6 +41,10 @@ interface EnvContextValue {
    * 미디어 소스 이름을 의미하며, 모든 측정 링크에서 반드시 포함되어야 할 유일하고 중요한 파라미터입니다.
    */
   afOnelinkPid: string
+  /**
+   * asset 파일의 웹 URL
+   */
+  webAssetUrl?: string
 }
 
 const EnvContext = createContext<EnvContextValue | null>(null)
@@ -55,6 +59,7 @@ export function EnvProvider({
   afOnelinkId,
   afOnelinkPid,
   afOnelinkSubdomain,
+  webAssetUrl,
   children,
   ...rest
 }: PropsWithChildren<EnvContextValue>) {
@@ -69,6 +74,7 @@ export function EnvProvider({
       afOnelinkId,
       afOnelinkPid,
       afOnelinkSubdomain,
+      webAssetUrl,
       ...rest,
     }),
     [
@@ -81,6 +87,7 @@ export function EnvProvider({
       afOnelinkId,
       afOnelinkPid,
       afOnelinkSubdomain,
+      webAssetUrl,
       rest,
     ],
   )

--- a/packages/react-contexts/src/env-context/index.tsx
+++ b/packages/react-contexts/src/env-context/index.tsx
@@ -44,7 +44,7 @@ interface EnvContextValue {
   /**
    * asset 파일의 웹 URL
    */
-  webAssetUrl?: string
+  webAssetsUrl?: string
 }
 
 const EnvContext = createContext<EnvContextValue | null>(null)
@@ -59,7 +59,7 @@ export function EnvProvider({
   afOnelinkId,
   afOnelinkPid,
   afOnelinkSubdomain,
-  webAssetUrl,
+  webAssetsUrl,
   children,
   ...rest
 }: PropsWithChildren<EnvContextValue>) {
@@ -74,7 +74,7 @@ export function EnvProvider({
       afOnelinkId,
       afOnelinkPid,
       afOnelinkSubdomain,
-      webAssetUrl,
+      webAssetsUrl,
       ...rest,
     }),
     [
@@ -87,7 +87,7 @@ export function EnvProvider({
       afOnelinkId,
       afOnelinkPid,
       afOnelinkSubdomain,
-      webAssetUrl,
+      webAssetsUrl,
       rest,
     ],
   )


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[footer] footer를 json으로 받아올 수 있도록 수정합니다.
[react-contexts] webAssetsUrl 환경변수를 추가합니다. 🚨 푸터를 사용하는 레포에서는 EnvContext에 해당 변수를 추가해야 합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- footer를 json 형식으로 web-assets에서 받아올 수 있도록 수정 ([관련 PR](https://github.com/titicacadev/triple-web-assets/pull/302))
- link의 css 변경 (단어 줄바꿈 방지)
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 기타
- storybook 빌드 이슈로 middleware 패키지를 스토리북 빌드에서 제외합니다.
