### PR TITLE
[footer] 푸터에 버튼, 링크, 드롭다운을 원격으로 설정할 수 있도록 수정합니다.

### DIFF
--- a/packages/core-elements/src/elements/accordion/accordion-content.tsx
+++ b/packages/core-elements/src/elements/accordion/accordion-content.tsx
@@ -17,13 +17,7 @@ export const AccordionContent = ({
   }
 
   return (
-    <Container
-      id={contentId}
-      css={{
-        margin: '5px 0 0',
-      }}
-      {...props}
-    >
+    <Container id={contentId} {...props}>
       {children}
     </Container>
   )

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -80,6 +80,7 @@ export function AwardFooter({
           hideAppDownloadButton={hideAppDownloadButton}
           businessExpanded={businessExpanded}
           setBusinessExpanded={setBusinessExpanded}
+          buttons={footerInfo.buttons}
         />
 
         <Text

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -93,7 +93,7 @@ export function AwardFooter({
           size={11}
           lineHeight="17px"
           color="gray500"
-          margin={{ top: businessExpanded ? 15 : 18, bottom: 5 }}
+          margin={{ top: businessExpanded ? 15 : 20, bottom: 5 }}
           css={{ maxWidth: 280, wordBreak: 'break-word' }}
         >
           {footerInfo.disclaimer}

--- a/packages/footer/src/award-footer.tsx
+++ b/packages/footer/src/award-footer.tsx
@@ -11,6 +11,7 @@ import { CompanyInfo } from './company-info'
 import { ExtraLinkGroup } from './extra-link-group'
 import { useFooterInfo } from './use-footer-info'
 import { FooterAward } from './type'
+import { AWARD_FOOTER_MIN_HEIGHT } from './constants'
 
 const InfoFlexBox = styled(FlexBox).attrs({
   flex: true,
@@ -62,7 +63,12 @@ export function AwardFooter({
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
   if (!footerInfo) {
-    return null
+    return (
+      <FooterFrame
+        {...props}
+        css={{ minHeight: AWARD_FOOTER_MIN_HEIGHT, width: '100%' }}
+      />
+    )
   }
 
   return (

--- a/packages/footer/src/button-area/button.tsx
+++ b/packages/footer/src/button-area/button.tsx
@@ -34,7 +34,7 @@ export const buttonCss = css`
   align-items: center;
   gap: 2px;
   height: 32px;
-  padding: 9px 12px;
+  padding: 9px 10px;
   font-size: 11px;
   font-weight: bold;
   line-height: 13px;

--- a/packages/footer/src/button-area/button.tsx
+++ b/packages/footer/src/button-area/button.tsx
@@ -44,12 +44,6 @@ export const buttonCss = css`
   border-radius: 4px;
   background-color: rgba(250, 250, 250, 1);
 
-  @media (max-width: ${MAX_PHONE_WIDTH}px) {
-    display: flex;
-    justify-content: space-between;
-    padding: 9px 16px;
-  }
-
   img {
     width: 16px;
   }

--- a/packages/footer/src/button-area/button.tsx
+++ b/packages/footer/src/button-area/button.tsx
@@ -1,0 +1,104 @@
+import { ReactNode } from 'react'
+import styled, { css } from 'styled-components'
+import { FlexBox } from '@titicaca/core-elements'
+import {
+  useEventTrackingContext,
+  useSessionAvailability,
+  useSessionControllers,
+} from '@titicaca/react-contexts'
+
+import { MAX_PHONE_WIDTH } from '../constants'
+import { FooterLinkButton } from '../type'
+
+export const ButtonContainer = styled(FlexBox)`
+  gap: 6px;
+
+  @media (max-width: ${MAX_PHONE_WIDTH}px) {
+    width: 100%;
+    margin-bottom: 20px;
+  }
+`
+
+export const buttonCss = css`
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+  height: 32px;
+  padding: 9px 12px;
+  font-size: 11px;
+  font-weight: bold;
+  line-height: 13px;
+  color: var(--color-gray600);
+  text-align: center;
+  border: 1px solid var(--color-gray200);
+  border-radius: 4px;
+  background-color: rgba(250, 250, 250, 1);
+
+  img {
+    width: 16px;
+  }
+`
+
+export const Button = styled.a`
+  ${buttonCss}
+`
+
+export const BUTTON_LIST: Record<string, ReactNode> = {
+  login: <LoginLogoutButton />,
+}
+
+function LoginLogoutButton() {
+  const sessionAvailable = useSessionAvailability()
+  const { login, logout } = useSessionControllers()
+  const { trackEvent } = useEventTrackingContext()
+
+  return (
+    <Button
+      as="button"
+      type="button"
+      onClick={() => {
+        if (sessionAvailable) {
+          logout()
+          return
+        }
+
+        trackEvent({
+          ga: ['푸터_로그인'],
+          fa: {
+            action: '푸터_로그인',
+          },
+        })
+        login()
+      }}
+    >
+      {sessionAvailable === true ? '로그아웃' : '로그인'}
+    </Button>
+  )
+}
+
+export function LinkButton({
+  href,
+  faEventAction,
+  label,
+  iconSrc,
+}: FooterLinkButton) {
+  const { trackEvent } = useEventTrackingContext()
+
+  return (
+    <Button
+      href={href}
+      onClick={() => {
+        trackEvent({
+          ga: [faEventAction],
+          fa: {
+            action: faEventAction,
+          },
+        })
+      }}
+    >
+      <span>{label}</span>
+      <img src={iconSrc} alt="link button arrow" />
+    </Button>
+  )
+}

--- a/packages/footer/src/button-area/button.tsx
+++ b/packages/footer/src/button-area/button.tsx
@@ -19,11 +19,20 @@ export const ButtonContainer = styled(FlexBox)`
   }
 `
 
+export const buttonFlexItemCss = css`
+  flex-shrink: 0;
+
+  @media (max-width: ${MAX_PHONE_WIDTH}px) {
+    width: 50%;
+  }
+`
+
 export const buttonCss = css`
+  ${buttonFlexItemCss}
   display: flex;
+  justify-content: center;
   align-items: center;
   gap: 2px;
-  flex-shrink: 0;
   height: 32px;
   padding: 9px 12px;
   font-size: 11px;
@@ -34,6 +43,12 @@ export const buttonCss = css`
   border: 1px solid var(--color-gray200);
   border-radius: 4px;
   background-color: rgba(250, 250, 250, 1);
+
+  @media (max-width: ${MAX_PHONE_WIDTH}px) {
+    display: flex;
+    justify-content: space-between;
+    padding: 9px 16px;
+  }
 
   img {
     width: 16px;

--- a/packages/footer/src/button-area/dropdown.tsx
+++ b/packages/footer/src/button-area/dropdown.tsx
@@ -31,7 +31,7 @@ const DropdownOptions = styled.ul`
   font-size: 12px;
   font-weight: 700;
   background: var(--color-white);
-  filter: drop-shadow(0 0 12px rgba(0, 0, 0, 0.1));
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.1);
 
   a {
     display: block;

--- a/packages/footer/src/button-area/dropdown.tsx
+++ b/packages/footer/src/button-area/dropdown.tsx
@@ -22,7 +22,7 @@ const DropdownOptions = styled.ul`
   font-size: 12px;
   font-weight: 700;
   background: var(--color-white);
-  filter: drop-shadow(0px 0px 12px rgba(0, 0, 0, 0.1));
+  filter: drop-shadow(0 0 12px rgba(0, 0, 0, 0.1));
 
   a {
     display: block;

--- a/packages/footer/src/button-area/dropdown.tsx
+++ b/packages/footer/src/button-area/dropdown.tsx
@@ -4,9 +4,18 @@ import styled from 'styled-components'
 
 import { FooterDropdownButton } from '../type'
 
-import { buttonCss } from './button'
+import { buttonCss, buttonFlexItemCss } from './button'
 
 const DROPDOWN_INITIAL_HEIGHT = 174
+
+const DropdownContainer = styled.div`
+  position: relative;
+  ${buttonFlexItemCss}
+
+  > button {
+    width: 100%;
+  }
+`
 
 const DropdownOptions = styled.ul`
   position: absolute;
@@ -71,7 +80,7 @@ export function Dropdown({
 
   const { trackEvent } = useEventTrackingContext()
   return (
-    <div css={{ position: 'relative', flexShrink: 0 }}>
+    <DropdownContainer>
       <button
         ref={buttonRef}
         css={buttonCss}
@@ -112,6 +121,6 @@ export function Dropdown({
           ))}
         </DropdownOptions>
       ) : null}
-    </div>
+    </DropdownContainer>
   )
 }

--- a/packages/footer/src/button-area/dropdown.tsx
+++ b/packages/footer/src/button-area/dropdown.tsx
@@ -60,7 +60,7 @@ export function Dropdown({
       const isButtonClicked =
         buttonRef.current && buttonRef.current.contains(event.target as Node)
 
-      if (isOptionsClicked && isButtonClicked) {
+      if (!isOptionsClicked && !isButtonClicked) {
         setDropdownOptionsVisible(false)
       }
     }

--- a/packages/footer/src/button-area/dropdown.tsx
+++ b/packages/footer/src/button-area/dropdown.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from 'react'
+import { useEventTrackingContext } from '@titicaca/react-contexts'
+import styled from 'styled-components'
+
+import { FooterDropdownButton } from '../type'
+
+import { buttonCss } from './button'
+
+const DROPDOWN_INITIAL_HEIGHT = 174
+
+const DropdownOptions = styled.ul`
+  position: absolute;
+  top: 32px;
+  right: 0;
+  list-style: none;
+  padding: 12px 0;
+  min-width: 135px;
+  z-index: 999;
+  border-radius: 8px;
+  border: 1px solid var(--color-gray200);
+  color: var(--color-gray);
+  font-size: 12px;
+  font-weight: 700;
+  background: var(--color-white);
+  filter: drop-shadow(0px 0px 12px rgba(0, 0, 0, 0.1));
+
+  a {
+    display: block;
+    padding: 8px 20px;
+  }
+`
+
+export function Dropdown({
+  label,
+  options,
+  faEventAction,
+}: FooterDropdownButton) {
+  const [dropdownOptionsVisible, setDropdownOptionsVisible] =
+    useState<boolean>(false)
+  const [dropdownOptionsHeight, setDropdownOptionsHeight] = useState<number>(
+    DROPDOWN_INITIAL_HEIGHT,
+  )
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const optionsRef = useRef<HTMLUListElement>(null)
+  const optionsHeightSettingFlag = useRef<boolean>(false)
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const isOptionsClicked =
+        optionsRef.current && optionsRef.current.contains(event.target as Node)
+      const isButtonClicked =
+        buttonRef.current && buttonRef.current.contains(event.target as Node)
+
+      if (isOptionsClicked && isButtonClicked) {
+        setDropdownOptionsVisible(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (optionsRef.current && !optionsHeightSettingFlag.current) {
+      setDropdownOptionsHeight(optionsRef.current.clientHeight)
+      optionsHeightSettingFlag.current = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dropdownOptionsVisible])
+
+  const { trackEvent } = useEventTrackingContext()
+  return (
+    <div css={{ position: 'relative', flexShrink: 0 }}>
+      <button
+        ref={buttonRef}
+        css={buttonCss}
+        onClick={(e) => {
+          e.stopPropagation()
+          setDropdownOptionsVisible((prev) => !prev)
+          faEventAction && trackEvent({ fa: { action: faEventAction } })
+        }}
+      >
+        <span>{label}</span>
+        <img
+          src="https://assets.triple.guide/images/ico_arrow_more@3x.png"
+          alt="dropdown arrow"
+          css={{ transform: 'rotate(270deg)' }}
+        />
+      </button>
+
+      {dropdownOptionsVisible ? (
+        <DropdownOptions
+          ref={optionsRef}
+          css={{ top: (dropdownOptionsHeight + 6) * -1 }}
+        >
+          {options.map(({ label, url, faEventAction }) => (
+            <li key={label} value={label}>
+              <a
+                href={url}
+                target="_blank"
+                rel="noreferrer"
+                onClick={() =>
+                  faEventAction
+                    ? trackEvent({ fa: { action: faEventAction } })
+                    : undefined
+                }
+              >
+                {label}
+              </a>
+            </li>
+          ))}
+        </DropdownOptions>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/footer/src/button-area/index.tsx
+++ b/packages/footer/src/button-area/index.tsx
@@ -1,0 +1,25 @@
+import { FooterButton } from '../type'
+
+import { BUTTON_LIST, ButtonContainer, LinkButton } from './button'
+import { Dropdown } from './dropdown'
+
+export function ButtonArea({ buttons }: { buttons: FooterButton[] }) {
+  return (
+    <ButtonContainer flex>
+      {buttons
+        .filter(({ hidden }) => !hidden)
+        .map((button) => {
+          switch (button.type) {
+            case 'button':
+              return BUTTON_LIST[button.key] || null
+            case 'link':
+              return <LinkButton {...button} />
+            case 'dropdown':
+              return <Dropdown {...button} />
+            default:
+              return null
+          }
+        })}
+    </ButtonContainer>
+  )
+}

--- a/packages/footer/src/company-info.tsx
+++ b/packages/footer/src/company-info.tsx
@@ -68,7 +68,7 @@ export function CompanyInfo({
     >
       <AccordionHeader flex alignItems="center" justifyContent="space-between">
         <Title>
-          트리플 사업자 정보
+          트리플 사업자정보
           <AccordionArrow
             src={`https://assets.triple.guide/images/${
               businessExpanded

--- a/packages/footer/src/company-info.tsx
+++ b/packages/footer/src/company-info.tsx
@@ -6,48 +6,17 @@ import {
   FlexBox,
   AccordionTitle,
 } from '@titicaca/core-elements'
-import {
-  useEventTrackingContext,
-  useSessionAvailability,
-  useSessionControllers,
-} from '@titicaca/react-contexts'
+import { useEventTrackingContext } from '@titicaca/react-contexts'
 import { Dispatch, Fragment, SetStateAction } from 'react'
 
-import { FooterText } from './type'
-
-const MAX_PHONE_WIDTH = 360
+import { FooterInfo, FooterText } from './type'
+import { MAX_PHONE_WIDTH } from './constants'
+import { ButtonArea } from './button-area'
 
 const AccordionHeader = styled(FlexBox)`
   @media (max-width: ${MAX_PHONE_WIDTH}px) {
     flex-direction: column-reverse;
     align-items: flex-start;
-  }
-`
-
-const Button = styled.a`
-  height: 32px;
-  padding: 9px 12px;
-  font-size: 11px;
-  font-weight: bold;
-  line-height: 13px;
-  color: var(--color-gray600);
-  text-align: center;
-  border: 1px solid var(--color-gray200);
-  border-radius: 4px;
-  background-color: rgba(250, 250, 250, 1);
-
-  &:first-child {
-    margin-right: 6px;
-  }
-
-  img {
-    width: 16px;
-    margin-left: 6px;
-    vertical-align: middle;
-  }
-
-  @media (max-width: ${MAX_PHONE_WIDTH}px) {
-    width: 100%;
   }
 `
 
@@ -70,19 +39,13 @@ const AccordionArrow = styled.img`
   height: 15px;
 `
 
-const ButtonContainer = styled(FlexBox)`
-  @media (max-width: ${MAX_PHONE_WIDTH}px) {
-    width: 100%;
-    margin-bottom: 20px;
-  }
-`
-
 const LinkContainer = styled.a`
   text-decoration: underline;
 `
 
 interface CompanyInfoProps {
   companyTexts: Array<FooterText[]>
+  buttons?: FooterInfo['buttons']
   hideAppDownloadButton?: boolean
   businessExpanded: boolean
   setBusinessExpanded: Dispatch<SetStateAction<boolean>>
@@ -90,14 +53,12 @@ interface CompanyInfoProps {
 
 export function CompanyInfo({
   companyTexts,
+  buttons,
   hideAppDownloadButton = false,
   businessExpanded,
   setBusinessExpanded,
 }: CompanyInfoProps) {
-  const sessionAvailable = useSessionAvailability()
-  const { login, logout } = useSessionControllers()
   const { trackEvent } = useEventTrackingContext()
-
   return (
     <Accordion
       active={businessExpanded}
@@ -117,47 +78,8 @@ export function CompanyInfo({
           />
         </Title>
 
-        {!hideAppDownloadButton ? (
-          <ButtonContainer flex>
-            <Button
-              as="button"
-              type="button"
-              onClick={() => {
-                if (sessionAvailable) {
-                  logout()
-                  return
-                }
-
-                trackEvent({
-                  ga: ['푸터_로그인'],
-                  fa: {
-                    action: '푸터_로그인',
-                  },
-                })
-                login()
-              }}
-            >
-              {sessionAvailable === true ? '로그아웃' : '로그인'}
-            </Button>
-
-            <Button
-              href="https://triple.onelink.me/aZP6?pid=intro_web&af_dp=triple%3A%2F%2F%2Fmain"
-              onClick={() => {
-                trackEvent({
-                  ga: ['푸터_트리플앱설치'],
-                  fa: {
-                    action: '푸터_트리플앱설치',
-                  },
-                })
-              }}
-            >
-              <span>트리플 앱</span>
-              <img
-                src="https://assets.triple.guide/images/ico_download@3x.png"
-                alt="app download"
-              />
-            </Button>
-          </ButtonContainer>
+        {!hideAppDownloadButton && !!buttons?.length ? (
+          <ButtonArea buttons={buttons} />
         ) : null}
       </AccordionHeader>
 

--- a/packages/footer/src/constants.ts
+++ b/packages/footer/src/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_PHONE_WIDTH = 360

--- a/packages/footer/src/constants.ts
+++ b/packages/footer/src/constants.ts
@@ -1,1 +1,3 @@
 export const MAX_PHONE_WIDTH = 360
+export const DEFAULT_FOOTER_MIN_HEIGHT = 184
+export const AWARD_FOOTER_MIN_HEIGHT = 210.5

--- a/packages/footer/src/constants.ts
+++ b/packages/footer/src/constants.ts
@@ -1,3 +1,3 @@
 export const MAX_PHONE_WIDTH = 360
-export const DEFAULT_FOOTER_MIN_HEIGHT = 184
-export const AWARD_FOOTER_MIN_HEIGHT = 210.5
+export const DEFAULT_FOOTER_MIN_HEIGHT = 179
+export const AWARD_FOOTER_MIN_HEIGHT = 205.5

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -6,6 +6,7 @@ import { LinkGroup } from './link-group'
 import { CompanyInfo } from './company-info'
 import { ExtraLinkGroup } from './extra-link-group'
 import { useFooterInfo } from './use-footer-info'
+import { DEFAULT_FOOTER_MIN_HEIGHT } from './constants'
 
 export const FooterFrame = styled.footer`
   background-color: rgba(250, 250, 250, 1);
@@ -25,7 +26,12 @@ function DefaultFooter({
   const [businessExpanded, setBusinessExpanded] = useState<boolean>(false)
 
   if (!footerInfo) {
-    return null
+    return (
+      <FooterFrame
+        {...props}
+        css={{ minHeight: DEFAULT_FOOTER_MIN_HEIGHT, width: '100%' }}
+      />
+    )
   }
 
   return (

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -55,7 +55,7 @@ function DefaultFooter({
           size={11}
           lineHeight="17px"
           color="gray500"
-          margin={{ top: businessExpanded ? 10 : 25, bottom: 20 }}
+          margin={{ top: businessExpanded ? 10 : 20, bottom: 20 }}
         >
           {footerInfo.disclaimer}
         </Text>

--- a/packages/footer/src/default-footer.tsx
+++ b/packages/footer/src/default-footer.tsx
@@ -43,6 +43,7 @@ function DefaultFooter({
           hideAppDownloadButton={hideAppDownloadButton}
           businessExpanded={businessExpanded}
           setBusinessExpanded={setBusinessExpanded}
+          buttons={footerInfo.buttons}
         />
         <Text
           size={11}

--- a/packages/footer/src/footer.json
+++ b/packages/footer/src/footer.json
@@ -44,26 +44,47 @@
       "imageUrl": "https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/1060b728-6ef3-477d-a64a-0a38f5c3250e.jpeg"
     }
   ],
-  "familySites": [
+  "buttons": [
     {
-      "label": "NOL 인터파크",
-      "url": "https://nol.interpark.com"
+      "type": "button",
+      "key": "login",
+      "faEventAction": "푸터_로그인",
+      "hidden": true
     },
     {
-      "label": "트리플",
-      "url": "https://triple.guide"
+      "type": "link",
+      "key": "app-download",
+      "label": "트리플 앱",
+      "href": "https://triple.onelink.me/aZP6?pid=intro_web&af_dp=triple%3A%2F%2F%2Fmain",
+      "faEventAction": "푸터_트리플앱설치",
+      "iconSrc": "https://assets.triple.guide/images/ico_download@3x.png"
     },
     {
-      "label": "인터파크 글로벌",
-      "url": "https://www.globalinterpark.com"
-    },
-    {
-      "label": "NOL 파트너센터",
-      "url": "https://partner.yanolja.com/intro"
-    },
-    {
-      "label": "NOL 광고센터",
-      "url": "https://nol.interpark.com"
+      "type": "dropdown",
+      "key": "family-site",
+      "label": "Family Site",
+      "options": [
+        {
+          "label": "NOL 인터파크",
+          "url": "https://nol.interpark.com"
+        },
+        {
+          "label": "트리플",
+          "url": "https://triple.guide"
+        },
+        {
+          "label": "인터파크 글로벌",
+          "url": "https://www.globalinterpark.com"
+        },
+        {
+          "label": "NOL 파트너센터",
+          "url": "https://partner.yanolja.com/intro"
+        },
+        {
+          "label": "NOL 광고센터",
+          "url": "https://nol.interpark.com"
+        }
+      ]
     }
   ]
 }

--- a/packages/footer/src/footer.json
+++ b/packages/footer/src/footer.json
@@ -19,11 +19,11 @@
     },
     {
       "label": "위치정보 이용약관",
-      "url": "/pages/privacy-policy.html"
+      "url": "/pages/tolbs.html"
     },
     {
       "label": "서비스 운영정책",
-      "url": "/pages/privacy-policy.html"
+      "url": "/pages/oppolicy.html"
     },
     {
       "label": "고객센터",

--- a/packages/footer/src/footer.json
+++ b/packages/footer/src/footer.json
@@ -43,5 +43,27 @@
       "alt": "국제표준 정보보호 인증마크 ISO27001, ISO 27701",
       "imageUrl": "https://media.triple.guide/triple-cms/c_limit,f_auto,h_2048,w_2048/1060b728-6ef3-477d-a64a-0a38f5c3250e.jpeg"
     }
+  ],
+  "familySites": [
+    {
+      "label": "NOL 인터파크",
+      "url": "https://nol.interpark.com"
+    },
+    {
+      "label": "트리플",
+      "url": "https://triple.guide"
+    },
+    {
+      "label": "인터파크 글로벌",
+      "url": "https://www.globalinterpark.com"
+    },
+    {
+      "label": "NOL 파트너센터",
+      "url": "https://partner.yanolja.com/intro"
+    },
+    {
+      "label": "NOL 광고센터",
+      "url": "https://nol.interpark.com"
+    }
   ]
 }

--- a/packages/footer/src/footer.stories.tsx
+++ b/packages/footer/src/footer.stories.tsx
@@ -41,3 +41,18 @@ export const NoButtons: StoryObj<typeof Footer> = {
     },
   },
 }
+
+export const SkeletonFooter: StoryObj<typeof Footer> = {
+  parameters: {
+    msw: {
+      handlers: [
+        rest.get(
+          'https://assets.triple-dev.titicaca-corp.com/footer/footer.json',
+          async (req, res, ctx) => {
+            return res(ctx.json(null))
+          },
+        ),
+      ],
+    },
+  },
+}

--- a/packages/footer/src/type.ts
+++ b/packages/footer/src/type.ts
@@ -4,6 +4,7 @@ export interface FooterInfo {
   links: FooterLink[]
   extraLinks: FooterLink[]
   awards: FooterAward[]
+  familySites?: FooterLink[]
 }
 
 export interface FooterText {

--- a/packages/footer/src/type.ts
+++ b/packages/footer/src/type.ts
@@ -4,7 +4,7 @@ export interface FooterInfo {
   links: FooterLink[]
   extraLinks: FooterLink[]
   awards: FooterAward[]
-  familySites?: FooterLink[]
+  buttons?: FooterButton[]
 }
 
 export interface FooterText {
@@ -24,3 +24,36 @@ export interface FooterAward {
   alt: string
   imageUrl: string
 }
+
+export interface FooterButtonBase {
+  /**
+   * 고유 key값
+   * type이 button인 경우 선언된 버튼 컴포넌트를 참조하는데 사용됩니다.
+   */
+  key: string
+  faEventAction?: string
+  hidden?: boolean
+}
+
+export interface FooterDefaultButton extends FooterButtonBase {
+  type: 'button'
+  key: string
+}
+
+export interface FooterLinkButton extends FooterButtonBase {
+  type: 'link'
+  label: string
+  href: string
+  iconSrc?: string
+}
+
+export interface FooterDropdownButton extends FooterButtonBase {
+  type: 'dropdown'
+  label: string
+  options: FooterLink[]
+}
+
+export type FooterButton =
+  | FooterDefaultButton
+  | FooterLinkButton
+  | FooterDropdownButton

--- a/packages/footer/src/type.ts
+++ b/packages/footer/src/type.ts
@@ -37,7 +37,6 @@ export interface FooterButtonBase {
 
 export interface FooterDefaultButton extends FooterButtonBase {
   type: 'button'
-  key: string
 }
 
 export interface FooterLinkButton extends FooterButtonBase {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- 푸터에 패밀리 사이트 드롭다운이 필요해지면서, 푸터의 버튼, 링크, 드롭다운을 triple-web-assets의 footer.json에서 받아올 수 있도록 합니다. ([피그마 링크](https://www.figma.com/design/MyEtr4Y2RUToFU86k3Gu4e/%EC%9B%B9-footer-%EA%B0%9C%EC%84%A0?node-id=702-138&p=f&t=btC21vPpf1dJW8j4-0))
- 드롭다운 기능을 추가합니다.
- 푸터의 정보를 받아오는 동안 스켈레톤을 구현합니다.
<img width="902" alt="스크린샷 2025-03-26 오전 8 53 14" src="https://github.com/user-attachments/assets/621d148c-1fd9-4dbc-bd83-ed1689cb314e" />

