### PR TITLE
(Chat) [DMTALK-51] 사용자 식별자 제외 API 응답 마이그레이션

### DIFF
--- a/packages/tds-widget/src/chat/chat/chat-room-messages/chat-api-service.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/chat-api-service.ts
@@ -2,6 +2,7 @@ import qs from 'qs'
 
 import {
   ChatMessageInterface,
+  ChatRoomMemberInterface,
   ChatUserInterface,
   HasUnreadOfRoomInterface,
   ReactionType,
@@ -30,7 +31,8 @@ interface ReactionPayload {
 }
 
 interface Sender {
-  id: ChatUserInterface['id']
+  id?: ChatUserInterface['id']
+  roomMemberId?: ChatRoomMemberInterface['roomMemberId']
   profile: {
     name: ChatUserInterface['profile']['name']
   }
@@ -47,6 +49,14 @@ export class ChatApiService<T = UserType> {
   public constructor(fetcher: ChatFetcher, isTripleChat = false) {
     this.fetcher = fetcher
     this.isTripleChat = isTripleChat
+  }
+
+  public getRoomMemberMe({
+    roomId,
+  }: {
+    roomId: string
+  }): Promise<ChatRoomMemberInterface<T>> {
+    return this.fetcher(`/rooms/${roomId}/members/me`)
   }
 
   public getMessages({

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/chat-message-context.tsx
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/chat-message-context.tsx
@@ -9,6 +9,7 @@ import {
 import {
   type MessagesAction,
   MessagesActions,
+  UnsentMessage,
   useMessagesReducer,
 } from '../messages-reducer'
 import {
@@ -36,8 +37,8 @@ export interface ChatMessagesContextValue<T = UserType> {
    * MessagesReducer의 state 및 dispatch
    */
   messages: ChatMessageInterface<T>[]
-  pendingMessages: ChatMessageInterface<T>[]
-  failedMessages: ChatMessageInterface<T>[]
+  pendingMessages: UnsentMessage<ChatMessageInterface<T>>[]
+  failedMessages: UnsentMessage<ChatMessageInterface<T>>[]
   hasPrevMessage: boolean
   dispatch: Dispatch<
     MessagesAction<ChatMessageInterface<T>, ChatMessageInterface<T>['id']>

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/messages.tsx
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/messages.tsx
@@ -12,6 +12,7 @@ import {
 import OriginalMessages from '../../messages'
 import { getProfileImageUrl } from '../../utils'
 import { UnsentMessage } from '../messages-reducer'
+import { getUserIdentifier } from '../../utils/user'
 
 export type ChatRoomMessageInterface<T = UserType> = Omit<
   ChatMessageInterface<T>,
@@ -155,13 +156,13 @@ function getMessageTypeAndValue<T = UserType>(
 }
 
 function convertChatUserToMessageUser<T = UserType>(
-  me: ChatMessageInterface<T>['sender'] | ChatRoomUser<T>,
+  user: ChatMessageInterface<T>['sender'] | ChatRoomUser<T>,
 ) {
   return {
-    id: 'roomMemberId' in me ? me.roomMemberId : me.id,
+    id: getUserIdentifier(user),
     profile: {
-      name: me.profile.name,
-      photo: me.profile.thumbnail || getProfileImageUrl(me),
+      name: user.profile.name,
+      photo: user.profile.thumbnail || getProfileImageUrl(user),
     },
   }
 }

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/messages.tsx
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/messages.tsx
@@ -4,13 +4,14 @@ import DOMPurify from 'dompurify'
 import {
   ChatMessageInterface,
   ChatMessagePayloadType,
-  ChatUserInterface,
+  ChatRoomUser,
   DisplayTargetAll,
   UserInterface,
   UserType,
 } from '../../types'
 import OriginalMessages from '../../messages'
 import { getProfileImageUrl } from '../../utils'
+import { UnsentMessage } from '../messages-reducer'
 
 export type ChatRoomMessageInterface<T = UserType> = Omit<
   ChatMessageInterface<T>,
@@ -32,10 +33,10 @@ export default function Messages<T = UserType>({
   showReactions = false,
   ...props
 }: {
-  me: ChatUserInterface<T>
+  me: ChatRoomUser<T>
   messages: ChatMessageInterface<T>[]
-  pendingMessages: ChatMessageInterface<T>[]
-  failedMessages: ChatMessageInterface<T>[]
+  pendingMessages: UnsentMessage<ChatMessageInterface<T>>[]
+  failedMessages: UnsentMessage<ChatMessageInterface<T>>[]
   displayTarget: T
   showReactions?: boolean
 } & Omit<
@@ -64,8 +65,24 @@ export default function Messages<T = UserType>({
 }
 
 function convertMessages<T = UserType>(
-  me: ChatUserInterface<T>,
+  me: ChatRoomUser<T>,
   messages: ChatMessageInterface<T>[],
+  roomDisplayTarget: T,
+  showReactions?: boolean,
+): OriginalMessagesPropTypes<T>['messages']
+
+function convertMessages<T = UserType>(
+  me: ChatRoomUser<T>,
+  messages: UnsentMessage<ChatMessageInterface<T>>[],
+  roomDisplayTarget: T,
+  showReactions?: boolean,
+): OriginalMessagesPropTypes<T>['pendingMessages']
+
+function convertMessages<T = UserType>(
+  me: ChatRoomUser<T>,
+  messages:
+    | ChatMessageInterface<T>[]
+    | UnsentMessage<ChatMessageInterface<T>>[],
   roomDisplayTarget: T,
   showReactions = false,
 ):
@@ -138,10 +155,10 @@ function getMessageTypeAndValue<T = UserType>(
 }
 
 function convertChatUserToMessageUser<T = UserType>(
-  me: ChatMessageInterface<T>['sender'] | ChatUserInterface<T>,
+  me: ChatMessageInterface<T>['sender'] | ChatRoomUser<T>,
 ) {
   return {
-    id: me.id,
+    id: 'roomMemberId' in me ? me.roomMemberId : me.id,
     profile: {
       name: me.profile.name,
       photo: me.profile.thumbnail || getProfileImageUrl(me),

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
@@ -307,30 +307,30 @@ export function useChatMessages<T = UserType>({
   }
 
   function onRetry(
-    message: UnsentMessage<ChatRoomMessageInterface<T>>,
+    { id, payload }: UnsentMessage<ChatRoomMessageInterface<T>>,
     {
       onComplete,
     }: {
       onComplete?: () => void
     } = {},
   ) {
-    removeUnsentMessages(message)
+    removeUnsentMessages({ id })
 
-    if (message.payload.type !== 'rich') {
-      onSendMessage?.(message.payload)
+    if (payload.type !== 'rich') {
+      onSendMessage?.(payload)
       onComplete?.()
     }
   }
 
   function onRetryCancel(
-    message: ChatRoomMessageInterface<T>,
+    { id }: UnsentMessage<ChatRoomMessageInterface<T>>,
     {
       onComplete,
     }: {
       onComplete?: () => void
     } = {},
   ) {
-    removeUnsentMessages(message)
+    removeUnsentMessages({ id })
     onComplete?.()
   }
 

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
@@ -4,10 +4,10 @@ import DOMPurify from 'dompurify'
 import {
   ChatMessageInterface,
   ChatMessagePayloadType,
+  ChatRoomDetailInterface,
   ChatRoomInterface,
   ChatRoomMemberInterface,
   ChatRoomUser,
-  CreatedChatRoomInterface,
   isChatRoomMember,
   isCreatedChatRoom,
   ReactionType,
@@ -28,7 +28,7 @@ import { ChatRoomMessageInterface } from './messages'
 
 interface ChatMessagesProps<T = UserType> {
   defaultMessageProperties?: Partial<ChatMessageInterface<T>>
-  createRoom?: () => Promise<CreatedChatRoomInterface | undefined>
+  createRoom?: () => Promise<ChatRoomDetailInterface | undefined>
 }
 
 export function useChatMessages<T = UserType>({
@@ -145,7 +145,7 @@ export function useChatMessages<T = UserType>({
     me,
     onError,
   }: {
-    room: CreatedChatRoomInterface
+    room: ChatRoomDetailInterface
     me: ChatRoomUser<T>
     onError?: () => void
   }) {
@@ -260,7 +260,7 @@ export function useChatMessages<T = UserType>({
     /** 첫 렌더링 시에만 자동 메세지를 보내도록 합니다. */
     if (isWelcomeMessagePendingRef.current) {
       await handleSendWelcomeMessage({
-        room: currentRoom as CreatedChatRoomInterface,
+        room: currentRoom as ChatRoomDetailInterface,
         me: roomMemberMe,
         onError,
       })
@@ -487,11 +487,11 @@ export function useChatMessages<T = UserType>({
 }
 
 function findSenderFromRoomMembers<T>(
-  room: CreatedChatRoomInterface,
+  room: ChatRoomDetailInterface,
   me: ChatRoomUser<T>,
   sender?: ChatRoomMemberInterface<T>,
 ) {
-  if (sender && 'members' in room) {
+  if (sender) {
     return room.members.find(
       (member) =>
         getUserIdentifier(member) === getUserIdentifier(sender) ||

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-unread-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-unread-messages.ts
@@ -1,12 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { useRoom } from '../room-context'
-import {
-  CreatedChatRoomInterface,
-  isCreatedChatRoom,
-  OtherUnreadInterface,
-  UserType,
-} from '../../types'
+import { isCreatedChatRoom, OtherUnreadInterface, UserType } from '../../types'
 import { shouldUseLegacyMemberId } from '../../utils'
 
 import { useChatApiService } from './chat-message-context'
@@ -76,7 +71,7 @@ export function useUnreadMessages<T = UserType>() {
   // TODO pusher unread 이벤트 api 리팩토링 완료시 해당 코드를 삭제합니다.
   useEffect(() => {
     handleUnreadEvent()
-  }, [(room as CreatedChatRoomInterface).id, lastMessageId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [(room as { id?: string }).id, lastMessageId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
     calculateUnreadCount,

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-unread-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-unread-messages.ts
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react'
 
 import { useRoom } from '../room-context'
 import {
-  ChatRoomInterface,
   CreatedChatRoomInterface,
   isCreatedChatRoom,
   OtherUnreadInterface,
   UserType,
 } from '../../types'
+import { shouldUseLegacyMemberId } from '../../utils'
 
 import { useChatApiService } from './chat-message-context'
 import { ChatRoomMessageInterface } from './messages'
@@ -83,12 +83,4 @@ export function useUnreadMessages<T = UserType>() {
     setLastMessageId,
     // handleUnreadEvent
   }
-}
-
-function shouldUseLegacyMemberId(room: ChatRoomInterface) {
-  return (
-    'members' in room &&
-    'identifier' in room.members[0] &&
-    'id' in room.members[0]
-  )
 }

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-unread-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-unread-messages.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { useRoom } from '../room-context'
 import {
+  ChatRoomInterface,
   CreatedChatRoomInterface,
   isCreatedChatRoom,
   OtherUnreadInterface,
@@ -54,7 +55,8 @@ export function useUnreadMessages<T = UserType>() {
     return otherReadInfo.reduce(
       (prev, info) =>
         Number(info.lastSeenMessageId) < Number(id) &&
-        (info.roomMemberId || info.memberId) !== sender.id
+        (shouldUseLegacyMemberId(room) ? info.memberId : info.roomMemberId) !==
+          sender.id
           ? prev + 1
           : prev,
       0,
@@ -81,4 +83,12 @@ export function useUnreadMessages<T = UserType>() {
     setLastMessageId,
     // handleUnreadEvent
   }
+}
+
+function shouldUseLegacyMemberId(room: ChatRoomInterface) {
+  return (
+    'members' in room &&
+    'identifier' in room.members[0] &&
+    'id' in room.members[0]
+  )
 }

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-unread-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-unread-messages.ts
@@ -54,7 +54,7 @@ export function useUnreadMessages<T = UserType>() {
     return otherReadInfo.reduce(
       (prev, info) =>
         Number(info.lastSeenMessageId) < Number(id) &&
-        info.roomMemberId !== sender.id
+        (info.roomMemberId || info.memberId) !== sender.id
           ? prev + 1
           : prev,
       0,

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-unread-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-unread-messages.ts
@@ -54,7 +54,7 @@ export function useUnreadMessages<T = UserType>() {
     return otherReadInfo.reduce(
       (prev, info) =>
         Number(info.lastSeenMessageId) < Number(id) &&
-        info.memberId !== sender.id
+        info.roomMemberId !== sender.id
           ? prev + 1
           : prev,
       0,

--- a/packages/tds-widget/src/chat/chat/messages-reducer.ts
+++ b/packages/tds-widget/src/chat/chat/messages-reducer.ts
@@ -13,16 +13,23 @@ export enum MessagesActions {
   HAS_NEXT = 'HAS_NEXT', // 다음 메세지 페이지네이션 플래그 설정
 }
 
-export interface MessageBase<Id = string> {
+export type UnsentMessage<
+  Message extends MessageBase<Id, Sender>,
+  Id = string | number,
+  Sender = unknown,
+> = Omit<Message, 'createdAt' | 'sender'> & { sender?: Message['sender'] }
+
+export interface MessageBase<Id = string | number, Sender = unknown> {
   id: Id
   createdAt?: string
   parentMessage?: MessageBase<Id> | null
+  sender?: Sender
 }
 
 export interface MessagesState<Message extends MessageBase<Id>, Id = string> {
   messages: Message[]
-  pendingMessages: Omit<Message, 'createdAt'>[]
-  failedMessages: Omit<Message, 'createdAt'>[]
+  pendingMessages: UnsentMessage<Message, Id>[]
+  failedMessages: UnsentMessage<Message, Id>[]
   hasPrevMessage: boolean
   hasNextMessage: boolean
 }
@@ -58,11 +65,11 @@ export type MessagesAction<Message extends MessageBase<Id>, Id = string> =
     }
   | {
       action: MessagesActions.PENDING
-      message: Omit<Message, 'createdAt'>
+      message: UnsentMessage<Message, Id>
     }
   | {
       action: MessagesActions.FAIL
-      message: Omit<Message, 'createdAt'>
+      message: UnsentMessage<Message, Id>
     }
   | {
       action: MessagesActions.REMOVE

--- a/packages/tds-widget/src/chat/chat/room-context.tsx
+++ b/packages/tds-widget/src/chat/chat/room-context.tsx
@@ -1,30 +1,33 @@
 import { createContext, useContext, PropsWithChildren, useState } from 'react'
 import deepmerge from 'deepmerge'
 
-import type { ChatUserInterface, ChatRoomInterface } from '../types'
+import type { ChatRoomInterface, ChatRoomUser } from '../types'
 
-export interface RoomProviderProps<
-  T = ChatRoomInterface,
-  U = ChatUserInterface,
-> {
+export interface RoomProviderProps<T = ChatRoomInterface, U = ChatRoomUser> {
   room: T
   me: U
 }
 
-interface RoomContextValue<T = ChatRoomInterface, U = ChatUserInterface> {
+interface RoomContextValue<T = ChatRoomInterface, U = ChatRoomUser> {
   room: T
   me: U
   updateRoom: (room: Partial<T>, options?: { deepMerge?: boolean }) => void
+  updateMe: (me: U) => void
 }
 
 export const RoomContext = createContext<RoomContextValue | null>(null)
 
-export function RoomProvider<T = ChatRoomInterface, U = ChatUserInterface>({
+export function RoomProvider<T = ChatRoomInterface, U = ChatRoomUser>({
   room: initialRoom,
-  me,
+  me: initialMe,
   children,
 }: PropsWithChildren<RoomProviderProps<T, U>>) {
   const [room, setRoom] = useState<T>(initialRoom)
+  const [me, setMe] = useState<U>(initialMe)
+
+  const updateMe = (me: U) => {
+    setMe((prev) => ({ ...prev, ...me }))
+  }
 
   const updateRoom = (room: Partial<T>, options?: { deepMerge?: boolean }) => {
     setRoom((prevRoom) =>
@@ -36,12 +39,13 @@ export function RoomProvider<T = ChatRoomInterface, U = ChatUserInterface>({
     room,
     me,
     updateRoom,
+    updateMe,
   } as unknown as RoomContextValue
 
   return <RoomContext.Provider value={value}>{children}</RoomContext.Provider>
 }
 
-export function useRoom<T = ChatRoomInterface, U = ChatUserInterface>() {
+export function useRoom<T = ChatRoomInterface, U = ChatRoomUser>() {
   const context = useContext(RoomContext)
 
   if (!context) {

--- a/packages/tds-widget/src/chat/types/message.ts
+++ b/packages/tds-widget/src/chat/types/message.ts
@@ -1,3 +1,5 @@
+import { UnsentMessage } from '../chat'
+
 import { MetaDataInterface } from './image'
 import {
   ChatRoomMemberInterface,
@@ -110,12 +112,11 @@ export interface ChatMessageInterface<T = UserType> {
   sender: ChatRoomMemberInterface<T>
 }
 
-export type WelcomeMessageInterface<T = UserType> = Omit<
-  ChatMessageInterface<T>,
-  'roomId'
-> & {
-  roomId?: string
-}
+export type WelcomeMessageInterface<T = UserType> = UnsentMessage<
+  Omit<ChatMessageInterface<T>, 'roomId'> & {
+    roomId?: string
+  }
+>
 
 export type CustomerBookingStatus =
   | 'BOOKED'

--- a/packages/tds-widget/src/chat/types/message.ts
+++ b/packages/tds-widget/src/chat/types/message.ts
@@ -1,5 +1,9 @@
 import { MetaDataInterface } from './image'
-import { ChatUserInterface, UserType } from './user'
+import {
+  ChatRoomMemberInterface,
+  TripleChatRoomMemberInterface,
+  UserType,
+} from './user'
 
 export type DisplayTargetAll = 'all'
 
@@ -79,17 +83,31 @@ type ChatAlternativeMessagePayload =
   | ChatTextMessagePayload
   | ChatRichMessagePayload
 
+/**
+ * triple-chat 서버 응답으로 받는 ChatMessageInterface
+ */
+export interface TripleChatMessageInterface<T = UserType>
+  extends Omit<ChatMessageInterface<T>, 'sender'> {
+  /**
+   * @deprecated
+   */
+  senderId?: string
+  sender: TripleChatRoomMemberInterface<T>
+}
+
+/**
+ * nol-chat 서버 응답으로 받는 ChatMessageInterface
+ */
 export interface ChatMessageInterface<T = UserType> {
   id: number
   roomId: string
-  senderId: string
   payload: ChatMessagePayload
   createdAt?: string
   displayTarget?: T[] | DisplayTargetAll
   alternative?: ChatAlternativeMessagePayload
   blindedAt?: string
   reactions?: { [type in ReactionType]?: { count: number; haveMine: boolean } }
-  sender: ChatUserInterface<T>
+  sender: ChatRoomMemberInterface<T>
 }
 
 export type WelcomeMessageInterface<T = UserType> = Omit<

--- a/packages/tds-widget/src/chat/types/message.ts
+++ b/packages/tds-widget/src/chat/types/message.ts
@@ -3,6 +3,7 @@ import { UnsentMessage } from '../chat'
 import { MetaDataInterface } from './image'
 import {
   ChatRoomMemberInterface,
+  PreDirectRoomMemberInterface,
   TripleChatRoomMemberInterface,
   UserType,
 } from './user'
@@ -113,8 +114,11 @@ export interface ChatMessageInterface<T = UserType> {
 }
 
 export type WelcomeMessageInterface<T = UserType> = UnsentMessage<
-  Omit<ChatMessageInterface<T>, 'roomId'> & {
+  Omit<ChatMessageInterface<T>, 'roomId' | 'sender'> & {
     roomId?: string
+    sender:
+      | ChatMessageInterface<T>['sender']
+      | PreDirectRoomMemberInterface<UserType>
   }
 >
 

--- a/packages/tds-widget/src/chat/types/room.ts
+++ b/packages/tds-widget/src/chat/types/room.ts
@@ -1,6 +1,11 @@
 import { ChatChannelInfo, ValueOf } from './base'
 import { ChatMessageInterface } from './message'
-import { ChatRoomMemberInterface, ChatUserInterface, UserType } from './user'
+import {
+  ChatRoomMemberInterface,
+  ChatUserInterface,
+  TripleChatUserInterface,
+  UserType,
+} from './user'
 
 export const RoomType = {
   DEFAULT: 'default', // 기존 파트너센터 챗
@@ -196,7 +201,7 @@ export interface RoomInterface<T = RoomType, U = UserType> {
   lastMessageId: number
   lastMessage: ChatMessageInterface<U>
   unreadCount?: number
-  members: ChatUserInterface<U>[]
+  members: TripleChatUserInterface<U>[]
   isDirect: boolean
   createdAt: string
   metadata?: EventMetaData

--- a/packages/tds-widget/src/chat/types/room.ts
+++ b/packages/tds-widget/src/chat/types/room.ts
@@ -115,7 +115,7 @@ export interface CreatedChatRoomDetailInterface<
    */
   expired: boolean
   memberCounts: number
-  members: ChatUserInterface<U>[]
+  members: ChatRoomMemberInterface<U>[]
 }
 
 interface ChatRoomDetailRoomInterface<T = RoomType, U = UserType> {

--- a/packages/tds-widget/src/chat/types/room.ts
+++ b/packages/tds-widget/src/chat/types/room.ts
@@ -184,7 +184,7 @@ export function isCreatedChatRoom<
 /**
  * @deprecated
  * 기존 triple-chat에서 사용하는 RoomInterface
- * nol-chat으로 변경 시 ChatRoomInterface를 사용해 주세요.
+ * nol-chat으로 변경 시 ChatRoomDetailInterface를 사용해 주세요.
  */
 export interface RoomInterface<T = RoomType, U = UserType> {
   id: string

--- a/packages/tds-widget/src/chat/types/room.ts
+++ b/packages/tds-widget/src/chat/types/room.ts
@@ -1,6 +1,6 @@
 import { ChatChannelInfo, ValueOf } from './base'
 import { ChatMessageInterface } from './message'
-import { ChatUserInterface, UserType } from './user'
+import { ChatRoomMemberInterface, ChatUserInterface, UserType } from './user'
 
 export const RoomType = {
   DEFAULT: 'default', // 기존 파트너센터 챗
@@ -86,7 +86,7 @@ interface DirectChatRoomInterface<
   U = UserType,
   V = ChatRoomMetadata<T>,
 > extends BaseChatRoomInterface<T, U, V> {
-  members: ChatUserInterface<U>[]
+  members: ChatRoomMemberInterface<U>[]
 }
 
 interface BaseChatRoomInterface<
@@ -144,19 +144,23 @@ export type ChatRoomDetailInterface<
   | CreatedChatRoomDetailInterface<T, U, V>
   | DirectChatRoomInterface<T, U, V>
 
+interface ChatRoomListMemberInterface<T = UserType>
+  extends ChatRoomMemberInterface<T>,
+    Pick<ChatUserInterface<T>, 'id'> {}
+
 export interface ChatRoomListItemInterface<T = RoomType, U = UserType>
   extends Pick<
-      CreatedChatRoomInterface<T, U>,
-      | 'id'
-      | 'createdAt'
-      | 'isDirect'
-      | 'name'
-      | 'lastMessageId'
-      | 'lastMessage'
-      | 'type'
-      | 'expired'
-    >,
-    Pick<Required<CreatedChatRoomInterface<T, U>>, 'members'> {
+    CreatedChatRoomInterface<T, U>,
+    | 'id'
+    | 'createdAt'
+    | 'isDirect'
+    | 'name'
+    | 'lastMessageId'
+    | 'lastMessage'
+    | 'type'
+    | 'expired'
+  > {
+  members: ChatRoomListMemberInterface[]
   unreadCount?: number
 }
 

--- a/packages/tds-widget/src/chat/types/room.ts
+++ b/packages/tds-widget/src/chat/types/room.ts
@@ -86,7 +86,7 @@ export type ChatRoomMetadata<T, U = ChatRoomMetadataMap> = T extends keyof U
  * @deprecated
  * 기존 트리플 파트너챗에서 /direct로 진입하는 생성되지 않은 채팅방
  */
-interface PreDirectRoomInterface<T = RoomType, U = UserType> {
+export interface PreDirectRoomInterface<T = RoomType, U = UserType> {
   preDirectRoom: true
   type: T
   members: PreDirectRoomMemberInterface<U>[]

--- a/packages/tds-widget/src/chat/types/room.ts
+++ b/packages/tds-widget/src/chat/types/room.ts
@@ -94,6 +94,9 @@ interface PreDirectRoomInterface<T = RoomType, U = UserType> {
   other?: PreDirectRoomMemberInterface<U>
 }
 
+/**
+ * 초대 링크로 진입한 생성되지 않은 RoomInterface
+ */
 export interface InvitationRoomInterface<
   T = RoomType,
   V = ChatRoomMetadata<T>,
@@ -155,6 +158,10 @@ export type ChatRoomInterface<
   | InvitationRoomInterface<T, V>
   | PreDirectRoomInterface<T, U>
 
+/**
+ * @deprecated
+ * 기존 트리플 파트너챗에서 /direct로 진입하는 생성되지 않은 채팅방인지 확인합니다.
+ */
 export function isPreDirectRoom<
   T = RoomType,
   U = UserType,
@@ -163,6 +170,9 @@ export function isPreDirectRoom<
   return !!(room as { preDirectRoom?: boolean }).preDirectRoom
 }
 
+/**
+ * 생성된 채팅방인지 확인합니다.
+ */
 export function isCreatedChatRoom<
   T = RoomType,
   U = UserType,

--- a/packages/tds-widget/src/chat/types/unread.ts
+++ b/packages/tds-widget/src/chat/types/unread.ts
@@ -11,6 +11,10 @@ export interface HasUnreadOfRoomInterface extends HasUnreadInterface {
 }
 
 export interface OtherUnreadInterface {
+  /**
+   * @deprecated
+   */
+  memberId: string
   roomMemberId: string
   lastSeenMessageId: number
 }

--- a/packages/tds-widget/src/chat/types/unread.ts
+++ b/packages/tds-widget/src/chat/types/unread.ts
@@ -11,7 +11,7 @@ export interface HasUnreadOfRoomInterface extends HasUnreadInterface {
 }
 
 export interface OtherUnreadInterface {
-  memberId: string
+  roomMemberId: string
   lastSeenMessageId: number
 }
 

--- a/packages/tds-widget/src/chat/types/user.ts
+++ b/packages/tds-widget/src/chat/types/user.ts
@@ -68,6 +68,9 @@ export interface ChatUserInterface<T = UserType> {
  */
 export interface ChatRoomMemberInterface<T = UserType>
   extends Omit<ChatUserInterface<T>, 'id' | 'channel'> {
+  /**
+   * 룸이 생성되기 전에는 임시 아이디이기 때문에 룸이 생성되면 변경될 수 있습니다.
+   */
   roomMemberId: string
 }
 

--- a/packages/tds-widget/src/chat/types/user.ts
+++ b/packages/tds-widget/src/chat/types/user.ts
@@ -24,20 +24,61 @@ interface ProfileInterface {
 }
 
 /**
- * triple-chat/nol-chat 서버 응답으로 받는 UserInterface
+ * @deprecated
+ * triple-chat 서버 응답으로 받는 UserInterface
+ */
+export interface TripleChatUserInterface<T = UserType>
+  extends ChatUserInterface<T> {
+  /**
+   * @deprecated
+   */
+  identifier: string
+  /**
+   * @deprecated
+   */
+  code: string
+}
+
+/**
+ * @deprecated
+ * triple-chat 서버 응답으로 받는 RoomMemberInterface
+ */
+export interface TripleChatRoomMemberInterface<T = UserType>
+  extends TripleChatUserInterface<T> {
+  roomMemberId: string
+}
+
+export type ChatRoomUser<T = UserType> =
+  | ChatUserInterface<T>
+  | ChatRoomMemberInterface<T>
+
+/**
+ * nol-chat 서버 응답으로 받는 UserInterface
  */
 export interface ChatUserInterface<T = UserType> {
   id: string
   createdAt: string
   type: T
-  identifier: string
-  code: string
   profile: ChatUserProfileInterface
   channel: ChatChannelInfo
+}
+
+/**
+ * nol-chat 서버 응답으로 받는 RoomMemberInterface
+ */
+export interface ChatRoomMemberInterface<T = UserType>
+  extends Omit<ChatUserInterface<T>, 'id' | 'channel'> {
+  roomMemberId: string
 }
 
 interface ChatUserProfileInterface {
   name: string
   thumbnail: string
   message: string
+}
+
+export function isChatRoomMember<T = UserType>(
+  member: ChatRoomMemberInterface<T> | ChatUserInterface<T>,
+): member is ChatRoomMemberInterface<T> {
+  return 'roomMemberId' in member
 }

--- a/packages/tds-widget/src/chat/types/user.ts
+++ b/packages/tds-widget/src/chat/types/user.ts
@@ -71,6 +71,10 @@ export interface ChatRoomMemberInterface<T = UserType>
   roomMemberId: string
 }
 
+/**
+ * @deprecated
+ * 기존 트리플 파트너챗에서 /direct로 진입하는 생성되지 않은 채팅방의 RoomMemberInterface
+ */
 export interface PreDirectRoomMemberInterface<T = UserType>
   extends Pick<ChatUserInterface<T>, 'id' | 'type' | 'profile'> {
   /**

--- a/packages/tds-widget/src/chat/types/user.ts
+++ b/packages/tds-widget/src/chat/types/user.ts
@@ -67,7 +67,7 @@ export interface ChatUserInterface<T = UserType> {
  * nol-chat 서버 응답으로 받는 RoomMemberInterface
  */
 export interface ChatRoomMemberInterface<T = UserType>
-  extends Omit<ChatUserInterface<T>, 'id' | 'channel'> {
+  extends Omit<ChatUserInterface<T>, 'id' | 'channel' | 'createdAt'> {
   roomMemberId: string
 }
 

--- a/packages/tds-widget/src/chat/types/user.ts
+++ b/packages/tds-widget/src/chat/types/user.ts
@@ -68,8 +68,13 @@ export interface ChatUserInterface<T = UserType> {
  */
 export interface ChatRoomMemberInterface<T = UserType>
   extends Omit<ChatUserInterface<T>, 'id' | 'channel'> {
+  roomMemberId: string
+}
+
+export interface PreDirectRoomMemberInterface<T = UserType>
+  extends Pick<ChatUserInterface<T>, 'id' | 'type' | 'profile'> {
   /**
-   * 룸이 생성되기 전에는 임시 아이디이기 때문에 룸이 생성되면 변경될 수 있습니다.
+   * 룸이 생성되기 전의 임시 아이디이기 때문에 룸이 생성되면 변경됩니다
    */
   roomMemberId: string
 }

--- a/packages/tds-widget/src/chat/utils/image.ts
+++ b/packages/tds-widget/src/chat/utils/image.ts
@@ -3,8 +3,9 @@ import {
   UserType,
   ChatMessageInterface,
   ChatRoomUser,
-  isChatRoomMember,
 } from '../types'
+
+import { getUserIdentifier } from './user'
 
 export function getProfileImageUrl<T = UserType>(
   user: ChatMessageInterface<T>['sender'] | ChatRoomUser<T>,
@@ -14,11 +15,7 @@ export function getProfileImageUrl<T = UserType>(
   } else {
     let imageNumber = 0
     try {
-      imageNumber =
-        parseInt(
-          (isChatRoomMember(user) ? user.roomMemberId : user.id).substr(0, 4),
-          16,
-        ) % 5
+      imageNumber = parseInt(getUserIdentifier(user).substr(0, 4), 16) % 5
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
       return `https://assets.triple.guide/images/ico-random-profile-${imageNumber}@3x.png`

--- a/packages/tds-widget/src/chat/utils/image.ts
+++ b/packages/tds-widget/src/chat/utils/image.ts
@@ -2,18 +2,23 @@ import {
   MetaDataInterface,
   UserType,
   ChatMessageInterface,
-  ChatUserInterface,
+  ChatRoomUser,
+  isChatRoomMember,
 } from '../types'
 
 export function getProfileImageUrl<T = UserType>(
-  user: ChatMessageInterface<T>['sender'] | ChatUserInterface<T>,
+  user: ChatMessageInterface<T>['sender'] | ChatRoomUser<T>,
 ) {
   if (user.profile.thumbnail) {
     return user.profile.thumbnail
   } else {
     let imageNumber = 0
     try {
-      imageNumber = parseInt(user.id.substr(0, 4), 16) % 5
+      imageNumber =
+        parseInt(
+          (isChatRoomMember(user) ? user.roomMemberId : user.id).substr(0, 4),
+          16,
+        ) % 5
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
       return `https://assets.triple.guide/images/ico-random-profile-${imageNumber}@3x.png`

--- a/packages/tds-widget/src/chat/utils/index.ts
+++ b/packages/tds-widget/src/chat/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './image'
 export { default as useATagNavigator } from './a-tag-navigator'
+export * from './user'

--- a/packages/tds-widget/src/chat/utils/user.ts
+++ b/packages/tds-widget/src/chat/utils/user.ts
@@ -1,10 +1,12 @@
 import {
   ChatMessageInterface,
+  ChatRoomInterface,
   ChatRoomUser,
   isChatRoomMember,
   UserType,
 } from '../types'
 
+// TODO: nol-chat으로 마이그레이션 후 제거
 export function getUserIdentifier<T = UserType>(
   user: ChatMessageInterface<T>['sender'] | ChatRoomUser<T>,
 ) {
@@ -16,4 +18,13 @@ export function getUserIdentifier<T = UserType>(
   }
 
   return isChatRoomMember(user) ? user.roomMemberId : user.id
+}
+
+// TODO: nol-chat으로 마이그레이션 후 제거
+export function shouldUseLegacyMemberId(room: ChatRoomInterface) {
+  return (
+    'members' in room &&
+    'identifier' in room.members[0] &&
+    'id' in room.members[0]
+  )
 }

--- a/packages/tds-widget/src/chat/utils/user.ts
+++ b/packages/tds-widget/src/chat/utils/user.ts
@@ -1,0 +1,19 @@
+import {
+  ChatMessageInterface,
+  ChatRoomUser,
+  isChatRoomMember,
+  UserType,
+} from '../types'
+
+export function getUserIdentifier<T = UserType>(
+  user: ChatMessageInterface<T>['sender'] | ChatRoomUser<T>,
+) {
+  /**
+   * triple-chat을 사용한다면 id를 우선적으로 사용하고, 그렇지 않다면 roomMemberId를 사용합니다.
+   */
+  if ('identifier' in user && 'id' in user) {
+    return user.id
+  }
+
+  return isChatRoomMember(user) ? user.roomMemberId : user.id
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

- id로 사용자를 특정할 수 없도록 하기 위하여 채팅 룸, 메시지의 member 정보에서 id, identifier, code 등을 제거합니다.
- 기존 룸 내부에서 메시지의 sender와 유저(나)를 구분자로 member.id를 사용하던 부분을 `roomMemberId` 필드를 사용합니다.
- nol-chat의 room 조회 reponse가 [변경됨](https://github.com/titicacadev/nol-chat/pull/138#issuecomment-2742979291)에 따라 해당 타입을 마이그레이션 합니다. 
  -  생성된 룸: [ChatRoomDetailInterface](https://github.com/titicacadev/triple-frontend/pull/3601/files#diff-e55122b1b80ad8814a2c708c4685afbf13ca82929e67e210563eacd9478485efR111)
  - direct/userType/userIdentifier로 진입 시 생성되지 않은 룸: [PreDirectRoomInterface](https://github.com/titicacadev/triple-frontend/pull/3601/files#diff-e55122b1b80ad8814a2c708c4685afbf13ca82929e67e210563eacd9478485efR89)
  - invitation으로 진입 시 생성되지 않은 룸: [InvitationRoomInterface](https://github.com/titicacadev/triple-frontend/pull/3601/files#diff-e55122b1b80ad8814a2c708c4685afbf13ca82929e67e210563eacd9478485efR100)

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
