### PR TITLE
[DMTALK] 네트워크 없을 경우 실패 아이콘 미노출되는 이슈 수정

### DIFF
--- a/packages/tds-widget/src/chat/bubble/nol/styles.ts
+++ b/packages/tds-widget/src/chat/bubble/nol/styles.ts
@@ -87,6 +87,20 @@ const NOL_BUBBLE_INFO_BASE_STYLE = css`
   font-weight: 400;
 `
 
+const RETRY_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M12.1765 10.0957C11.4332 11.6604 9.83839 12.7422 7.99089 12.7422C5.43308 12.7422 3.35957 10.6687 3.35957 8.11086C3.35957 5.55305 5.43308 3.47954 7.99089 3.47954C9.96595 3.47954 11.6522 4.71586 12.3181 6.45682" stroke="white" stroke-width="1.3" stroke-linecap="round"/>
+  <path d="M10.7359 6.33256L12.7017 6.60742L12.9765 4.64169" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>`
+
+const DELETE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none">
+  <path d="M2 10L10 2" stroke="white" stroke-width="1.3" stroke-linecap="round"/>
+  <path d="M2 2L10 10" stroke="white" stroke-width="1.3" stroke-linecap="round"/>
+</svg>`
+
+const getSVG = (svg: string) => {
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
+}
+
 export const NOL_PARTNER_ROOM_BUBBLE_INFO_STYLE = {
   failureHandler: {
     css: css`
@@ -105,12 +119,12 @@ export const NOL_PARTNER_ROOM_BUBBLE_INFO_STYLE = {
         }
 
         &:first-of-type {
-          background-image: url('https://assets.triple.guide/images/partners-center/talk_send_16.svg');
+          background-image: url('${getSVG(RETRY_SVG)}');
           background-size: 16px 16px;
         }
 
         &:last-of-type {
-          background-image: url('https://assets.triple.guide/images/partners-center/close_12.svg');
+          background-image: url('${getSVG(DELETE_SVG)}');
           background-size: 12px 12px;
         }
       }

--- a/packages/tds-widget/src/chat/messages/messages.stories.tsx
+++ b/packages/tds-widget/src/chat/messages/messages.stories.tsx
@@ -1,6 +1,13 @@
 import { ComponentProps } from 'react'
+import { createGlobalStyle } from 'styled-components'
 
 import { ScrollProvider } from '../chat'
+import {
+  NOL_PARTNER_ROOM_BUBBLE_INFO_STYLE,
+  NOL_PARTNER_ROOM_BUBBLE_STYLE as BASE_NOL_PARTNER_ROOM_BUBBLE_STYLE,
+} from '../bubble'
+import { NolThemeProvider } from '../nol-theme-provider'
+import { NOL_COLOR } from '../reservation-info/reservation-info.stories'
 
 import MessagesComponent from './'
 
@@ -352,5 +359,155 @@ export const MessagesWithDateDivider = {
       },
     },
     hasDateDivider: true,
+  },
+}
+
+const NolGlobalStyle = createGlobalStyle`
+  html {
+    text-size-adjust: none;
+    -webkit-touch-callout: none;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    font-size: 62.5%;
+    background-color: #fff;
+  }
+
+  body {
+    font-weight: normal;
+    font-size: 1.3rem;
+    line-height: 1.3;
+
+    * {
+      letter-spacing: 0;
+      word-spacing: 0;
+    }
+}
+`
+
+export const NolMessages = {
+  render: (args: ComponentProps<typeof MessagesComponent>) => (
+    <NolThemeProvider theme={NOL_COLOR}>
+      <ScrollProvider>
+        <NolGlobalStyle />
+        <MessagesComponent {...args} />
+      </ScrollProvider>
+    </NolThemeProvider>
+  ),
+  args: {
+    messages: [
+      {
+        type: 'text',
+        value: { message: '안녕하세요.' },
+        id: 'text message',
+        sender: {
+          id: 'test user',
+          profile: {
+            name: 'test user',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1).toISOString(),
+        thanks: { count: 1, haveMine: false },
+      },
+      {
+        type: 'text',
+        value: { message: '안녕하세요.' },
+        id: 'my text message',
+        sender: {
+          id: 'test',
+          profile: {
+            name: 'test',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1).toISOString(),
+      },
+      {
+        type: 'text',
+        value: { message: '연속 두번째로 보내는 메시지 입니다.' },
+        id: 'my text message 2',
+        sender: {
+          id: 'test',
+          profile: {
+            name: 'test',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1).toISOString(),
+      },
+    ],
+    pendingMessages: [
+      {
+        type: 'text',
+        value: { message: '보내는 중인 메시지.' },
+        id: 'text message pending',
+        sender: {
+          id: 'test',
+          profile: {
+            name: 'test',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+        createdAt: new Date(2022, 10, 1).toISOString(),
+      },
+    ],
+    failedMessages: [
+      {
+        type: 'text',
+        value: { message: '실패한 메시지 메시지.' },
+        id: 'text message pending',
+        sender: {
+          id: 'test',
+          profile: {
+            name: 'test',
+            photo:
+              'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+          },
+          unregistered: false,
+          unfriended: false,
+        },
+      },
+    ],
+    me: {
+      id: 'test',
+      profile: {
+        name: '테스트',
+        photo:
+          'https://assets.triple-dev.titicaca-corp.com/images/app-download@2x.png',
+      },
+    },
+    customBubble: {
+      another: (message: { id: string; value: { text: string } }) => {
+        return (
+          <div key={message.id} css={{ display: 'inline-block' }}>
+            {message.value.text}
+          </div>
+        )
+      },
+    },
+    hasDateDivider: true,
+    displayTarget: 'TNA_PARTNER',
+    onRetry: () => {},
+    onRetryCancel: () => {},
+    bubbleStyle: {
+      ...BASE_NOL_PARTNER_ROOM_BUBBLE_STYLE,
+      sent: BASE_NOL_PARTNER_ROOM_BUBBLE_STYLE.white,
+      received: BASE_NOL_PARTNER_ROOM_BUBBLE_STYLE.blue,
+    },
+    bubbleInfoStyle: NOL_PARTNER_ROOM_BUBBLE_INFO_STYLE,
+    showProfilePhoto: false,
+    spacing: { message: 6 },
   },
 }

--- a/packages/tds-widget/src/chat/reservation-info/reservation-info.stories.tsx
+++ b/packages/tds-widget/src/chat/reservation-info/reservation-info.stories.tsx
@@ -4,7 +4,7 @@ import { NolThemeProvider } from '../nol-theme-provider'
 
 import { ReservationInfo, type ReservationInfoProps } from './reservation-info'
 
-const NOL_COLOR = {
+export const NOL_COLOR = {
   // black
   'color-neutral-b-100': 'rgba(41, 41, 45, 1)',
   'color-neutral-b-80': 'rgba(41, 41, 45, 0.8)',


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

[TPB-3001]
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- 네트워크 없는 경우에도 실패 아이콘이 노출되도록 svg를 가지고 있도록 수정합니다.
- 스토리북에 놀 메시지를 추가합니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
https://617b7c4431c922004a42c7cc-igrtthjywu.chromatic.com/?path=/story/tds-widget-chat-messages--nol-messages

<img width="1055" alt="Screenshot 2025-04-15 at 8 14 42 AM" src="https://github.com/user-attachments/assets/c32e95ca-0e6c-45f3-b79f-9764fd37ed27" />


[TPB-3001]: https://yanoljagroup.atlassian.net/browse/TPB-3001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ