### PR TITLE
[DMTALK] 채팅창 상세에서 상품/예약정보 접기펼치기 영역 확대

### DIFF
--- a/packages/tds-widget/src/chat/reservation-info/elements.tsx
+++ b/packages/tds-widget/src/chat/reservation-info/elements.tsx
@@ -99,6 +99,7 @@ export const TitleContainer = styled(BaseContainer)`
   display: flex;
   flex-direction: row;
   gap: 16px;
+  cursor: pointer;
 
   &:has(${ArrowButton}) {
     padding-right: 18px;
@@ -126,6 +127,7 @@ export const Label = styled(Text).attrs({
   padding: 3px 6px;
   border-radius: 6px;
   height: fit-content;
+  cursor: pointer;
 
   ${({ color, theme: { nol = {} } }) =>
     color && getLabelColorVariants(color, nol)}

--- a/packages/tds-widget/src/chat/reservation-info/reservation-info.tsx
+++ b/packages/tds-widget/src/chat/reservation-info/reservation-info.tsx
@@ -69,7 +69,10 @@ function ReservationInfoImpl(
         css={{ alignItems: hasDetails || expanded ? 'flex-start' : 'center' }}
       >
         {thumbnail ? <Thumbnail src={thumbnail} small={!hasDetails} /> : null}
-        <DetailContainer expanded={expanded}>
+        <DetailContainer
+          expanded={expanded}
+          onClick={() => setExpanded(!expanded)}
+        >
           <TitleContainer>
             {title ? (
               <Title ref={titleRef} maxLines={expanded ? undefined : 1}>
@@ -84,7 +87,6 @@ function ReservationInfoImpl(
             {expandable ? (
               <ArrowButton
                 expanded={expanded}
-                onClick={() => setExpanded(!expanded)}
                 css={{ top: hasDetails ? '5px' : '10px' }}
               >
                 <ArrowTopIcon />


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

[TPB-3003]
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

- 채팅창 상세에서 상품/예약정보 접기펼치기 영역을 타이틀 영역까지 확대합니다.
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->


[TPB-3003]: https://yanoljagroup.atlassian.net/browse/TPB-3003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ