### PR TITLE
[middlware] 세션 갱신 로직을 수정합니다.

### DIFF
--- a/packages/fetcher/package.json
+++ b/packages/fetcher/package.json
@@ -46,7 +46,6 @@
     "@sentry/nextjs": "7.120.3",
     "@titicaca/view-utilities": "workspace:*",
     "@types/node-fetch": "^2.6.12",
-    "@types/set-cookie-parser": "^2.4.10",
     "isomorphic-fetch": "^2.2.1",
     "next": "^14.2.24",
     "node-fetch": "^2.7.0"

--- a/packages/fetcher/src/index.ts
+++ b/packages/fetcher/src/index.ts
@@ -16,3 +16,8 @@ export {
   sessionRefreshOnSSR,
   type SetCookie,
 } from './session-refresh'
+export {
+  serverFetchers,
+  serverFetcherize,
+  removeInvalidCookies,
+} from './server-fetch'

--- a/packages/fetcher/src/server-fetch.ts
+++ b/packages/fetcher/src/server-fetch.ts
@@ -1,0 +1,57 @@
+import { parseCookie } from 'next/dist/compiled/@edge-runtime/cookies'
+import { cookies as getCookies } from 'next/headers'
+import Cookies from 'universal-cookie'
+
+import { fetcher } from './fetcher'
+import { del, get, post, put } from './methods'
+import { BaseFetcher } from './factories'
+
+export const serverFetchers = {
+  fetcher: serverFetcherize((href, options) => fetcher(href, options || {})),
+  get: serverFetcherize(get),
+  post: serverFetcherize(post),
+  put: serverFetcherize(put),
+  del: serverFetcherize(del),
+}
+
+export function serverFetcherize<Fetcher extends BaseFetcher>(
+  fetcher: Fetcher,
+): Fetcher {
+  return ((href, options) => {
+    const { cookie: overridingCookie } = options || {}
+    const finalCookie = removeInvalidCookies(
+      overridingCookie ?? getCookies().toString(),
+    )
+
+    return fetcher(href, {
+      ...options,
+      ...(finalCookie && { cookie: finalCookie }),
+      withApiUriBase: true,
+      headers: {
+        ...options?.headers,
+        'x-triple-from-ssr': 'true',
+      },
+    })
+  }) as Fetcher
+}
+
+export function removeInvalidCookies(_cookies: string) {
+  const validCookies = new Cookies()
+  const cookieMap = parseCookie(_cookies)
+  cookieMap.forEach(([name, value]) => {
+    if (isValidCookieValue(value)) {
+      validCookies.set(name, value)
+    }
+  })
+  return validCookies.getAll<string>()
+}
+
+function isValidCookieValue(value?: string | null) {
+  return (
+    value !== undefined &&
+    value !== null &&
+    value !== 'null' &&
+    value !== 'undefined' &&
+    value.length > 0
+  )
+}

--- a/packages/fetcher/src/server-fetch.ts
+++ b/packages/fetcher/src/server-fetch.ts
@@ -1,4 +1,7 @@
-import { parseCookie } from 'next/dist/compiled/@edge-runtime/cookies'
+import {
+  parseCookie,
+  stringifyCookie,
+} from 'next/dist/compiled/@edge-runtime/cookies'
 import Cookies from 'universal-cookie'
 
 import { fetcher } from './fetcher'
@@ -52,7 +55,7 @@ export function removeInvalidCookies(_cookies: string) {
       validCookies.set(name, value)
     }
   })
-  return validCookies.getAll<string>()
+  return stringifyCookie(validCookies.getAll<{ name: string; value: string }>())
 }
 
 function isValidCookieValue(value?: string | null) {

--- a/packages/fetcher/src/server-fetch.ts
+++ b/packages/fetcher/src/server-fetch.ts
@@ -17,10 +17,20 @@ export const serverFetchers = {
 export function serverFetcherize<Fetcher extends BaseFetcher>(
   fetcher: Fetcher,
 ): Fetcher {
-  return ((href, options: RequestOptions & { cookie: string }) => {
-    const { cookie } = options || {}
+  return (async (href, options: RequestOptions) => {
+    const isServer = typeof window === 'undefined'
+    let serverCookie: string | undefined
 
-    const validCookies = cookie ? removeInvalidCookies(cookie) : undefined
+    if (isServer) {
+      const { cookies } = await import('next/headers')
+
+      serverCookie = cookies().toString()
+    }
+
+    const finalCookie = options?.cookie ?? serverCookie
+    const validCookies = finalCookie
+      ? removeInvalidCookies(finalCookie)
+      : undefined
 
     return fetcher(href, {
       ...options,

--- a/packages/middlewares/package.json
+++ b/packages/middlewares/package.json
@@ -41,14 +41,15 @@
     ]
   },
   "dependencies": {
+    "cookie": "^1.0.2",
     "semver": "^7.6.3",
     "set-cookie-parser": "^2.7.1",
     "universal-cookie": "^4.0.4",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "@titicaca/fetcher": "workspace:*",
     "@titicaca/constants": "workspace:*",
+    "@titicaca/fetcher": "workspace:*",
     "@titicaca/triple-web-utils": "workspace:*",
     "@titicaca/view-utilities": "workspace:*",
     "@types/semver": "^7.5.8",

--- a/packages/middlewares/src/index.ts
+++ b/packages/middlewares/src/index.ts
@@ -1,12 +1,20 @@
 import { chain } from './chain'
 import type { MiddlewareFactory } from './types'
-import { refreshSessionMiddleware } from './refresh-session'
+import {
+  refreshSessionMiddleware,
+  refreshSessionMiddlewareNext13,
+} from './refresh-session'
 import { setWebDeviceIdMiddleware } from './set-web-device-id'
 
 export const constructMiddleware = (functions: MiddlewareFactory[]) =>
   chain([...functions, refreshSessionMiddleware, setWebDeviceIdMiddleware])
+export const constructMiddlewareNext13 = (functions: MiddlewareFactory[]) =>
+  chain([...functions, refreshSessionMiddlewareNext13])
 
 export * from './types'
 export { chain } from './chain'
-export { refreshSessionMiddleware } from './refresh-session'
+export {
+  refreshSessionMiddleware,
+  refreshSessionMiddlewareNext13,
+} from './refresh-session'
 export { setWebDeviceIdMiddleware } from './set-web-device-id'

--- a/packages/middlewares/src/refresh-session.ts
+++ b/packages/middlewares/src/refresh-session.ts
@@ -14,6 +14,9 @@ import {
 } from '@titicaca/fetcher'
 import { parseString } from 'set-cookie-parser'
 import { TP_SE, TP_TK } from '@titicaca/constants'
+import { serialize, SerializeOptions } from 'cookie'
+
+import { getDomain } from './utils/get-domain'
 
 export function refreshSessionMiddleware(next: NextMiddleware) {
   return async function middleware(
@@ -59,8 +62,12 @@ export function refreshSessionMiddleware(next: NextMiddleware) {
 
     if (checkFirstTrialResponse !== NEED_REFRESH_IDENTIFIER) {
       captureHttpError(firstTrialResponse)
-      const setCookie = firstTrialResponse.headers.getSetCookie()
-      if (setCookie) {
+      const setCookieHeader = firstTrialResponse.headers.getSetCookie()
+      if (setCookieHeader) {
+        const setCookie = changeSetCookieDomainOnLocalhost(
+          request,
+          setCookieHeader,
+        )
         setCookie.forEach((cookie) => {
           const { name, value, ...rest } = parseString(cookie)
           response.cookies.set(name, value, { ...(rest as ResponseCookie) })
@@ -75,9 +82,13 @@ export function refreshSessionMiddleware(next: NextMiddleware) {
     const refreshResponse = await post('/api/users/web-session/token', options)
     captureHttpError(refreshResponse)
 
-    const setCookie = refreshResponse.headers.getSetCookie()
+    const setCookieHeader = refreshResponse.headers.getSetCookie()
 
-    if (setCookie) {
+    if (setCookieHeader) {
+      const setCookie = changeSetCookieDomainOnLocalhost(
+        request,
+        setCookieHeader,
+      )
       setCookie.forEach((cookie) => {
         const { name, value, ...rest } = parseString(cookie)
         response.cookies.set(name, value, { ...(rest as ResponseCookie) })
@@ -89,4 +100,23 @@ export function refreshSessionMiddleware(next: NextMiddleware) {
 
 function deriveAllCookies(cookies: { name: string; value: string }[]) {
   return cookies.map(({ name, value }) => [name, value].join('=')).join('; ')
+}
+
+function changeSetCookieDomainOnLocalhost(
+  request: NextRequest,
+  setCookie: string[],
+) {
+  const domain = getDomain(request)
+  if (domain !== 'localhost') {
+    return setCookie
+  }
+
+  const domainChangedSetCookies = setCookie.map((cookie) => {
+    const { domain: originalDomain, ...rest } = parseString(cookie)
+    return { domain, ...rest }
+  })
+
+  return domainChangedSetCookies.map((cookie) => {
+    return serialize(cookie.name, cookie.value, cookie as SerializeOptions)
+  })
 }

--- a/packages/middlewares/src/refresh-session/index.ts
+++ b/packages/middlewares/src/refresh-session/index.ts
@@ -1,0 +1,2 @@
+export { refreshSessionMiddleware } from './next-14'
+export { refreshSessionMiddleware as refreshSessionMiddlewareNext13 } from './next-13'

--- a/packages/middlewares/src/refresh-session/next-13.ts
+++ b/packages/middlewares/src/refresh-session/next-13.ts
@@ -1,0 +1,102 @@
+import { type ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies'
+import {
+  NextFetchEvent,
+  NextMiddleware,
+  NextRequest,
+  NextResponse,
+} from 'next/server'
+import {
+  get,
+  post,
+  handle401Error,
+  NEED_REFRESH_IDENTIFIER,
+  captureHttpError,
+} from '@titicaca/fetcher'
+import { parseString, splitCookiesString } from 'set-cookie-parser'
+import { TP_SE, TP_TK } from '@titicaca/constants'
+
+import { applySetCookie } from '../utils/apply-set-cookie'
+
+/**
+ *
+ * next v13 이하에서 사용하는 refreshSessionMiddleware
+ */
+export function refreshSessionMiddleware(next: NextMiddleware) {
+  return async function middleware(
+    request: NextRequest,
+    event: NextFetchEvent,
+  ) {
+    const response = (await next(request, event)) as NextResponse
+    const url = request.nextUrl
+
+    const isPageUrl = url.pathname.match('^/((?!(api|static|.*\\..*|_next)).*)')
+    if (!isPageUrl) {
+      return response
+    }
+
+    const allCookies = request.cookies.getAll()
+
+    const isSessionExisted = allCookies.some(
+      ({ name }) => name === TP_TK || name === TP_SE,
+    )
+    const cookies = deriveAllCookies(allCookies)
+
+    if (!isSessionExisted) {
+      return response
+    }
+
+    const options = {
+      cookie: cookies,
+      withApiUriBase: true,
+    }
+
+    /**
+     * /users/session/verify는 아래와 같은 상태값을 갖습니다.
+     * 200 : TP_SE와 TP_TK가 모두 유효한 경우
+     * 401 : TP_SE가 유효하지 않고 TP_TK가 유효한 경우
+     * 403 : TP_TK가 모두 유효하지 않은 경우
+     */
+    const firstTrialResponse = await get<
+      unknown,
+      { status: number; exception: string; message: string }
+    >('/api/users/session/verify', options)
+
+    const checkFirstTrialResponse = await handle401Error(firstTrialResponse)
+
+    if (checkFirstTrialResponse !== NEED_REFRESH_IDENTIFIER) {
+      captureHttpError(firstTrialResponse)
+      const setCookie = firstTrialResponse.headers.get('set-cookie')
+      if (setCookie) {
+        const setCookies = splitCookiesString(setCookie)
+        setCookies.forEach((cookie) => {
+          const { name, value, ...rest } = parseString(cookie)
+          response.cookies.set(name, value, { ...(rest as ResponseCookie) })
+        })
+        applySetCookie(request, response)
+      }
+      return response
+    }
+
+    /**
+     * /web-session/token은 TP-TK의 유효성을 확인해서 TP_TK, TP_SE, x-soto-session 응답합니다.
+     */
+    const refreshResponse = await post('/api/users/web-session/token', options)
+    captureHttpError(refreshResponse)
+
+    const setCookie = refreshResponse.headers.get('set-cookie')
+
+    if (setCookie) {
+      const setCookies = splitCookiesString(setCookie)
+      setCookies.forEach((cookie) => {
+        const { name, value, ...rest } = parseString(cookie)
+        response.cookies.set(name, value, { ...(rest as ResponseCookie) })
+      })
+      applySetCookie(request, response)
+    }
+    return response
+  }
+}
+
+function deriveAllCookies(cookies: { name: string; value: string }[]) {
+  return cookies.map(({ name, value }) => [name, value].join('=')).join('; ')
+}

--- a/packages/middlewares/src/refresh-session/next-14.ts
+++ b/packages/middlewares/src/refresh-session/next-14.ts
@@ -16,8 +16,12 @@ import { parseString } from 'set-cookie-parser'
 import { TP_SE, TP_TK } from '@titicaca/constants'
 import { serialize, SerializeOptions } from 'cookie'
 
-import { getDomain } from './utils/get-domain'
+import { getDomain } from '../utils/get-domain'
 
+/**
+ *
+ * next v14 이상에서 사용하는 refreshSessionMiddleware
+ */
 export function refreshSessionMiddleware(next: NextMiddleware) {
   return async function middleware(
     request: NextRequest,

--- a/packages/middlewares/src/set-web-device-id.ts
+++ b/packages/middlewares/src/set-web-device-id.ts
@@ -6,10 +6,10 @@ import {
 } from 'next/server'
 import { v4 as uuidV4 } from 'uuid'
 import { X_TRIPLE_WEB_DEVICE_ID } from '@titicaca/constants'
-import { parseUrl } from '@titicaca/view-utilities'
 
 import { getIsTripleApp } from './utils/get-triple-app'
 import { applySetCookie } from './utils/apply-set-cookie'
+import { getDomain } from './utils/get-domain'
 
 export function setWebDeviceIdMiddleware(next: NextMiddleware) {
   return async function middleware(
@@ -39,12 +39,4 @@ export function setWebDeviceIdMiddleware(next: NextMiddleware) {
 
     return response
   }
-}
-
-function getDomain(request: NextRequest) {
-  const hostFromRequest = request.headers.get('host')
-  const isLocalhost = hostFromRequest?.split(':')[0] === 'localhost'
-  const { host } = parseUrl(process.env.NEXT_PUBLIC_WEB_URL_BASE)
-
-  return isLocalhost ? 'localhost' : `.${host}`
 }

--- a/packages/middlewares/src/utils/get-domain.ts
+++ b/packages/middlewares/src/utils/get-domain.ts
@@ -1,0 +1,10 @@
+import { parseUrl } from '@titicaca/view-utilities'
+import { NextRequest } from 'next/server'
+
+export function getDomain(request: NextRequest) {
+  const hostFromRequest = request.headers.get('host')
+  const isLocalhost = hostFromRequest?.split(':')[0] === 'localhost'
+  const { host } = parseUrl(process.env.NEXT_PUBLIC_WEB_URL_BASE)
+
+  return isLocalhost ? 'localhost' : `.${host}`
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,6 +374,9 @@ importers:
 
   packages/middlewares:
     dependencies:
+      cookie:
+        specifier: ^1.0.2
+        version: 1.0.2
       semver:
         specifier: ^7.6.3
         version: 7.6.3
@@ -5314,6 +5317,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   core-js-compat@3.36.1:
     resolution: {integrity: sha512-Dk997v9ZCt3X/npqzyGdTlq6t7lDBhZwGvV94PKzDArjp7BTRm7WlDAXYd/OWdeFHO8OChQYRJNJvUCqCbrtKA==}
@@ -15981,6 +15988,8 @@ snapshots:
   cookie@0.4.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.0.2: {}
 
   core-js-compat@3.36.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,9 +329,6 @@ importers:
       '@types/node-fetch':
         specifier: ^2.6.12
         version: 2.6.12
-      '@types/set-cookie-parser':
-        specifier: ^2.4.10
-        version: 2.4.10
       isomorphic-fetch:
         specifier: ^2.2.1
         version: 2.2.1


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
next14에 맞게 middleware를 수정하고 서버 컴포넌트에서 사용할 `serverFetcherize` 함수를 추가합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- next14에서는 미들웨어에서 `response.cookies.set` 함수를 사용할 경우 `set-cookie` 뿐 아니라 response의 cookie에도 적용이 되므로 이를 위해 사용했던 `applySetCookie` 함수를 제거합니다. 
  - v13 참고 : https://github.com/titicacadev/triple-frontend/pull/3592 
  - v13에서는 기존 코드를 사용하기 위해 `constructMiddlewareNext13`을 분리했습니다. next14 버전 이상으로 모든 레포가 업데이트 되면 없어질 예정이기 때문에 따로 next14 함수와 공통 부분을 분리하지 않고 복사해 코드를 작성했습니다. 
- invalid한 쿠키값을 제외하고 요청을 보낼 수 있도록 `removeInvalidCookies` 함수를 적용합니다.
  - `severFetcherize` 함수에서는 기본적으로 적용합니다.
  - next14로 업데이트되면서 middleware에서 변경된 쿠키 값을 적용해도 빈값을 넣어주면 `undefined`로 값이 인식되므로 명시적으로 invalid한 값들을 제거하는 과정을 추가합니다. invalid한 쿠키 값은 빈값(null, undefined)이거나 길이가 0인 string입니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 사용 예시
- next 13
```
// middlware.ts
import { constructMiddlewareNext13 } from '@titicaca/middlewares'

export default constructMiddlewareNext13([])
```

- next 14
```
import { constructMiddleware } from '@titicaca/middlewares'

export default constructMiddleware([])
```