### PR TITLE
(Chat) nol-chat getMessages 응답값 migration

### DIFF
--- a/packages/tds-widget/src/chat/chat/chat-room-messages/chat-api-service.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/chat-api-service.ts
@@ -67,7 +67,10 @@ export class ChatApiService<T = UserType> {
     roomId: string
     backward?: boolean
     lastMessageId: number | string | null
-  }): Promise<ChatMessageInterface<T>[]> {
+  }): Promise<
+    | { messages: ChatMessageInterface<T>[]; hasNext: boolean }
+    | ChatMessageInterface<T>[] // legacy API
+  > {
     return this.fetcher(
       `/rooms/${roomId}/messages?${qs.stringify({ backward, lastMessageId })}`,
     )

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/chat-message-context.tsx
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/chat-message-context.tsx
@@ -24,6 +24,7 @@ import { ChatFetcher, ChatApiService } from './chat-api-service'
 
 export interface ChatMessagesProviderProps<T = UserType> {
   messages?: ChatMessageInterface<T>[]
+  hasPrevMessage?: boolean
   welcomeMessages?: WelcomeMessageInterface<T>[]
   fetcher: ChatFetcher
   /**
@@ -55,6 +56,7 @@ export const ChatMessagesContext =
 export function ChatMessagesProvider<T = UserType>({
   welcomeMessages = [],
   messages: initialMessages = [],
+  hasPrevMessage: initialPrevMessage,
   fetcher,
   useTripleChat = false,
   children,
@@ -82,6 +84,7 @@ export function ChatMessagesProvider<T = UserType>({
       })
     } else {
       let messages = initialMessages
+      let hasPrevMessage: boolean | undefined = initialPrevMessage
 
       if (!initMessages.length) {
         try {
@@ -90,7 +93,12 @@ export function ChatMessagesProvider<T = UserType>({
             backward: true,
             lastMessageId: Number(room.lastMessageId) + 1,
           })
-          messages = result
+          if ('messages' in result) {
+            messages = result.messages
+            hasPrevMessage = result.hasNext
+          } else {
+            messages = result
+          }
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (error) {}
       }
@@ -98,6 +106,7 @@ export function ChatMessagesProvider<T = UserType>({
       dispatch({
         action: MessagesActions.INIT,
         messages,
+        hasPrevMessage: hasPrevMessage ?? messages.length > 0,
       })
     }
   }

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
@@ -289,19 +289,29 @@ export function useChatMessages<T = UserType>({
     if (scrollable) {
       const prevScrollY = getScrollContainerHeight()
       let pastMessages: ChatMessageInterface<T>[] = []
+      let hasPrevMessage: boolean | undefined
 
       try {
-        pastMessages = await api.getMessages({
+        const result = await api.getMessages({
           roomId: room.id,
           lastMessageId: messages[0].id,
           backward: true,
         })
+
+        if ('messages' in result) {
+          pastMessages = result.messages
+          hasPrevMessage = result.hasNext
+        } else {
+          pastMessages = result
+        }
+
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
       } catch (error) {}
 
       dispatch({
         action: MessagesActions.PAST,
         messages: pastMessages,
+        hasPrevMessage,
       })
       setScrollY(prevScrollY)
     } else if (isIntersecting && firstRenderForPrevScrollRef.current) {

--- a/packages/tds-widget/src/chat/chat/messages-reducer.ts
+++ b/packages/tds-widget/src/chat/chat/messages-reducer.ts
@@ -46,10 +46,12 @@ export type MessagesAction<Message extends MessageBase<Id>, Id = string> =
   | {
       action: MessagesActions.INIT
       messages: Message[]
+      hasPrevMessage?: boolean
     }
   | {
       action: MessagesActions.PAST
       messages: Message[]
+      hasPrevMessage?: boolean
     }
   | {
       action: MessagesActions.NEW
@@ -93,13 +95,14 @@ function MessagesReducer<Message extends MessageBase<Id>, Id = string>(
       return {
         ...state,
         messages: action.messages,
+        hasPrevMessage: action.hasPrevMessage ?? state.hasPrevMessage,
       }
 
     case MessagesActions.PAST:
       return {
         ...state,
         messages: [...action.messages, ...state.messages],
-        hasPrevMessage: action.messages.length > 0,
+        hasPrevMessage: action.hasPrevMessage ?? action.messages.length > 0,
       }
 
     case MessagesActions.NEW:


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

- nol-chat getMessages 응답 인터페이스가 변경되어 migration합니다.
  - triple-chat: ChatMessageInterface[]
  - nol-chat: { messages: ChatMessageInterface[], hasPrev: boolean }
 
## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
