### PR TITLE
tds-widget/chat에서 triple-web 디펜던시를 제거

### DIFF
--- a/packages/tds-widget/src/chat/chat/chat-scroll-container.tsx
+++ b/packages/tds-widget/src/chat/chat/chat-scroll-container.tsx
@@ -1,6 +1,5 @@
 import { PropsWithChildren, useEffect } from 'react'
 import { InView } from 'react-intersection-observer'
-import { useUserAgent } from '@titicaca/triple-web'
 import { Container } from '@titicaca/tds-ui'
 
 import { useScroll } from './scroll-context'
@@ -9,11 +8,11 @@ export interface ChatScrollContainerProps {
   onTopIntersecting?: (entry: IntersectionObserverEntry) => void
   onBottomIntersecting?: (entry: IntersectionObserverEntry) => void
   /**
-   * ios에서 스크롤 시 실행되는 리스너입니다.
-   * 키보드가 내려가도록 closeKeyboard interface를 전달하여 사용할 수 있습니다.
+   * 스크롤 시 실행되는 리스너입니다.
+   * iOS에서 키보드가 내려가도록 closeKeyboard interface를 전달하여 사용할 수 있습니다.
    * ref: https://github.com/titicacadev/triple-chat-web/pull/37
    */
-  onIosTouchMove?: () => void
+  onTouchMove?: () => void
 }
 
 /** 
@@ -23,20 +22,19 @@ export interface ChatScrollContainerProps {
 export function ChatScrollContainer({
   onTopIntersecting,
   onBottomIntersecting,
-  onIosTouchMove,
+  onTouchMove,
   children,
   ...props
 }: PropsWithChildren<ChatScrollContainerProps>) {
   const { chatContainerRef, scrollContainerRef, bottomRef } = useScroll()
-  const { os } = useUserAgent()
 
   useEffect(() => {
     const chatContainerElement = chatContainerRef.current
 
-    if (chatContainerElement && os.name === 'iOS' && onIosTouchMove) {
-      chatContainerElement.addEventListener('touchmove', onIosTouchMove)
+    if (chatContainerElement && onTouchMove) {
+      chatContainerElement.addEventListener('touchmove', onTouchMove)
       return () => {
-        chatContainerElement.removeEventListener('touchmove', onIosTouchMove)
+        chatContainerElement.removeEventListener('touchmove', onTouchMove)
       }
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

- tds-widget/chat에서 triple-web 디펜던시를 제거합니다.

## 변경 내역

- `onIosTouchMove` => `onTouchMove`로 변경하고, ChatScrollContainer 내부에서 os 확인하는 로직을 제거합니다.
- 이에따라, 외부에서 os를 확인하여 프롭스를 전달해야 합니다.

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL


https://github.com/user-attachments/assets/0c7a1276-5ee7-4dd9-bbc2-5536cdda8959



<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
