### PR TITLE
middleware 내부에서 httpError 로깅 추가 및 x-soto-session 제거 로직 삭제

### DIFF
--- a/packages/react-contexts/src/middlewares/refresh-session.ts
+++ b/packages/react-contexts/src/middlewares/refresh-session.ts
@@ -10,15 +10,10 @@ import {
   post,
   handle401Error,
   NEED_REFRESH_IDENTIFIER,
+  captureHttpError,
 } from '@titicaca/fetcher'
 import { parseString, splitCookiesString } from 'set-cookie-parser'
-import {
-  TP_SE,
-  TP_TK,
-  SESSION_KEY as X_SOTO_SESSION,
-} from '@titicaca/constants'
-
-import { parseApp } from '../user-agent-context'
+import { TP_SE, TP_TK } from '@titicaca/constants'
 
 import { applySetCookie } from './utils/apply-set-cookie'
 
@@ -37,17 +32,10 @@ export function refreshSessionMiddleware(next: NextMiddleware) {
 
     const allCookies = request.cookies.getAll()
 
-    const userAgent = request.headers.get('User-Agent')
-    const tripleApp = userAgent ? parseApp(userAgent) : null
-
-    const cookiesWithoutXSotoSession = tripleApp
-      ? allCookies
-      : allCookies.filter(({ name }) => name !== X_SOTO_SESSION)
-
-    const isSessionExisted = cookiesWithoutXSotoSession.some(
+    const isSessionExisted = allCookies.some(
       ({ name }) => name === TP_TK || name === TP_SE,
     )
-    const cookies = deriveAllCookies(cookiesWithoutXSotoSession)
+    const cookies = deriveAllCookies(allCookies)
 
     if (!isSessionExisted) {
       return response
@@ -68,6 +56,7 @@ export function refreshSessionMiddleware(next: NextMiddleware) {
       unknown,
       { status: number; exception: string; message: string }
     >('/api/users/session/verify', options)
+    captureHttpError(firstTrialResponse)
 
     const checkFirstTrialResponse = await handle401Error(firstTrialResponse)
 
@@ -88,6 +77,7 @@ export function refreshSessionMiddleware(next: NextMiddleware) {
      * /web-session/token은 TP-TK의 유효성을 확인해서 TP_TK, TP_SE, x-soto-session 응답합니다.
      */
     const refreshResponse = await post('/api/users/web-session/token', options)
+    captureHttpError(refreshResponse)
 
     const setCookie = refreshResponse.headers.get('set-cookie')
 

--- a/packages/react-contexts/src/middlewares/refresh-session.ts
+++ b/packages/react-contexts/src/middlewares/refresh-session.ts
@@ -56,11 +56,11 @@ export function refreshSessionMiddleware(next: NextMiddleware) {
       unknown,
       { status: number; exception: string; message: string }
     >('/api/users/session/verify', options)
-    captureHttpError(firstTrialResponse)
 
     const checkFirstTrialResponse = await handle401Error(firstTrialResponse)
 
     if (checkFirstTrialResponse !== NEED_REFRESH_IDENTIFIER) {
+      captureHttpError(firstTrialResponse)
       const setCookie = firstTrialResponse.headers.get('set-cookie')
       if (setCookie) {
         const setCookies = splitCookiesString(setCookie)


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
당분간 x-soto-session을 유지하기로 했으므로 x-soto-session을 제외하는 로직을 삭제합니다.
미들웨어의 에러 트래킹을 위해 `captureHttpError`를 추가합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->
