### PR TITLE
[react-contexts] 클라이언트 세션 갱신 로직을 추가합니다. 

### DIFF
--- a/packages/ab-experiments/src/triple-ab-experiment-context/context.tsx
+++ b/packages/ab-experiments/src/triple-ab-experiment-context/context.tsx
@@ -12,6 +12,7 @@ import {
   useEventTrackingContext,
   useSessionAvailability,
 } from '@titicaca/react-contexts'
+import { NEED_LOGIN_IDENTIFIER } from '@titicaca/fetcher'
 
 import { TripleABExperimentMeta, getTripleABExperiment } from './service'
 
@@ -44,12 +45,14 @@ export function TripleABExperimentProvider({
     async function fetchAndSetMeta() {
       const response = await getTripleABExperiment(slug)
 
-      if (response.ok === false) {
-        const { status, url } = response
-
-        if (onError !== undefined) {
-          onError(new Error(`${status} - ${url}`))
+      if (response === NEED_LOGIN_IDENTIFIER || response.ok === false) {
+        if (response === NEED_LOGIN_IDENTIFIER) {
+          onError?.(new Error(NEED_LOGIN_IDENTIFIER))
+        } else {
+          const { status, url } = response
+          onError?.(new Error(`${status} - ${url}`))
         }
+
         return
       }
 

--- a/packages/ab-experiments/src/triple-ab-experiment-context/service.ts
+++ b/packages/ab-experiments/src/triple-ab-experiment-context/service.ts
@@ -1,4 +1,4 @@
-import { get, HttpResponse, RequestOptions } from '@titicaca/fetcher'
+import { authGuardedFetchers, RequestOptions } from '@titicaca/fetcher'
 
 export interface TripleABExperimentMeta {
   testId: number
@@ -8,6 +8,9 @@ export interface TripleABExperimentMeta {
 export async function getTripleABExperiment(
   slug: string,
   options?: RequestOptions,
-): Promise<HttpResponse<TripleABExperimentMeta>> {
-  return get(`/api/abtest/${slug}`, options)
+) {
+  return authGuardedFetchers.get<TripleABExperimentMeta>(
+    `/api/abtest/${slug}`,
+    options,
+  )
 }

--- a/packages/ad-banners/src/api.ts
+++ b/packages/ad-banners/src/api.ts
@@ -1,6 +1,6 @@
 import qs from 'querystring'
 
-import { get, post } from '@titicaca/fetcher'
+import { authGuardedFetchers, NEED_LOGIN_IDENTIFIER } from '@titicaca/fetcher'
 
 import { Banner } from './typing'
 
@@ -54,20 +54,19 @@ export async function getAdBanners({
     userLocation,
   })
 
-  const response = await get<{ items: Banner[] }>(
+  const response = await authGuardedFetchers.get<{ items: Banner[] }>(
     `/api/inventories/${bannerType}/items?${search}`,
     {
       credentials: 'same-origin',
     },
   )
-  if (response.ok === true) {
-    const {
-      parsedBody: { items },
-    } = response
-    return items
-  } else {
+  if (response === NEED_LOGIN_IDENTIFIER || !response.ok) {
     return []
   }
+  const {
+    parsedBody: { items },
+  } = response
+  return items
 }
 
 /**
@@ -106,13 +105,16 @@ export async function postAdBannerEvent({
     userLocation,
   })
 
-  return post(`/api/inventories/${bannerType}/items/${itemId}/events`, {
-    body,
-    headers: {
-      'content-type': 'application/json',
+  return authGuardedFetchers.post(
+    `/api/inventories/${bannerType}/items/${itemId}/events`,
+    {
+      body,
+      headers: {
+        'content-type': 'application/json',
+      },
+      credentials: 'same-origin',
     },
-    credentials: 'same-origin',
-  })
+  )
 }
 
 function getSearchQuery(

--- a/packages/date-picker/src/service.ts
+++ b/packages/date-picker/src/service.ts
@@ -1,4 +1,4 @@
-import { get, RequestOptions, HttpResponse } from '@titicaca/fetcher'
+import { authGuardedFetchers, RequestOptions } from '@titicaca/fetcher'
 
 export interface Holiday {
   name: string
@@ -10,6 +10,9 @@ export interface Holiday {
 export async function fetchPublicHolidays(
   { from, to }: { from: string; to: string },
   options: RequestOptions,
-): Promise<HttpResponse<Holiday[]>> {
-  return get(`/api/calendar/holidays/KR/${from}/${to}`, options)
+) {
+  return authGuardedFetchers.get<Holiday[]>(
+    `/api/calendar/holidays/KR/${from}/${to}`,
+    options,
+  )
 }

--- a/packages/date-picker/src/use-public-holidays.ts
+++ b/packages/date-picker/src/use-public-holidays.ts
@@ -1,5 +1,6 @@
 import { useMemo, useEffect, useState } from 'react'
 import moment from 'moment'
+import { NEED_LOGIN_IDENTIFIER } from '@titicaca/fetcher'
 
 import { fetchPublicHolidays, Holiday } from './service'
 
@@ -23,7 +24,7 @@ export function usePublicHolidays({
       const fetchData = async () => {
         const response = await fetchPublicHolidays({ from, to }, {})
 
-        if (response.ok === true) {
+        if (response !== NEED_LOGIN_IDENTIFIER && response.ok === true) {
           const { parsedBody } = response
 
           setPublicHolidays(parsedBody)

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -38,7 +38,6 @@
     ]
   },
   "dependencies": {
-    "set-cookie-parser": "^2.7.1",
     "ts-custom-error": "^3.3.1",
     "universal-cookie": "^4.0.4"
   },
@@ -46,7 +45,6 @@
     "@sentry/nextjs": "7.92.0",
     "@titicaca/view-utilities": "workspace:*",
     "@types/node-fetch": "^2.6.7",
-    "@types/set-cookie-parser": "^2.4.10",
     "isomorphic-fetch": "^2.2.1",
     "next": "13.4.13",
     "node-fetch": "^2.7.0"

--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -38,6 +38,7 @@
     ]
   },
   "dependencies": {
+    "set-cookie-parser": "^2.7.1",
     "ts-custom-error": "^3.3.1",
     "universal-cookie": "^4.0.4"
   },
@@ -45,6 +46,7 @@
     "@sentry/nextjs": "7.92.0",
     "@titicaca/view-utilities": "workspace:*",
     "@types/node-fetch": "^2.6.7",
+    "@types/set-cookie-parser": "^2.4.10",
     "isomorphic-fetch": "^2.2.1",
     "next": "13.4.13",
     "node-fetch": "^2.7.0"

--- a/packages/fetcher/src/factories.ts
+++ b/packages/fetcher/src/factories.ts
@@ -2,6 +2,7 @@ import { GetServerSidePropsContext } from 'next'
 import { generateUrl, parseUrl } from '@titicaca/view-utilities'
 
 import { HttpResponse, RequestOptions } from './types'
+import { captureHttpError } from './response-handler'
 
 export type BaseFetcher<Extending = unknown> = <
   SuccessBody,
@@ -150,6 +151,7 @@ export function authFetcherize<Fetcher extends BaseFetcher>(
 
     if (refreshResponse.ok === false) {
       if (refreshResponse.status === 400 || refreshResponse.status === 401) {
+        captureHttpError(refreshResponse)
         return NEED_LOGIN_IDENTIFIER
       }
 

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -6,3 +6,8 @@ export { fetcher } from './fetcher'
 export { get, put, post, del } from './methods'
 export { authGuardedFetchers } from './auth-guarded-methods'
 export { captureHttpError } from './response-handler'
+export {
+  sessionRefresh,
+  sessionRefreshOnSSR,
+  SetCookie,
+} from './session-refresh'

--- a/packages/fetcher/src/session-refresh.ts
+++ b/packages/fetcher/src/session-refresh.ts
@@ -1,0 +1,54 @@
+import { parseString, splitCookiesString } from 'set-cookie-parser'
+
+import { ssrFetcherize } from './factories'
+import { post } from './methods'
+import { RequestOptions } from './types'
+
+export type SetCookie = Record<string, string>
+/**
+ *
+ * @param fetcher post 함수
+ * @param options fetcher에 전달할 옵션
+ * @returns session 갱신이 성공한 경우에는 새로운 쿠키를 key: set-cookie 값의 형태로 반환하고, 실패한 경우에는 undefined를 반환합니다.
+ * ex) TP_SE : 'TP_SE=some session token; Path=/; HttpOnly; Secure'
+ */
+export async function sessionRefresh({
+  fetcher = post,
+  options,
+}: {
+  fetcher?: typeof post
+  options?: RequestOptions
+}): Promise<SetCookie | undefined> {
+  const response = await fetcher<Record<never, never> | { message: string }>(
+    '/api/users/web-session/token',
+    options,
+  )
+  if (response.ok) {
+    const setCookie = response.headers.get('set-cookie')
+    if (setCookie) {
+      const setCookies = splitCookiesString(setCookie)
+      const setCookiesMap: SetCookie = {}
+      setCookies.forEach((cookie) => {
+        const { name } = parseString(cookie)
+        setCookiesMap[name] = cookie
+      })
+      return setCookiesMap
+    }
+  }
+  return undefined
+}
+
+export async function sessionRefreshOnSSR({
+  apiUriBase,
+  cookie,
+  options: initialOptions,
+}: {
+  apiUriBase: string
+  cookie: string
+  options?: Omit<RequestOptions, 'cookie'>
+}) {
+  const fetch = ssrFetcherize(post, { apiUriBase, cookie })
+  return async () => {
+    await sessionRefresh({ fetcher: fetch, options: initialOptions })
+  }
+}

--- a/packages/fetcher/src/session-refresh.ts
+++ b/packages/fetcher/src/session-refresh.ts
@@ -1,5 +1,3 @@
-import { parseString, splitCookiesString } from 'set-cookie-parser'
-
 import { ssrFetcherize } from './factories'
 import { post } from './methods'
 import { RequestOptions } from './types'
@@ -9,8 +7,8 @@ export type SetCookie = Record<string, string>
  *
  * @param fetcher post 함수
  * @param options fetcher에 전달할 옵션
- * @returns session 갱신이 성공한 경우에는 새로운 쿠키를 key: set-cookie 값의 형태로 반환하고, 실패한 경우에는 undefined를 반환합니다.
- * ex) TP_SE : 'TP_SE=some session token; Path=/; HttpOnly; Secure'
+ * @returns session 갱신이 성공한 경우에는 새로운 쿠키를 string[] 값의 형태로 반환하고, 실패한 경우에는 undefined를 반환합니다.
+ * ex)  ['TP_SE=some session token; Path=/; HttpOnly; Secure']
  */
 export async function sessionRefresh({
   fetcher = post,
@@ -18,22 +16,14 @@ export async function sessionRefresh({
 }: {
   fetcher?: typeof post
   options?: RequestOptions
-}): Promise<SetCookie | undefined> {
+}): Promise<string[] | undefined> {
   const response = await fetcher<Record<never, never> | { message: string }>(
     '/api/users/web-session/token',
     options,
   )
   if (response.ok) {
-    const setCookie = response.headers.get('set-cookie')
-    if (setCookie) {
-      const setCookies = splitCookiesString(setCookie)
-      const setCookiesMap: SetCookie = {}
-      setCookies.forEach((cookie) => {
-        const { name } = parseString(cookie)
-        setCookiesMap[name] = cookie
-      })
-      return setCookiesMap
-    }
+    const setCookie = response.headers.getSetCookie()
+    return setCookie
   }
   return undefined
 }

--- a/packages/poi-detail/src/recommended-articles/api-client.ts
+++ b/packages/poi-detail/src/recommended-articles/api-client.ts
@@ -1,4 +1,4 @@
-import { get } from '@titicaca/fetcher'
+import { authGuardedFetchers, NEED_LOGIN_IDENTIFIER } from '@titicaca/fetcher'
 import qs from 'qs'
 
 import { ArticleListingData } from './types'
@@ -10,7 +10,7 @@ export async function fetchRecommendedArticles({
   regionId?: string
   zoneId?: string
 }): Promise<ArticleListingData[]> {
-  const response = await get<ArticleListingData[]>(
+  const response = await authGuardedFetchers.get<ArticleListingData[]>(
     `/api/content/articles?${qs.stringify({
       ...((regionId || zoneId) && {
         geotags: [
@@ -22,11 +22,11 @@ export async function fetchRecommendedArticles({
     })}`,
   )
 
-  if (response.ok === true) {
+  if (response !== NEED_LOGIN_IDENTIFIER && response.ok === true) {
     const { parsedBody } = response
     return shuffle(parsedBody.filter(({ source: { image } }) => image))
   } else {
-    throw new Error('Failed to fetch recommended articles')
+    throw new Error(`Failed to fetch recommended articles`)
   }
 }
 

--- a/packages/react-contexts/src/images-context/use-fetch-images.tsx
+++ b/packages/react-contexts/src/images-context/use-fetch-images.tsx
@@ -2,7 +2,11 @@ import qs from 'querystring'
 
 import { useState } from 'react'
 import { ImageMeta } from '@titicaca/type-definitions'
-import { captureHttpError, get } from '@titicaca/fetcher'
+import {
+  captureHttpError,
+  authGuardedFetchers,
+  NEED_LOGIN_IDENTIFIER,
+} from '@titicaca/fetcher'
 
 import { ImageCategoryOrder } from './types'
 
@@ -75,7 +79,7 @@ async function sendFetchImages(
   querystring: string,
   endpoint: 'content' | 'reviews',
 ) {
-  const response = await get<
+  const response = await authGuardedFetchers.get<
     {
       data: ImageMeta[]
       total: number
@@ -86,11 +90,13 @@ async function sendFetchImages(
     { message: string }
   >(`/api/${endpoint}/v2/images?${querystring}`)
 
-  if (response.ok === true) {
+  if (response !== NEED_LOGIN_IDENTIFIER && response.ok === true) {
     const { parsedBody } = response
     return parsedBody
   } else {
-    captureHttpError(response)
+    if (response !== NEED_LOGIN_IDENTIFIER) {
+      captureHttpError(response)
+    }
     throw new Error(`Fail to fetch ${endpoint} images`)
   }
 }

--- a/packages/react-contexts/src/scraps-context/api-client.ts
+++ b/packages/react-contexts/src/scraps-context/api-client.ts
@@ -1,4 +1,4 @@
-import { post, del } from '@titicaca/fetcher'
+import { authGuardedFetchers } from '@titicaca/fetcher'
 
 import { Target } from './types'
 
@@ -22,11 +22,13 @@ interface ScrapFailResponse {
 }
 
 export function scrape({ id, type }: Target) {
-  return post<ScrapSuccessResponse, ScrapFailResponse>(
+  return authGuardedFetchers.post<ScrapSuccessResponse, ScrapFailResponse>(
     `/api/scraps/${mapTypes(type)}/${id}`,
   )
 }
 
 export function unscrape({ id, type }: Target) {
-  return del<unknown, ScrapFailResponse>(`/api/scraps/${mapTypes(type)}/${id}`)
+  return authGuardedFetchers.del<unknown, ScrapFailResponse>(
+    `/api/scraps/${mapTypes(type)}/${id}`,
+  )
 }

--- a/packages/react-contexts/src/scraps-context/scraps-context.tsx
+++ b/packages/react-contexts/src/scraps-context/scraps-context.tsx
@@ -14,6 +14,7 @@ import {
   subscribeScrapedChangeEvent,
   unsubscribeScrapedChangeEvent,
 } from '@titicaca/triple-web-to-native-interfaces'
+import { NEED_LOGIN_IDENTIFIER } from '@titicaca/fetcher'
 
 import { Target } from './types'
 import {
@@ -159,7 +160,10 @@ export function ScrapsProvider({
 
       const response = await nativeScrape({ id, type })
 
-      if (response.ok) {
+      if (response === NEED_LOGIN_IDENTIFIER) {
+        onScrapeFailed?.({ id, type }, false, '로그인이 필요합니다.')
+        dispatch({ type: SCRAPE_FAILED, id })
+      } else if (response.ok) {
         notifyScraped(id)
 
         afterScrapedChange && afterScrapedChange({ id, type }, true)
@@ -196,7 +200,10 @@ export function ScrapsProvider({
 
       const response = await nativeUnscrape({ id, type })
 
-      if (response.ok) {
+      if (response === NEED_LOGIN_IDENTIFIER) {
+        onScrapeFailed?.({ id, type }, true, '로그인이 필요합니다.')
+        dispatch({ type: UNSCRAPE_FAILED, id })
+      } else if (response.ok) {
         notifyUnscraped(id)
 
         afterScrapedChange && afterScrapedChange({ id, type }, false)

--- a/packages/replies/src/hook.tsx
+++ b/packages/replies/src/hook.tsx
@@ -1,0 +1,15 @@
+import { useLoginCtaModal } from '@titicaca/modals'
+
+import { SessionError } from './replies-api-client'
+
+export function useHttpResponseError() {
+  const { show: showLoginCtaModal } = useLoginCtaModal()
+
+  return (error: SessionError | Error) => {
+    if (error instanceof SessionError) {
+      showLoginCtaModal()
+    } else {
+      // Handle other types of errors
+    }
+  }
+}

--- a/packages/replies/src/list/reply.tsx
+++ b/packages/replies/src/list/reply.tsx
@@ -10,7 +10,7 @@ import {
 } from '@titicaca/core-elements'
 import { formatTimestamp, findFoldedPosition } from '@titicaca/view-utilities'
 import { useAppCallback, useSessionCallback } from '@titicaca/ui-flow'
-import { TransitionType, useLoginCtaModal } from '@titicaca/modals'
+import { TransitionType } from '@titicaca/modals'
 import { useNavigate } from '@titicaca/router'
 import {
   useUriHash,
@@ -20,8 +20,9 @@ import {
 import { ActionSheet, ActionSheetItem } from '@titicaca/action-sheet'
 
 import { Reply as ReplyType, Writer } from '../types'
-import { likeReply, SessionError, unlikeReply } from '../replies-api-client'
+import { likeReply, unlikeReply } from '../replies-api-client'
 import { useRepliesContext } from '../context'
+import { useHttpResponseError } from '../hook'
 
 const MoreActionsButton = styled.button`
   width: 19px;
@@ -142,7 +143,7 @@ export default function Reply({
     focusInput()
   }
 
-  const { show: showLoginCtaModal } = useLoginCtaModal()
+  const handleHttpResponseError = useHttpResponseError()
 
   const handleDeleteReplyClick = useCallback(
     async ({
@@ -178,8 +179,8 @@ export default function Reply({
           haveMine: true,
         }))
       } catch (e) {
-        if (e instanceof SessionError) {
-          showLoginCtaModal()
+        if (e instanceof Error) {
+          handleHttpResponseError(e)
         }
       }
     },
@@ -195,8 +196,8 @@ export default function Reply({
           haveMine: false,
         }))
       } catch (e) {
-        if (e instanceof SessionError) {
-          showLoginCtaModal()
+        if (e instanceof Error) {
+          handleHttpResponseError(e)
         }
       }
     },

--- a/packages/replies/src/replies-api-client.ts
+++ b/packages/replies/src/replies-api-client.ts
@@ -242,6 +242,12 @@ export async function deleteReply({
   return reply
 }
 
+export class SessionError extends Error {
+  public constructor() {
+    super('로그인이 필요한 호출입니다.')
+  }
+}
+
 export async function likeReply({ messageId }: { messageId: string }) {
   const response = await authGuardedFetchers.put(
     `/api/reply/messages/${messageId}/like`,
@@ -253,7 +259,7 @@ export async function likeReply({ messageId }: { messageId: string }) {
   )
 
   if (response === 'NEED_LOGIN') {
-    throw new Error('로그인이 필요한 호출입니다.')
+    throw new SessionError()
   }
 
   captureHttpError(response)
@@ -270,7 +276,7 @@ export async function unlikeReply({ messageId }: { messageId: string }) {
   )
 
   if (response === 'NEED_LOGIN') {
-    throw new Error('로그인이 필요한 호출입니다.')
+    throw new SessionError()
   }
 
   captureHttpError(response)
@@ -303,7 +309,7 @@ function confirmAuthorization<T>(
   response: 'NEED_LOGIN' | HttpResponse<T, unknown>,
 ): HttpResponse<T, unknown> {
   if (response === 'NEED_LOGIN') {
-    throw new Error('로그인이 필요한 호출입니다.')
+    throw new SessionError()
   }
 
   captureHttpError(response)

--- a/packages/replies/src/replies-api-client.ts
+++ b/packages/replies/src/replies-api-client.ts
@@ -258,11 +258,7 @@ export async function likeReply({ messageId }: { messageId: string }) {
     },
   )
 
-  if (response === 'NEED_LOGIN') {
-    throw new SessionError()
-  }
-
-  captureHttpError(response)
+  throwResponseError(response)
 }
 
 export async function unlikeReply({ messageId }: { messageId: string }) {
@@ -275,11 +271,7 @@ export async function unlikeReply({ messageId }: { messageId: string }) {
     },
   )
 
-  if (response === 'NEED_LOGIN') {
-    throw new SessionError()
-  }
-
-  captureHttpError(response)
+  throwResponseError(response)
 }
 
 function parseRepliesListResponse(
@@ -328,4 +320,15 @@ function sortChildren(reply: Reply): Reply {
   }
 
   return result
+}
+
+function throwResponseError<S, F>(response: 'NEED_LOGIN' | HttpResponse<S, F>) {
+  if (response === 'NEED_LOGIN') {
+    throw new SessionError()
+  }
+
+  captureHttpError(response)
+  if (!response.ok) {
+    throw new Error('Failed to like the reply')
+  }
 }

--- a/packages/review/src/components/shorten-list/services.ts
+++ b/packages/review/src/components/shorten-list/services.ts
@@ -6,6 +6,7 @@ import {
   GetLatestReviewsQueryVariables,
   GetReviewsByRatingQueryVariables,
   client,
+  reviewClient,
 } from '../../data/graphql'
 
 export function usePopularReviews(
@@ -17,10 +18,12 @@ export function usePopularReviews(
       { ...params, size: SHORTENED_REVIEWS_COUNT_PER_PAGE },
     ],
     () =>
-      client.GetPopularReviews({
-        ...params,
-        size: SHORTENED_REVIEWS_COUNT_PER_PAGE,
-      }),
+      reviewClient(
+        client.GetPopularReviews({
+          ...params,
+          size: SHORTENED_REVIEWS_COUNT_PER_PAGE,
+        }),
+      ),
     { refetchOnWindowFocus: false },
   )
 }
@@ -34,10 +37,12 @@ export function useLatestReviews(
       { ...params, size: SHORTENED_REVIEWS_COUNT_PER_PAGE },
     ],
     () =>
-      client.GetLatestReviews({
-        ...params,
-        size: SHORTENED_REVIEWS_COUNT_PER_PAGE,
-      }),
+      reviewClient(
+        client.GetLatestReviews({
+          ...params,
+          size: SHORTENED_REVIEWS_COUNT_PER_PAGE,
+        }),
+      ),
     { refetchOnWindowFocus: false },
   )
 }
@@ -51,10 +56,12 @@ export function useRatingReviews(
       { ...params, size: SHORTENED_REVIEWS_COUNT_PER_PAGE },
     ],
     () =>
-      client.GetReviewsByRating({
-        ...params,
-        size: SHORTENED_REVIEWS_COUNT_PER_PAGE,
-      }),
+      reviewClient(
+        client.GetReviewsByRating({
+          ...params,
+          size: SHORTENED_REVIEWS_COUNT_PER_PAGE,
+        }),
+      ),
     { refetchOnWindowFocus: false },
   )
 }

--- a/packages/review/src/components/shorten-list/services.ts
+++ b/packages/review/src/components/shorten-list/services.ts
@@ -18,7 +18,7 @@ export function usePopularReviews(
       { ...params, size: SHORTENED_REVIEWS_COUNT_PER_PAGE },
     ],
     () =>
-      reviewClient(
+      reviewClient(() =>
         client.GetPopularReviews({
           ...params,
           size: SHORTENED_REVIEWS_COUNT_PER_PAGE,
@@ -37,7 +37,7 @@ export function useLatestReviews(
       { ...params, size: SHORTENED_REVIEWS_COUNT_PER_PAGE },
     ],
     () =>
-      reviewClient(
+      reviewClient(() =>
         client.GetLatestReviews({
           ...params,
           size: SHORTENED_REVIEWS_COUNT_PER_PAGE,
@@ -56,7 +56,7 @@ export function useRatingReviews(
       { ...params, size: SHORTENED_REVIEWS_COUNT_PER_PAGE },
     ],
     () =>
-      reviewClient(
+      reviewClient(() =>
         client.GetReviewsByRating({
           ...params,
           size: SHORTENED_REVIEWS_COUNT_PER_PAGE,

--- a/packages/review/src/data/graphql/client.ts
+++ b/packages/review/src/data/graphql/client.ts
@@ -4,19 +4,23 @@ import { sessionRefresh } from '@titicaca/fetcher'
 import { Requester, getSdk } from './generated'
 
 const requester: Requester = (doc, vars) =>
-  request({ document: doc, url: '/api/graphql', variables: vars ?? undefined })
+  request({
+    document: doc,
+    url: '/api/graphql',
+    variables: vars ?? undefined,
+  })
 
 export const client = getSdk(requester)
 
-export async function reviewClient<T>(query: Promise<T>) {
+export async function reviewClient<T>(query: () => Promise<T>) {
   try {
-    const response = await query
+    const response = await query()
     return response
   } catch (e) {
     if (e instanceof ClientError && e.response.status === 401) {
       const refreshResponse = await sessionRefresh({})
       if (refreshResponse) {
-        const newResponse = await query
+        const newResponse = await query()
         return newResponse
       }
     }

--- a/packages/review/src/data/graphql/client.ts
+++ b/packages/review/src/data/graphql/client.ts
@@ -1,4 +1,5 @@
-import { request } from 'graphql-request'
+import { ClientError, request } from 'graphql-request'
+import { sessionRefresh } from '@titicaca/fetcher'
 
 import { Requester, getSdk } from './generated'
 
@@ -6,3 +7,16 @@ const requester: Requester = (doc, vars) =>
   request({ document: doc, url: '/api/graphql', variables: vars ?? undefined })
 
 export const client = getSdk(requester)
+
+export async function reviewClient<T>(query: Promise<T>) {
+  try {
+    const response = await query
+    return response
+  } catch (e) {
+    if (e instanceof ClientError && e.response.status === 401) {
+      await sessionRefresh({})
+      return query
+    }
+    throw e
+  }
+}

--- a/packages/review/src/data/graphql/client.ts
+++ b/packages/review/src/data/graphql/client.ts
@@ -14,8 +14,11 @@ export async function reviewClient<T>(query: Promise<T>) {
     return response
   } catch (e) {
     if (e instanceof ClientError && e.response.status === 401) {
-      await sessionRefresh({})
-      return query
+      const refreshResponse = await sessionRefresh({})
+      if (refreshResponse) {
+        const newResponse = await query
+        return newResponse
+      }
     }
     throw e
   }

--- a/packages/review/src/services/use-reviews.ts
+++ b/packages/review/src/services/use-reviews.ts
@@ -29,7 +29,7 @@ export function useReviewCount(
 ) {
   return useQuery<unknown, unknown, GetReviewsCountQuery>(
     ['reviews/getReviewCount', { ...params }],
-    async () => {
+    () => {
       reviewClient(client.GetReviewsCount(params))
     },
     {
@@ -47,7 +47,7 @@ export function useReviewCount(
 export function useDescriptions(params: GetReviewSpecificationQueryVariables) {
   return useQuery(
     ['review/getReviewSpecification', params],
-    async () => reviewClient(client.GetReviewSpecification(params)),
+    () => reviewClient(client.GetReviewSpecification(params)),
     { refetchOnWindowFocus: false },
   )
 }
@@ -55,7 +55,7 @@ export function useDescriptions(params: GetReviewSpecificationQueryVariables) {
 export function useMyReview(params: GetMyReviewQueryVariables) {
   return useQuery(
     ['review/getMyReview', params],
-    async () => reviewClient(client.GetMyReview(params)),
+    () => reviewClient(client.GetMyReview(params)),
     { refetchOnWindowFocus: false },
   )
 }
@@ -65,7 +65,7 @@ export function useLikeReviewMutation() {
   const queryClient = useQueryClient()
 
   return useMutation(
-    async (variables: LikeReviewMutationVariables & { resourceId: string }) =>
+    (variables: LikeReviewMutationVariables & { resourceId: string }) =>
       reviewClient(client.LikeReview({ reviewId: variables.reviewId })),
     {
       onSuccess: (data, variables) => {
@@ -170,7 +170,7 @@ export function useUnlikeReviewMutation() {
   const queryClient = useQueryClient()
 
   return useMutation(
-    async (variables: UnlikeReviewMutationVariables & { resourceId: string }) =>
+    (variables: UnlikeReviewMutationVariables & { resourceId: string }) =>
       reviewClient(client.UnlikeReview({ reviewId: variables.reviewId })),
     {
       onSuccess: (data, variables) => {

--- a/packages/review/src/services/use-reviews.ts
+++ b/packages/review/src/services/use-reviews.ts
@@ -19,15 +19,19 @@ import {
   LikeReviewMutationVariables,
   UnlikeReviewMutationVariables,
   client,
+  reviewClient,
+  GetReviewsCountQuery,
 } from '../data/graphql'
 
 export function useReviewCount(
   params: GetReviewsCountQueryVariables,
   initialValue?: number,
 ) {
-  return useQuery(
+  return useQuery<unknown, unknown, GetReviewsCountQuery>(
     ['reviews/getReviewCount', { ...params }],
-    () => client.GetReviewsCount(params),
+    async () => {
+      reviewClient(client.GetReviewsCount(params))
+    },
     {
       refetchOnWindowFocus: false,
       initialData: initialValue
@@ -43,7 +47,7 @@ export function useReviewCount(
 export function useDescriptions(params: GetReviewSpecificationQueryVariables) {
   return useQuery(
     ['review/getReviewSpecification', params],
-    () => client.GetReviewSpecification(params),
+    async () => reviewClient(client.GetReviewSpecification(params)),
     { refetchOnWindowFocus: false },
   )
 }
@@ -51,7 +55,7 @@ export function useDescriptions(params: GetReviewSpecificationQueryVariables) {
 export function useMyReview(params: GetMyReviewQueryVariables) {
   return useQuery(
     ['review/getMyReview', params],
-    () => client.GetMyReview(params),
+    async () => reviewClient(client.GetMyReview(params)),
     { refetchOnWindowFocus: false },
   )
 }
@@ -61,8 +65,8 @@ export function useLikeReviewMutation() {
   const queryClient = useQueryClient()
 
   return useMutation(
-    (variables: LikeReviewMutationVariables & { resourceId: string }) =>
-      client.LikeReview({ reviewId: variables.reviewId }),
+    async (variables: LikeReviewMutationVariables & { resourceId: string }) =>
+      reviewClient(client.LikeReview({ reviewId: variables.reviewId })),
     {
       onSuccess: (data, variables) => {
         notifyReviewLiked?.(variables.resourceId, variables.reviewId)
@@ -166,8 +170,8 @@ export function useUnlikeReviewMutation() {
   const queryClient = useQueryClient()
 
   return useMutation(
-    (variables: UnlikeReviewMutationVariables & { resourceId: string }) =>
-      client.UnlikeReview({ reviewId: variables.reviewId }),
+    async (variables: UnlikeReviewMutationVariables & { resourceId: string }) =>
+      reviewClient(client.UnlikeReview({ reviewId: variables.reviewId })),
     {
       onSuccess: (data, variables) => {
         notifyReviewUnliked?.(variables.resourceId, variables.reviewId)
@@ -270,12 +274,12 @@ export function useDeleteReviewMutation() {
   const queryClient = useQueryClient()
 
   return useMutation(
-    (
+    async (
       variables: DeleteReviewMutationVariables & {
         resourceId: string
         resourceType: string
       },
-    ) => client.DeleteReview(variables),
+    ) => reviewClient(client.DeleteReview(variables)),
     {
       onSuccess: (data, variables) => {
         notifyReviewDeleted?.(

--- a/packages/review/src/services/use-reviews.ts
+++ b/packages/review/src/services/use-reviews.ts
@@ -30,7 +30,7 @@ export function useReviewCount(
   return useQuery<unknown, unknown, GetReviewsCountQuery>(
     ['reviews/getReviewCount', { ...params }],
     () => {
-      reviewClient(client.GetReviewsCount(params))
+      reviewClient(() => client.GetReviewsCount(params))
     },
     {
       refetchOnWindowFocus: false,
@@ -47,7 +47,7 @@ export function useReviewCount(
 export function useDescriptions(params: GetReviewSpecificationQueryVariables) {
   return useQuery(
     ['review/getReviewSpecification', params],
-    () => reviewClient(client.GetReviewSpecification(params)),
+    () => reviewClient(() => client.GetReviewSpecification(params)),
     { refetchOnWindowFocus: false },
   )
 }
@@ -55,7 +55,7 @@ export function useDescriptions(params: GetReviewSpecificationQueryVariables) {
 export function useMyReview(params: GetMyReviewQueryVariables) {
   return useQuery(
     ['review/getMyReview', params],
-    () => reviewClient(client.GetMyReview(params)),
+    () => reviewClient(() => client.GetMyReview(params)),
     { refetchOnWindowFocus: false },
   )
 }
@@ -66,7 +66,7 @@ export function useLikeReviewMutation() {
 
   return useMutation(
     (variables: LikeReviewMutationVariables & { resourceId: string }) =>
-      reviewClient(client.LikeReview({ reviewId: variables.reviewId })),
+      reviewClient(() => client.LikeReview({ reviewId: variables.reviewId })),
     {
       onSuccess: (data, variables) => {
         notifyReviewLiked?.(variables.resourceId, variables.reviewId)
@@ -171,7 +171,7 @@ export function useUnlikeReviewMutation() {
 
   return useMutation(
     (variables: UnlikeReviewMutationVariables & { resourceId: string }) =>
-      reviewClient(client.UnlikeReview({ reviewId: variables.reviewId })),
+      reviewClient(() => client.UnlikeReview({ reviewId: variables.reviewId })),
     {
       onSuccess: (data, variables) => {
         notifyReviewUnliked?.(variables.resourceId, variables.reviewId)
@@ -279,7 +279,7 @@ export function useDeleteReviewMutation() {
         resourceId: string
         resourceType: string
       },
-    ) => reviewClient(client.DeleteReview(variables)),
+    ) => reviewClient(() => client.DeleteReview(variables)),
     {
       onSuccess: (data, variables) => {
         notifyReviewDeleted?.(

--- a/packages/triple-document/src/elements/tna/index.tsx
+++ b/packages/triple-document/src/elements/tna/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { HR2 } from '@titicaca/core-elements'
-import { get } from '@titicaca/fetcher'
+import { authGuardedFetchers, NEED_LOGIN_IDENTIFIER } from '@titicaca/fetcher'
 
 import { TnaProductsResponse } from './types'
 import { Slot } from './slot'
@@ -17,11 +17,11 @@ function useProducts({ slotId }: { slotId?: number }): TnaProductsResponse {
         return
       }
 
-      const response = await get<TnaProductsResponse>(
+      const response = await authGuardedFetchers.get<TnaProductsResponse>(
         `/api/tna-v2/slots/${slotId}`,
       )
 
-      if (response.ok) {
+      if (response !== NEED_LOGIN_IDENTIFIER && response.ok) {
         const {
           parsedBody: { title, products },
         } = response

--- a/packages/triple-header/src/service.ts
+++ b/packages/triple-header/src/service.ts
@@ -1,4 +1,4 @@
-import { get } from '@titicaca/fetcher'
+import { authGuardedFetchers, NEED_LOGIN_IDENTIFIER } from '@titicaca/fetcher'
 
 export const ARTICLE_ANIMATION_STORAGE_TYPE = 'lottie-animation-v1'
 
@@ -13,11 +13,11 @@ export async function getStorage({
     throw new Error('Id가 없습니다.')
   }
 
-  const response = await get<{ data: string }>(
+  const response = await authGuardedFetchers.get<{ data: string }>(
     `/api/storage/storages/${type}/${id}`,
   )
 
-  if (!response.ok) {
+  if (response === NEED_LOGIN_IDENTIFIER || !response.ok) {
     throw new Error('Request failed')
   }
 

--- a/packages/user-verification/src/confirmation-services.ts
+++ b/packages/user-verification/src/confirmation-services.ts
@@ -1,4 +1,4 @@
-import { get } from '@titicaca/fetcher'
+import { authGuardedFetchers, NEED_LOGIN_IDENTIFIER } from '@titicaca/fetcher'
 
 export function confirmVerification(type: string): Promise<{
   verified: boolean | undefined
@@ -18,11 +18,12 @@ export function confirmVerification(type: string): Promise<{
 }
 
 async function confirmSmsVerification() {
-  const response = await get<{
+  const response = await authGuardedFetchers.get<{
     phoneNumber: string
   }>('/api/users/smscert')
-
-  if (response.status === 404) {
+  if (response === NEED_LOGIN_IDENTIFIER) {
+    return { verified: undefined, error: NEED_LOGIN_IDENTIFIER }
+  } else if (response.status === 404) {
     return { verified: false }
   } else if (response.ok) {
     const { phoneNumber, ...payload } = response.parsedBody
@@ -34,11 +35,12 @@ async function confirmSmsVerification() {
 }
 
 async function confirmPersonalIdVerificationWithResidence() {
-  const response = await get<{
+  const response = await authGuardedFetchers.get<{
     phoneNumber: string
   }>('/api/users/kto-stay-2021')
-
-  if (response.status === 404) {
+  if (response === NEED_LOGIN_IDENTIFIER) {
+    return { verified: undefined, error: NEED_LOGIN_IDENTIFIER }
+  } else if (response.status === 404) {
     return { verified: false }
   } else if (response.ok) {
     const { phoneNumber, ...payload } = response.parsedBody
@@ -50,11 +52,12 @@ async function confirmPersonalIdVerificationWithResidence() {
 }
 
 async function confirmPersonalIdVerification() {
-  const response = await get<{
+  const response = await authGuardedFetchers.get<{
     mobile: string
   }>('/api/users/namecheck')
-
-  if (response.status === 404) {
+  if (response === NEED_LOGIN_IDENTIFIER) {
+    return { verified: undefined, error: NEED_LOGIN_IDENTIFIER }
+  } else if (response.status === 404) {
     return { verified: false }
   } else if (response.ok) {
     const { mobile: phoneNumber, ...payload } = response.parsedBody
@@ -68,11 +71,13 @@ async function confirmPersonalIdVerification() {
 async function confirmExternalPromotionEligibility(type: string) {
   const externalPromotionId = type.replace(/^external-promotion-/, '')
 
-  const response = await get<{
+  const response = await authGuardedFetchers.get<{
     phoneNumber?: string
   }>(`/api/users/external-promotion/${externalPromotionId}/eligibility`)
 
-  if (response.status === 404) {
+  if (response === NEED_LOGIN_IDENTIFIER) {
+    return { verified: undefined, error: NEED_LOGIN_IDENTIFIER }
+  } else if (response.status === 404) {
     return { verified: false }
   } else if (response.ok) {
     const { phoneNumber, ...payload } = response.parsedBody

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -581,6 +581,9 @@ importers:
 
   packages/fetcher:
     dependencies:
+      set-cookie-parser:
+        specifier: ^2.7.1
+        version: 2.7.1
       ts-custom-error:
         specifier: ^3.3.1
         version: 3.3.1
@@ -597,6 +600,9 @@ importers:
       '@types/node-fetch':
         specifier: ^2.6.7
         version: 2.6.7
+      '@types/set-cookie-parser':
+        specifier: ^2.4.10
+        version: 2.4.10
       isomorphic-fetch:
         specifier: ^2.2.1
         version: 2.2.1
@@ -5246,9 +5252,6 @@ packages:
 
   '@types/set-cookie-parser@2.4.10':
     resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
-
-  '@types/set-cookie-parser@2.4.2':
-    resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
 
   '@types/stack-utils@2.0.1':
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
@@ -10632,9 +10635,6 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
-  set-cookie-parser@2.6.0:
-    resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
-
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
@@ -14221,8 +14221,8 @@ snapshots:
 
   '@mswjs/cookies@0.2.2':
     dependencies:
-      '@types/set-cookie-parser': 2.4.2
-      set-cookie-parser: 2.6.0
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 2.7.1
 
   '@mswjs/interceptors@0.17.10':
     dependencies:
@@ -16590,10 +16590,6 @@ snapshots:
       '@types/node': 18.18.7
 
   '@types/set-cookie-parser@2.4.10':
-    dependencies:
-      '@types/node': 18.18.7
-
-  '@types/set-cookie-parser@2.4.2':
     dependencies:
       '@types/node': 18.18.7
 
@@ -23415,8 +23411,6 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0: {}
-
-  set-cookie-parser@2.6.0: {}
 
   set-cookie-parser@2.7.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -581,9 +581,6 @@ importers:
 
   packages/fetcher:
     dependencies:
-      set-cookie-parser:
-        specifier: ^2.7.1
-        version: 2.7.1
       ts-custom-error:
         specifier: ^3.3.1
         version: 3.3.1
@@ -600,9 +597,6 @@ importers:
       '@types/node-fetch':
         specifier: ^2.6.7
         version: 2.6.7
-      '@types/set-cookie-parser':
-        specifier: ^2.4.10
-        version: 2.4.10
       isomorphic-fetch:
         specifier: ^2.2.1
         version: 2.2.1


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
클라이언트에서의 세션 갱신을 위한 로직을 구현합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- `fetcher`의 기본 methods를 사용하고 있던 부분을 `authGuardedFetchers`로 변경하고 해당 메소드의 return 값에 맞게 로직을 수정합니다.
  - `NEED_LOGIN` string을 리턴하는 경우를 처리합니다. 
  - TF 내부에서 응답을 처리하는 부분은 기존 로직과 변경된 점이 없어야 합니다. 
 - ReactQuery를 사용해 API를 fetch하는 `Review` 컴포넌트의 경우 queryFn에 들어가는 로직을 함수로 감싸 session refresh 로직이 실행되도록 했습니다. 
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## TODO
- API 응답에서 status code가 401인 경우 body를 통해 세션 만료인지, 로그인이 필요한 API인지 구분할 수 있도록 변경되었습니다. 이 부분은 해당 PR 리뷰 이후 적용 예정입니다. 
