### PR TITLE
[public-header] provider 타입 추가에 따른 프로필 변경

### DIFF
--- a/packages/public-header/src/side-menu/profile.tsx
+++ b/packages/public-header/src/side-menu/profile.tsx
@@ -66,6 +66,10 @@ const PROVIDER_INFO = {
     label: '네이버',
     icon: 'https://assets.triple.guide/images/header/icon_naver@4x.png',
   },
+  INVALID: {
+    label: '',
+    icon: undefined,
+  },
 }
 
 const PROFILE_EVENT_METADATA_LABEL = {
@@ -80,11 +84,15 @@ export function Profile() {
   const { trackEvent } = useEventTrackingContext()
 
   const returnUrl = encodeURIComponent(location.href)
-  const providerIconSrc = user ? PROVIDER_INFO[user.provider].icon : undefined
   const badgeUrl = user ? user.mileage?.badges[0]?.icon.image_url : undefined
-  const providerVisible = user && !user.nolConnected
+
+  const { provider, email, nolConnected } = user || {}
+  const { icon: providerIconSrc, label: providerLabel } =
+    PROVIDER_INFO[provider || 'INVALID'] || {}
+
+  const providerVisible = user && !nolConnected
   const profileLabel = providerVisible
-    ? user.email || PROVIDER_INFO[user.provider].label
+    ? email || providerLabel
     : NOL_CONNECTED_LABEL
 
   const onProfileClick = (

--- a/packages/public-header/src/side-menu/profile.tsx
+++ b/packages/public-header/src/side-menu/profile.tsx
@@ -81,19 +81,38 @@ const NOL_CONNECTED_LABEL = 'NOL 멤버스 계정'
 
 export function Profile() {
   const user = useUser()
+  const returnUrl = encodeURIComponent(location.href)
   const { trackEvent } = useEventTrackingContext()
 
-  const returnUrl = encodeURIComponent(location.href)
-  const badgeUrl = user ? user.mileage?.badges[0]?.icon.image_url : undefined
+  const onLoginClick = () => {
+    trackEvent({ fa: { category: '메인메뉴', action: '로그인_선택' } })
+  }
 
-  const { provider, email, nolConnected } = user || {}
+  if (!user) {
+    return (
+      <FlexBox flex css={{ padding: '20px 20px 30px', alignItems: 'center' }}>
+        <Link href={`/login?returnUrl=${returnUrl}`} onClick={onLoginClick}>
+          로그인
+        </Link>
+        <Text size={24} bold css={{ marginTop: -3 }}>
+          /
+        </Text>
+        <Link href={`/login?returnUrl=${returnUrl}`} onClick={onLoginClick}>
+          회원가입
+        </Link>
+      </FlexBox>
+    )
+  }
+
+  const { provider, email, nolConnected, mileage } = user
+
   const { icon: providerIconSrc, label: providerLabel } =
-    PROVIDER_INFO[provider || 'INVALID'] || {}
+    PROVIDER_INFO[provider] || {}
+  const profileLabel = nolConnected
+    ? NOL_CONNECTED_LABEL
+    : email || providerLabel
 
-  const providerVisible = user && !nolConnected
-  const profileLabel = providerVisible
-    ? email || providerLabel
-    : NOL_CONNECTED_LABEL
+  const badgeUrl = mileage?.badges[0]?.icon.image_url
 
   const onProfileClick = (
     referrer: keyof typeof PROFILE_EVENT_METADATA_LABEL,
@@ -107,11 +126,7 @@ export function Profile() {
     })
   }
 
-  const onLoginClick = () => {
-    trackEvent({ fa: { category: '메인메뉴', action: '로그인_선택' } })
-  }
-
-  return user ? (
+  return (
     <FlexBox
       flex
       css={{ padding: 20, justifyContent: 'space-between', gap: 16 }}
@@ -119,7 +134,7 @@ export function Profile() {
       <Container>
         <UserName onClick={() => onProfileClick('name')}>{user.name}</UserName>
         <UserEmailOrProvider>
-          {providerIconSrc && providerVisible ? (
+          {!nolConnected && providerIconSrc ? (
             <SocialIcon src={providerIconSrc} alt="social login icon" />
           ) : null}
           {profileLabel}
@@ -133,18 +148,6 @@ export function Profile() {
         <ProfileImage src={user.photo} alt="profile" />
         {badgeUrl ? <Badge src={badgeUrl} alt="badge" /> : null}
       </Container>
-    </FlexBox>
-  ) : (
-    <FlexBox flex css={{ padding: '20px 20px 30px', alignItems: 'center' }}>
-      <Link href={`/login?returnUrl=${returnUrl}`} onClick={onLoginClick}>
-        로그인
-      </Link>
-      <Text size={24} bold css={{ marginTop: -3 }}>
-        /
-      </Text>
-      <Link href={`/login?returnUrl=${returnUrl}`} onClick={onLoginClick}>
-        회원가입
-      </Link>
     </FlexBox>
   )
 }

--- a/packages/react-contexts/src/session-context/index.tsx
+++ b/packages/react-contexts/src/session-context/index.tsx
@@ -1,5 +1,5 @@
 export { default as SessionContextProvider } from './provider'
 export { useSessionAvailability, useSessionControllers } from './hooks'
-export { useUser, User } from './user'
+export { useUser, User, AuthProvider } from './user'
 export { default as getSessionAvailabilityFromRequest } from './session-availability'
 export { putInvalidSessionIdRemover } from './invalid-session-id-remover'

--- a/packages/react-contexts/src/session-context/user.ts
+++ b/packages/react-contexts/src/session-context/user.ts
@@ -2,7 +2,7 @@ import { createContext, useCallback, useContext, useState } from 'react'
 
 export interface User {
   name: string
-  provider: Provider
+  provider: AuthProvider
   country: string
   lang: string
   unregister: boolean | null
@@ -14,7 +14,13 @@ export interface User {
   nolConnectedAt?: string
 }
 
-type Provider = 'TRIPLE' | 'NAVER' | 'KAKAO' | 'FACEBOOK' | 'APPLE'
+export type AuthProvider =
+  | 'TRIPLE'
+  | 'NAVER'
+  | 'KAKAO'
+  | 'FACEBOOK'
+  | 'APPLE'
+  | 'INVALID'
 
 interface Mileage {
   badges: {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[public-header] provider 타입 추가에 따른 프로필 변경
- NOL 회원 통합으로 provider에 'INVALID' 타입이 추가되었습니다. 이에 따라 NOL 연동 회원의 경우 기존에 선언되었던 아이콘과 라벨을 찾지 못해 아이코가 뜨는 문제가 있습니다. 
- UI에서는 INVALID 타입을 사용하지 않으며, nolConnected 여부로 UI를 판단하도록 수정했습니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
