### PR TITLE
[DMTALK-133] 상대방 메시지 실시간 받을 경우 스크롤이 올라가도록 수정

### DIFF
--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import DOMPurify from 'dompurify'
 
 import {
@@ -56,6 +56,9 @@ export function useChatMessages<T = UserType>(
 
   const firstRenderForPrevScrollRef = useRef(true)
   const isWelcomeMessagePendingRef = useRef(false)
+  const [onCompleteSendMessage, setOnCompleteSendMessage] = useState<
+    (() => void) | undefined
+  >(undefined)
 
   const {
     messages,
@@ -424,7 +427,7 @@ export function useChatMessages<T = UserType>(
             messages: [message],
           })
         }
-        onComplete?.(message, myMessage)
+        setOnCompleteSendMessage(() => onComplete?.(message, myMessage))
         if (scrollToBottomOnNewMessage) {
           triggerScrollToBottom()
         }
@@ -527,6 +530,13 @@ export function useChatMessages<T = UserType>(
       })
     }
   }
+
+  useEffect(() => {
+    if (onCompleteSendMessage) {
+      onCompleteSendMessage()
+      setOnCompleteSendMessage(undefined)
+    }
+  }, [onCompleteSendMessage])
 
   return {
     messages,

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import DOMPurify from 'dompurify'
 
 import {
@@ -56,9 +56,6 @@ export function useChatMessages<T = UserType>(
 
   const firstRenderForPrevScrollRef = useRef(true)
   const isWelcomeMessagePendingRef = useRef(false)
-  const [onCompleteSendMessage, setOnCompleteSendMessage] = useState<
-    (() => void) | undefined
-  >(undefined)
 
   const {
     messages,
@@ -427,7 +424,7 @@ export function useChatMessages<T = UserType>(
             messages: [message],
           })
         }
-        setOnCompleteSendMessage(() => onComplete?.(message, myMessage))
+        onComplete?.(message, myMessage)
         if (scrollToBottomOnNewMessage) {
           triggerScrollToBottom()
         }
@@ -530,13 +527,6 @@ export function useChatMessages<T = UserType>(
       })
     }
   }
-
-  useEffect(() => {
-    if (onCompleteSendMessage) {
-      onCompleteSendMessage()
-      setOnCompleteSendMessage(undefined)
-    }
-  }, [onCompleteSendMessage])
 
   return {
     messages,

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-scroll.tsx
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-scroll.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { useScroll as useBaseScroll } from '../scroll-context'
+import { useScroll as useBaseScroll, ScrollOptions } from '../scroll-context'
 
 export function useScroll() {
   const { setScrollY, getScrollContainerHeight, scrollToBottom } =
@@ -8,18 +8,22 @@ export function useScroll() {
 
   const [shouldScrollToBottom, setShouldScrollToBottom] =
     useState<boolean>(false)
+  const [scrollOptions, setScrollOptions] = useState<ScrollOptions>({})
 
   /** pusher의 이벤트 핸들러에서 scrollToBottom을 호출할 경우 이벤트가 늦게 발생하여 state로 우회합니다. */
   useEffect(() => {
     if (shouldScrollToBottom) {
-      scrollToBottom()
+      scrollToBottom(scrollOptions)
       setShouldScrollToBottom(false)
     }
-  }, [shouldScrollToBottom, scrollToBottom])
+  }, [shouldScrollToBottom, scrollToBottom, scrollOptions])
 
   return {
     setScrollY,
     getScrollContainerHeight,
-    triggerScrollToBottom: () => setShouldScrollToBottom(true),
+    triggerScrollToBottom: (options?: ScrollOptions) => {
+      setShouldScrollToBottom(true)
+      options && setScrollOptions(options)
+    },
   }
 }

--- a/packages/tds-widget/src/chat/scroll-buttons-area/index.tsx
+++ b/packages/tds-widget/src/chat/scroll-buttons-area/index.tsx
@@ -10,7 +10,7 @@ import {
 import { Container } from '@titicaca/tds-ui'
 
 import { ChatMessageInterface, UserType } from '../types'
-import { useScroll } from '../chat'
+import { useScroll } from '../chat/chat-room-messages/use-scroll'
 
 import { ScrollButtons, type ScrollButtonsProps } from './scroll-buttons'
 
@@ -51,11 +51,11 @@ function ScrollButtonsAreaImpl<T = UserType>(
 
   const mounted = useRef(false)
 
-  const { scrollToBottom } = useScroll()
+  const { triggerScrollToBottom } = useScroll()
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const onButtonClick = (behavior: ScrollBehavior = 'smooth') => {
-    scrollToBottom({ scrollBehavior: behavior })
+    triggerScrollToBottom({ scrollBehavior: behavior })
   }
 
   useImperativeHandle(ref, () => {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

[DMTALK-133]
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

사용부(파센, 챗웹)에서 경우에 따라 실행플로우가 달라집니다.
- `my=true`인 경우 -> 상태를 변경시킨 후 effect로 변경하기 때문에 딜레이가 걸림 + dispatch로 상태변경 없음
- `my=false`인 경우 -> dispatch로 상태변경 + 바로 scrollToBottom 호출// 상태변경이 반영이 안된 상태에서 스크롤이 아래로 내려졌던 것일 수 있음

`useChatMessages` 속 다른 `dispatch` 실행 후 실행하는 코드들은 **상태로 저장되거나 딜레이가 있어** 상태 반영 후 실행이 되어 문제가 없었던 것으로 보입니다.
따라서 `onButtonClick`에서도 상태를 변경시켜 스크롤을 변경하는 `triggerScrollToBottom`가 실행되도록 변경합니다.
기존에 `scrollBehavior` 값을 다르게 받고 있었기 때문에 `scrollOptions`를 추가로 받을 수 있도록 수정합니다.

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

반영 PR

- https://github.com/titicacadev/tna-partners-web/pull/2275
- https://github.com/titicacadev/triple-chat-web/pull/485
<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->


https://github.com/user-attachments/assets/27fbe104-1fa6-4454-a701-61e30034b5a1




[DMTALK-133]: https://yanoljagroup.atlassian.net/browse/DMTALK-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ