### PR TITLE
[view-utilities] routelist의 static-pages 정규식을 수정합니다.

### DIFF
--- a/packages/view-utilities/src/routelist/routelist.spec.ts
+++ b/packages/view-utilities/src/routelist/routelist.spec.ts
@@ -3,6 +3,7 @@ import { checkIfRoutable } from './routelist'
 describe('checkIfRoutable', () => {
   const regionId = '5eb828fe-cb69-482c-bf37-e166d6cce259'
   const hotelId = 'f20c23b6-8eff-47d7-b25a-032be42c1ea6'
+  const communityPostId = '45e178b2-41f1-48f7-94db-0dca71361f27'
 
   it('should allow navigation to login path', () => {
     expect(
@@ -94,6 +95,33 @@ describe('checkIfRoutable', () => {
 
   it('should allow navigation to article', () => {
     const path = `/articles/${hotelId}`
+    expect(
+      checkIfRoutable({
+        href: path,
+      }),
+    ).toBe(true)
+  })
+
+  it('should allow navigation to privacy-policy page', () => {
+    const path = `/pages/privacy-policy.html`
+    expect(
+      checkIfRoutable({
+        href: path,
+      }),
+    ).toBe(true)
+  })
+
+  it('should allow navigation to community', () => {
+    const path = `/community/posts/${communityPostId}`
+    expect(
+      checkIfRoutable({
+        href: path,
+      }),
+    ).toBe(true)
+  })
+
+  it('should allow navigation to game', () => {
+    const path = `/game/my-luggage/${regionId}/missions`
     expect(
       checkIfRoutable({
         href: path,

--- a/packages/view-utilities/src/routelist/routelist.ts
+++ b/packages/view-utilities/src/routelist/routelist.ts
@@ -24,9 +24,9 @@ const PUBLIC_ROUTELIST_REGEXES = [
   /^\/trips\/promotion\/customized-schedule(\/.*)?$/,
   /^\/trips\/plan(\/.*)?$/,
   /^\/reviews\/list(\/.*)?$/,
-  /^\/pages\/?$/,
-  /^\/community\/?$/,
-  /^\/game\/?$/,
+  /^\/pages\/.*/,
+  /^\/community\/.*/,
+  /^\/game\/.*/,
 ]
 
 export function checkIfRoutable({ href }: { href: string }) {

--- a/packages/view-utilities/src/routelist/routelist.ts
+++ b/packages/view-utilities/src/routelist/routelist.ts
@@ -24,9 +24,9 @@ const PUBLIC_ROUTELIST_REGEXES = [
   /^\/trips\/promotion\/customized-schedule(\/.*)?$/,
   /^\/trips\/plan(\/.*)?$/,
   /^\/reviews\/list(\/.*)?$/,
-  /^\/pages\/.*/,
-  /^\/community\/.*/,
-  /^\/game\/.*/,
+  /^\/pages(\/.*)?$/,
+  /^\/community(\/.*)?$/,
+  /^\/game(\/.*)?$/,
 ]
 
 export function checkIfRoutable({ href }: { href: string }) {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[view-utilities] routelist의 static-pages 정규식을 수정하고 테스트 코드를 추가합니다. (테스트 코드의 중요성..😂)
- 기존 정규식 `/^\/pages\/?$/`은 `/pages/` 경로만 허용합니다. (하위 경로 허용x)
- `/pages`, `/pages/` 및 `/pages/` 이하의 하위경로까지 포함하는 regex로 수정합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

