### PR TITLE
[triple-web-nextjs-pages] 앱/웹 구분 없이 authFetcherize를 추가합니다. 

### DIFF
--- a/packages/triple-web-nextjs-pages/src/initializers/session.ts
+++ b/packages/triple-web-nextjs-pages/src/initializers/session.ts
@@ -7,35 +7,22 @@ import {
   post,
   get,
 } from '@titicaca/fetcher'
-import {
-  GET_USER_REQUEST_URL,
-  checkClientApp,
-} from '@titicaca/triple-web-utils'
+import { GET_USER_REQUEST_URL } from '@titicaca/triple-web-utils'
 
 import { checkSession } from '../helpers/session'
 
 /**
- * - app (server-side): refresh X
- * - app (client-side): refresh X
- * - browser (server-side) refresh O
- * - browser (client-side) refresh O
  * @returns
  */
 export async function getSession(ctx: NextPageContext): Promise<SessionValue> {
-  const userAgent = ctx.req
-    ? (ctx.req.headers['user-agent'] ?? '')
-    : window.navigator.userAgent
-
-  const isClientApp = checkClientApp(userAgent)
-
-  const user = await fetchUser(ctx, isClientApp)
+  const user = await fetchUser(ctx)
 
   return {
     user,
   }
 }
 
-async function fetchUser(ctx: NextPageContext, isClientApp: boolean) {
+async function fetchUser(ctx: NextPageContext) {
   if (ctx.req) {
     // Server-side
 
@@ -52,80 +39,49 @@ async function fetchUser(ctx: NextPageContext, isClientApp: boolean) {
       cookie: ctx.req.headers.cookie,
     }
 
-    if (isClientApp) {
-      const finalFetcher = ssrFetcherize(get, ssrFetcherizeOptions)
+    const finalFetcher = authFetcherize(
+      ssrFetcherize(get, ssrFetcherizeOptions),
+      {
+        refresh: () =>
+          ssrFetcherize(
+            post,
+            ssrFetcherizeOptions,
+          )('/api/users/web-session/token'),
+      },
+    )
 
-      const response = await finalFetcher<SessionUser>(GET_USER_REQUEST_URL)
+    const response = await finalFetcher<SessionUser>(GET_USER_REQUEST_URL)
 
-      if (response.status !== 401) {
-        captureHttpError(response)
-      }
-
-      if (response.ok === false) {
-        return null
-      }
-
-      return response.parsedBody
-    } else {
-      const finalFetcher = authFetcherize(
-        ssrFetcherize(get, ssrFetcherizeOptions),
-        {
-          refresh: () =>
-            ssrFetcherize(
-              post,
-              ssrFetcherizeOptions,
-            )('/api/users/web-session/token'),
-        },
-      )
-
-      const response = await finalFetcher<SessionUser>(GET_USER_REQUEST_URL)
-
-      if (response === 'NEED_LOGIN') {
-        return null
-      }
-
-      captureHttpError(response)
-
-      if (response.ok === false) {
-        return null
-      }
-
-      return response.parsedBody
+    if (response === 'NEED_LOGIN') {
+      return null
     }
+
+    captureHttpError(response)
+
+    if (response.ok === false) {
+      return null
+    }
+
+    return response.parsedBody
   } else {
     // Client-side
-    if (isClientApp) {
-      const finalFetcher = get
 
-      const response = await finalFetcher<SessionUser>(GET_USER_REQUEST_URL)
+    const finalFetcher = authFetcherize(get, {
+      refresh: () => post('/api/users/web-session/token'),
+    })
 
-      if (response.status !== 401) {
-        captureHttpError(response)
-      }
+    const response = await finalFetcher<SessionUser>(GET_USER_REQUEST_URL)
 
-      if (response.ok === false) {
-        return null
-      }
-
-      return response.parsedBody
-    } else {
-      const finalFetcher = authFetcherize(get, {
-        refresh: () => post('/api/users/web-session/token'),
-      })
-
-      const response = await finalFetcher<SessionUser>(GET_USER_REQUEST_URL)
-
-      if (response === 'NEED_LOGIN') {
-        return null
-      }
-
-      captureHttpError(response)
-
-      if (response.ok === false) {
-        return null
-      }
-
-      return response.parsedBody
+    if (response === 'NEED_LOGIN') {
+      return null
     }
+
+    captureHttpError(response)
+
+    if (response.ok === false) {
+      return null
+    }
+
+    return response.parsedBody
   }
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
웹뷰/웹에 관계없이 TP_TK, TP_SE를 사용하는 인증 로직을 사용하는 것으로 변경되어 웹뷰/웹 구분 없이 로직을 통일합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
