### PR TITLE
[review] queryFn return 추가

### DIFF
--- a/packages/review/src/services/use-reviews.ts
+++ b/packages/review/src/services/use-reviews.ts
@@ -20,18 +20,15 @@ import {
   UnlikeReviewMutationVariables,
   client,
   reviewClient,
-  GetReviewsCountQuery,
 } from '../data/graphql'
 
 export function useReviewCount(
   params: GetReviewsCountQueryVariables,
   initialValue?: number,
 ) {
-  return useQuery<unknown, unknown, GetReviewsCountQuery>(
+  return useQuery(
     ['reviews/getReviewCount', { ...params }],
-    () => {
-      reviewClient(() => client.GetReviewsCount(params))
-    },
+    () => reviewClient(() => client.GetReviewsCount(params)),
     {
       refetchOnWindowFocus: false,
       initialData: initialValue


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
`getReviewsCount` 쿼리의 queryFn에서 return을 하지 않아 data가 undefined가 되는 문제를 해결합니다. 이전에 `content-web`에서 테스트했을 때에는 리뷰 개수를 노출하지 않아 미처 발견하지 못했습니다. 🥲
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- queryFn의 반환값을 추가합니다. 
- 불필요하고 잘못된 타입을 제거합니다. 
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->
