### PR TITLE
[react-contexts] setWebDeviceId 미들웨어에 domain을 추가합니다.

### DIFF
--- a/packages/react-contexts/src/middlewares/set-web-device-id.ts
+++ b/packages/react-contexts/src/middlewares/set-web-device-id.ts
@@ -6,6 +6,7 @@ import {
 } from 'next/server'
 import { v4 as uuidV4 } from 'uuid'
 import { X_TRIPLE_WEB_DEVICE_ID } from '@titicaca/constants'
+import { parseUrl } from '@titicaca/view-utilities'
 
 import { getTripleApp } from './utils/get-triple-app'
 import { applySetCookie } from './utils/apply-set-cookie'
@@ -31,10 +32,19 @@ export function setWebDeviceIdMiddleware(next: NextMiddleware) {
       const randomWebDeviceId = uuidV4()
       response.cookies.set(X_TRIPLE_WEB_DEVICE_ID, randomWebDeviceId, {
         secure: true,
+        domain: getDomain(request),
       })
       applySetCookie(request, response)
     }
 
     return response
   }
+}
+
+function getDomain(request: NextRequest) {
+  const hostFromRequest = request.headers.get('host')
+  const isLocalhost = hostFromRequest?.split(':')[0] === 'localhost'
+  const { host } = parseUrl(process.env.NEXT_PUBLIC_WEB_URL_BASE)
+
+  return isLocalhost ? 'localhost' : `.${host}`
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[react-contexts] setWebDeviceId 미들웨어에 domain을 추가합니다.
- 도메인이 없으면 API 호출시 x-triple-web-device-id가 중복되어 보내지는 이슈가 있습니다. 도메인을 설정하여 쿠키가 중복되지 않도록 합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
