### PR TITLE
[public-header, react-contexts] NOL 연동 회원의 경우 웹 사이드바 프로필에서 provider를 노출하지 않습니다.

### DIFF
--- a/packages/public-header/src/side-menu/profile.tsx
+++ b/packages/public-header/src/side-menu/profile.tsx
@@ -73,6 +73,8 @@ const PROFILE_EVENT_METADATA_LABEL = {
   photo: '프로필사진',
 }
 
+const NOL_CONNECTED_LABEL = 'NOL 멤버스 계정'
+
 export function Profile() {
   const user = useUser()
   const { trackEvent } = useEventTrackingContext()
@@ -81,9 +83,9 @@ export function Profile() {
   const providerIconSrc = user ? PROVIDER_INFO[user.provider].icon : undefined
   const badgeUrl = user ? user.mileage?.badges[0]?.icon.image_url : undefined
   const providerVisible = user && !user.nolConnected
-  const providerLabel = providerVisible
-    ? PROVIDER_INFO[user.provider].label
-    : null
+  const profileLabel = providerVisible
+    ? user.email || PROVIDER_INFO[user.provider].label
+    : NOL_CONNECTED_LABEL
 
   const onProfileClick = (
     referrer: keyof typeof PROFILE_EVENT_METADATA_LABEL,
@@ -112,7 +114,7 @@ export function Profile() {
           {providerIconSrc && providerVisible ? (
             <SocialIcon src={providerIconSrc} alt="social login icon" />
           ) : null}
-          {user.email || providerLabel}
+          {profileLabel}
         </UserEmailOrProvider>
       </Container>
 

--- a/packages/public-header/src/side-menu/profile.tsx
+++ b/packages/public-header/src/side-menu/profile.tsx
@@ -80,6 +80,10 @@ export function Profile() {
   const returnUrl = encodeURIComponent(location.href)
   const providerIconSrc = user ? PROVIDER_INFO[user.provider].icon : undefined
   const badgeUrl = user ? user.mileage?.badges[0]?.icon.image_url : undefined
+  const providerVisible = user && !user.nolConnected
+  const providerLabel = providerVisible
+    ? PROVIDER_INFO[user.provider].label
+    : ''
 
   const onProfileClick = (
     referrer: keyof typeof PROFILE_EVENT_METADATA_LABEL,
@@ -105,10 +109,10 @@ export function Profile() {
       <Container>
         <UserName onClick={() => onProfileClick('name')}>{user.name}</UserName>
         <UserEmailOrProvider>
-          {providerIconSrc ? (
+          {providerIconSrc && providerVisible ? (
             <SocialIcon src={providerIconSrc} alt="social login icon" />
           ) : null}
-          {user.email || PROVIDER_INFO[user.provider].label}
+          {user.email || providerLabel}
         </UserEmailOrProvider>
       </Container>
 

--- a/packages/public-header/src/side-menu/profile.tsx
+++ b/packages/public-header/src/side-menu/profile.tsx
@@ -83,7 +83,7 @@ export function Profile() {
   const providerVisible = user && !user.nolConnected
   const providerLabel = providerVisible
     ? PROVIDER_INFO[user.provider].label
-    : ''
+    : null
 
   const onProfileClick = (
     referrer: keyof typeof PROFILE_EVENT_METADATA_LABEL,

--- a/packages/react-contexts/src/session-context/index.tsx
+++ b/packages/react-contexts/src/session-context/index.tsx
@@ -1,5 +1,5 @@
 export { default as SessionContextProvider } from './provider'
 export { useSessionAvailability, useSessionControllers } from './hooks'
-export { useUser } from './user'
+export { useUser, User } from './user'
 export { default as getSessionAvailabilityFromRequest } from './session-availability'
 export { putInvalidSessionIdRemover } from './invalid-session-id-remover'

--- a/packages/react-contexts/src/session-context/user.ts
+++ b/packages/react-contexts/src/session-context/user.ts
@@ -10,6 +10,8 @@ export interface User {
   mileage: Mileage
   uid: string
   email: string
+  nolConnected?: boolean
+  nolConnectedAt?: string
 }
 
 type Provider = 'TRIPLE' | 'NAVER' | 'KAKAO' | 'FACEBOOK' | 'APPLE'

--- a/packages/ui-flow/src/auth-guard/index.ts
+++ b/packages/ui-flow/src/auth-guard/index.ts
@@ -3,12 +3,10 @@ import { get } from '@titicaca/fetcher'
 import { parseTripleClientUserAgent } from '@titicaca/react-triple-client-interfaces'
 import qs from 'qs'
 import { generateUrl, parseUrl, strictQuery } from '@titicaca/view-utilities'
-import { getSessionAvailabilityFromRequest } from '@titicaca/react-contexts'
-
-interface UserResponse {
-  uid: string
-  // TODO
-}
+import {
+  getSessionAvailabilityFromRequest,
+  User,
+} from '@titicaca/react-contexts'
 
 interface AuthGuardOptions {
   authType?: string
@@ -25,7 +23,7 @@ const NON_MEMBER_REGEX = /^_PH/
 export function authGuard<Props>(
   gssp: (
     ctx: GetServerSidePropsContext & {
-      customContext?: { user?: UserResponse }
+      customContext?: { user?: User }
     },
   ) => Promise<GetServerSidePropsResult<Props>>,
   options?: AuthGuardOptions,
@@ -47,7 +45,7 @@ export function authGuard<Props>(
       ? options.resolveReturnUrl(ctx)
       : `${process.env.NEXT_PUBLIC_BASE_PATH || ''}${resolvedUrl}`
 
-    const response = await get<UserResponse>('/api/users/me', {
+    const response = await get<User>('/api/users/me', {
       req,
       retryable: true,
     })


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
NOL 연동 회원의 경우 웹 사이드바 프로필에서 auth provider(카카오톡, 네이버 등) 정보 대신 `NOL 멤버스 계정` 문구를 노출합니다.
|기존 회원|NOL 연동 회원|
|-----|-----|
|<img width="325" alt="스크린샷 2025-03-11 오후 2 34 15" src="https://github.com/user-attachments/assets/c9d75fda-ad89-437d-b204-3159c8292ac9" />|<img width="325" alt="tobe" src="https://github.com/user-attachments/assets/fe438b01-9538-4e83-8a49-7ae66a4e687d" />|


<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

