### PR TITLE
[DMTALK] get messages 응답 인터페이스 변경 대응

### DIFF
--- a/packages/tds-widget/src/chat/chat/chat-room-messages/chat-api-service.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/chat-api-service.ts
@@ -68,7 +68,7 @@ export class ChatApiService<T = UserType> {
     backward?: boolean
     lastMessageId: number | string | null
   }): Promise<
-    | { messages: ChatMessageInterface<T>[]; hasNext: boolean }
+    | { messages: ChatMessageInterface<T>[]; nextToken?: number }
     | ChatMessageInterface<T>[] // legacy API
   > {
     return this.fetcher(

--- a/packages/tds-widget/src/chat/chat/messages-reducer.ts
+++ b/packages/tds-widget/src/chat/chat/messages-reducer.ts
@@ -32,6 +32,11 @@ export interface MessagesState<Message extends MessageBase<Id>, Id = string> {
   failedMessages: UnsentMessage<Message, Id>[]
   hasPrevMessage: boolean
   hasNextMessage: boolean
+  /**
+   * [nol-chat] 다음 페이지 요청 cursor
+   * nol-chat에서는 hasPrevMessage 대신 prevToken을 사용
+   */
+  prevToken?: Id
 }
 
 export const initialMessagesState = {
@@ -46,12 +51,12 @@ export type MessagesAction<Message extends MessageBase<Id>, Id = string> =
   | {
       action: MessagesActions.INIT
       messages: Message[]
-      hasPrevMessage?: boolean
+      prevToken?: Id
     }
   | {
       action: MessagesActions.PAST
       messages: Message[]
-      hasPrevMessage?: boolean
+      prevToken?: Id
     }
   | {
       action: MessagesActions.NEW
@@ -95,14 +100,19 @@ function MessagesReducer<Message extends MessageBase<Id>, Id = string>(
       return {
         ...state,
         messages: action.messages,
-        hasPrevMessage: action.hasPrevMessage ?? state.hasPrevMessage,
+        prevToken: action.prevToken,
+        ...('prevToken' in action && { hasPrevMessage: !!action.prevToken }),
       }
 
     case MessagesActions.PAST:
       return {
         ...state,
         messages: [...action.messages, ...state.messages],
-        hasPrevMessage: action.hasPrevMessage ?? action.messages.length > 0,
+        hasPrevMessage:
+          'prevToken' in action
+            ? !!action.prevToken
+            : action.messages.length > 0,
+        prevToken: action.prevToken,
       }
 
     case MessagesActions.NEW:


### PR DESCRIPTION

<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

- getMessages 인터페이스 변경에 대응합니다.
  - `hasNext` => `nextToken`
  - 현재 backward만 사용하므로 서버로 부터 받은 nextToken을 prevToken으로 변환합니다. 추후 backward=false 사용이 추가된다면, 분기처리가 필요합니다.

[이전 PR](https://github.com/titicacadev/triple-frontend/pull/3634)의 Base가 잘못되어 재오픈 합니다. 🙏 

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
