### PR TITLE
[react-contexts] 미들웨어 세션 갱신 로직을 분리하고 로컬 호스트 예외 처리를 추가합니다. 

### DIFF
--- a/packages/react-contexts/src/middlewares/index.ts
+++ b/packages/react-contexts/src/middlewares/index.ts
@@ -1,12 +1,17 @@
 import { chain } from './chain'
 import type { MiddlewareFactory } from './types'
-import { refreshSessionMiddleware } from './refresh-session'
 import { setWebDeviceIdMiddleware } from './set-web-device-id'
+import { serverRefreshSessionMiddleware } from './session/server'
 
 export const constructMiddleware = (functions: MiddlewareFactory[]) =>
-  chain([...functions, refreshSessionMiddleware, setWebDeviceIdMiddleware])
+  chain([
+    ...functions,
+    serverRefreshSessionMiddleware,
+    setWebDeviceIdMiddleware,
+  ])
 
 export * from './types'
 export { chain } from './chain'
-export { refreshSessionMiddleware } from './refresh-session'
+export { serverRefreshSessionMiddleware } from './session/server'
 export { setWebDeviceIdMiddleware } from './set-web-device-id'
+export { applySetCookie } from './utils/apply-set-cookie'

--- a/packages/react-contexts/src/middlewares/session/refresh-session.ts
+++ b/packages/react-contexts/src/middlewares/session/refresh-session.ts
@@ -1,0 +1,47 @@
+import { post, RequestOptions } from '@titicaca/fetcher'
+import {
+  NextFetchEvent,
+  NextMiddleware,
+  NextRequest,
+  NextResponse,
+} from 'next/server'
+import { parseString, splitCookiesString } from 'set-cookie-parser'
+import { SESSION_KEY as X_SOTO_SESSION } from '@titicaca/constants'
+import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies'
+
+import { applySetCookie } from '../utils/apply-set-cookie'
+
+export async function getSessionRefreshResponse({
+  next,
+  request,
+  event,
+  options,
+}: {
+  next: NextMiddleware
+  request: NextRequest
+  event: NextFetchEvent
+  options?: RequestOptions
+}) {
+  /**
+   * /web-session/token은 TP-TK의 유효성을 확인해서 TP_TK, TP_SE, x-soto-session 응답합니다.
+   */
+  const refreshResponse = await post('/api/users/web-session/token', options)
+
+  if (refreshResponse.ok) {
+    const setCookie = refreshResponse.headers.get('set-cookie')
+
+    if (setCookie) {
+      const response = (await next(request, event)) as NextResponse
+      const setCookies = splitCookiesString(setCookie)
+      setCookies.forEach((cookie) => {
+        const { name, value, ...rest } = parseString(cookie)
+        if (name !== X_SOTO_SESSION) {
+          response.cookies.set(name, value, { ...(rest as ResponseCookie) })
+        }
+      })
+      applySetCookie(request, response)
+
+      return response
+    }
+  }
+}

--- a/packages/react-contexts/src/middlewares/session/refresh-session.ts
+++ b/packages/react-contexts/src/middlewares/session/refresh-session.ts
@@ -10,6 +10,7 @@ import { SESSION_KEY as X_SOTO_SESSION } from '@titicaca/constants'
 import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies'
 
 import { applySetCookie } from '../utils/apply-set-cookie'
+import { getDomain } from '../utils/get-domain'
 
 export async function getSessionRefreshResponse({
   next,
@@ -28,9 +29,13 @@ export async function getSessionRefreshResponse({
   const refreshResponse = await post('/api/users/web-session/token', options)
 
   if (refreshResponse.ok) {
-    const setCookie = refreshResponse.headers.get('set-cookie')
+    const setCookieHeader = refreshResponse.headers.get('set-cookie')
 
-    if (setCookie) {
+    if (setCookieHeader) {
+      const setCookie = changeSetCookieDomainOnLocalhost(
+        request,
+        setCookieHeader,
+      )
       const response = (await next(request, event)) as NextResponse
       const setCookies = splitCookiesString(setCookie)
       setCookies.forEach((cookie) => {
@@ -44,4 +49,29 @@ export async function getSessionRefreshResponse({
       return response
     }
   }
+}
+
+function changeSetCookieDomainOnLocalhost(
+  request: NextRequest,
+  setCookie: string,
+) {
+  const domain = getDomain(request)
+  if (domain !== 'localhost') {
+    return setCookie
+  }
+  const setCookies = splitCookiesString(setCookie)
+  const domainChangedSetCookies = setCookies.map((cookie) => {
+    const { domain: cookieDomain, ...rest } = parseString(cookie)
+    return { domain, ...rest }
+  })
+
+  const updatedSetCookie = domainChangedSetCookies
+    .map((cookie) => {
+      const { name, value, ...rest } = cookie
+      return `${name}=${value}; ${Object.entries(rest)
+        .map(([key, val]) => `${key}=${val.toString()}`)
+        .join('; ')}`
+    })
+    .join(', ')
+  return updatedSetCookie
 }

--- a/packages/react-contexts/src/middlewares/set-web-device-id.ts
+++ b/packages/react-contexts/src/middlewares/set-web-device-id.ts
@@ -6,10 +6,10 @@ import {
 } from 'next/server'
 import { v4 as uuidV4 } from 'uuid'
 import { X_TRIPLE_WEB_DEVICE_ID } from '@titicaca/constants'
-import { parseUrl } from '@titicaca/view-utilities'
 
 import { getTripleApp } from './utils/get-triple-app'
 import { applySetCookie } from './utils/apply-set-cookie'
+import { getDomain } from './utils/get-domain'
 
 export function setWebDeviceIdMiddleware(next: NextMiddleware) {
   return async function middleware(
@@ -39,12 +39,4 @@ export function setWebDeviceIdMiddleware(next: NextMiddleware) {
 
     return response
   }
-}
-
-function getDomain(request: NextRequest) {
-  const hostFromRequest = request.headers.get('host')
-  const isLocalhost = hostFromRequest?.split(':')[0] === 'localhost'
-  const { host } = parseUrl(process.env.NEXT_PUBLIC_WEB_URL_BASE)
-
-  return isLocalhost ? 'localhost' : `.${host}`
 }

--- a/packages/react-contexts/src/middlewares/utils/get-domain.ts
+++ b/packages/react-contexts/src/middlewares/utils/get-domain.ts
@@ -1,0 +1,10 @@
+import { parseUrl } from '@titicaca/view-utilities'
+import { NextRequest } from 'next/server'
+
+export function getDomain(request: NextRequest) {
+  const hostFromRequest = request.headers.get('host')
+  const isLocalhost = hostFromRequest?.split(':')[0] === 'localhost'
+  const { host } = parseUrl(process.env.NEXT_PUBLIC_WEB_URL_BASE)
+
+  return isLocalhost ? 'localhost' : `.${host}`
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- 가독성을 위해 미들웨어 세션 갱신 파일을 분리했습니다. 
- `getDomain` 함수를 util로 이동했습니다.
  - `localhost`에서 실행할 때, 세션 관련 쿠키가 브라우저에 정상적으로 동작할 수 있도록 도메인을 `localhost`로 바꾸어주었습니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
