### PR TITLE
[DMTALK] Preview 날짜 표기 방식 util 추가

### DIFF
--- a/packages/tds-widget/src/chat/preview/elements.tsx
+++ b/packages/tds-widget/src/chat/preview/elements.tsx
@@ -1,7 +1,7 @@
 import { Container, List, Text } from '@titicaca/tds-ui'
 import { css, styled } from 'styled-components'
 
-import { convertDateTime as defaultConvertDateTime } from './utils'
+import { formatRelativeTime } from './utils'
 
 export const PreviewListItem = styled(List.Item)<{ isSelected: boolean }>`
   cursor: pointer;
@@ -41,7 +41,7 @@ export const ChatRoomMessage = styled(Text).attrs({
 
 export const ChatRoomCreatedAt = ({
   createdAt,
-  convertDateTime = defaultConvertDateTime,
+  convertDateTime = formatRelativeTime,
   ...props
 }: {
   createdAt: string

--- a/packages/tds-widget/src/chat/preview/elements.tsx
+++ b/packages/tds-widget/src/chat/preview/elements.tsx
@@ -1,7 +1,7 @@
 import { Container, List, Text } from '@titicaca/tds-ui'
 import { css, styled } from 'styled-components'
 
-import { formatRelativeTime } from './utils'
+import { convertDateTime as defaultConvertDateTime } from './utils'
 
 export const PreviewListItem = styled(List.Item)<{ isSelected: boolean }>`
   cursor: pointer;
@@ -41,7 +41,7 @@ export const ChatRoomMessage = styled(Text).attrs({
 
 export const ChatRoomCreatedAt = ({
   createdAt,
-  convertDateTime = formatRelativeTime,
+  convertDateTime = defaultConvertDateTime,
   ...props
 }: {
   createdAt: string

--- a/packages/tds-widget/src/chat/preview/preview.tsx
+++ b/packages/tds-widget/src/chat/preview/preview.tsx
@@ -11,7 +11,7 @@ import {
   UserType,
 } from '../types'
 
-import { convertDateTime, getTextMessage } from './utils'
+import { getTextMessage } from './utils'
 import { ChatRoomMessage, ChatRoomTitle } from './elements'
 
 export interface PreviewProps<T, U> {
@@ -80,9 +80,7 @@ export function Preview<T = RoomType, U = UserType>({
           <Message>{getTextMessage(payload)}</Message>
         ) : null}
 
-        {createdAt && CreatedAt ? (
-          <CreatedAt createdAt={createdAt} convertDateTime={convertDateTime} />
-        ) : null}
+        {createdAt && CreatedAt ? <CreatedAt createdAt={createdAt} /> : null}
       </Container>
 
       {unreadCount && Unread ? <Unread unreadCount={unreadCount} /> : null}

--- a/packages/tds-widget/src/chat/preview/utils.ts
+++ b/packages/tds-widget/src/chat/preview/utils.ts
@@ -1,6 +1,8 @@
-import { format, isSameDay } from 'date-fns'
+import { differenceInDays, format, isSameDay, parseISO } from 'date-fns'
 
 import { ChatMessagePayload, ChatMessagePayloadType } from '../types'
+
+const DATE_FORMAT = 'yyyy.MM.dd'
 
 export const getTextMessage = (payload: ChatMessagePayload) => {
   const replaceNewlinesWithSpaces = (text: string) =>
@@ -30,11 +32,27 @@ export function convertDateTime(
   formatType?: string,
 ): string {
   const dateTime = new Date(createdAt)
-  const DATE_FORMAT = 'yyyy.MM.dd'
 
   if (isSameDay(dateTime, new Date())) {
     return format(dateTime, 'a h:mm')
   } else {
     return format(dateTime, formatType ?? DATE_FORMAT)
+  }
+}
+
+export function formatRelativeTime(
+  createdAt: string,
+  formatString?: string,
+): string {
+  const dateTime = parseISO(createdAt)
+  const today = new Date()
+  const diff = differenceInDays(today, dateTime)
+
+  if (isSameDay(dateTime, today)) {
+    return format(dateTime, 'a h:mm')
+  } else if (diff <= 7) {
+    return `${diff}일 전`
+  } else {
+    return format(dateTime, formatString ?? DATE_FORMAT)
   }
 }

--- a/packages/tds-widget/src/chat/preview/utils.ts
+++ b/packages/tds-widget/src/chat/preview/utils.ts
@@ -1,4 +1,4 @@
-import { differenceInDays, format, isSameDay, parseISO } from 'date-fns'
+import { differenceInCalendarDays, format, isSameDay, parseISO } from 'date-fns'
 
 import { ChatMessagePayload, ChatMessagePayloadType } from '../types'
 
@@ -46,7 +46,7 @@ export function formatRelativeTime(
 ): string {
   const dateTime = parseISO(createdAt)
   const today = new Date()
-  const diff = differenceInDays(today, dateTime)
+  const diff = differenceInCalendarDays(today, dateTime)
 
   if (isSameDay(dateTime, today)) {
     return format(dateTime, 'a h:mm')


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

Preview 날짜 표기 기본 방식 util을 추가합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

시간에 따라 다르게 표기되는 formatRelativeTime 함수를 추가합니다.

- 당일 : 시간
- 7일 이내 : ~일전
- 7일 이후 : 날짜
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

적용을 원하면 CreatedAt prop으로 설정이 필요합니다.

```tsx
import { formatRelativeTime } from '@titicaca/tds-widget'
...
                CreatedAt={({ createdAt }) => (
                  <ChatRoomCreatedAt
                    createdAt={createdAt}
                    convertDateTime={formatRelativeTime}
                  />
                )}
```

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
