### PR TITLE
[DMTALK] 취소 후 만료정책 추가

### DIFF
--- a/packages/tds-widget/src/chat/types/room.ts
+++ b/packages/tds-widget/src/chat/types/room.ts
@@ -92,7 +92,7 @@ export type ChatRoomMetadata<T, U = ChatRoomMetadataMap> = T extends keyof U
   ? U[T]
   : undefined
 
-type ExpirePolicyType = 'AFTER_DATE_OF_USE' | 'AFTER_MESSAGE'
+type ExpirePolicyType = 'AFTER_DATE_OF_USE' | 'AFTER_MESSAGE' | 'AFTER_CANCEL'
 
 interface ExpirePolicyBase {
   type: ExpirePolicyType
@@ -103,18 +103,26 @@ interface ExpirePolicyBase {
     seconds: number
     milliSeconds: number
   }
+  baseAt?: string
+  expiredAt?: string
 }
 
 interface AfterDateOfUsePolicy extends ExpirePolicyBase {
   type: 'AFTER_DATE_OF_USE'
-  dateOfUseEndsAt: string
 }
 
 interface AfterMessagePolicy extends ExpirePolicyBase {
   type: 'AFTER_MESSAGE'
 }
 
-type ExpirePolicy = AfterDateOfUsePolicy | AfterMessagePolicy
+interface AfterCancelPolicy extends ExpirePolicyBase {
+  type: 'AFTER_CANCEL'
+}
+
+type ExpirePolicy =
+  | AfterDateOfUsePolicy
+  | AfterMessagePolicy
+  | AfterCancelPolicy
 
 /**
  * @deprecated


### PR DESCRIPTION
## PR 설명
취소 후 만료 정책이 추가됨에 따라 이를 ExpirePolicy에 반영합니다.
만료 정책의 응답 값 수정을 반영합니다.
https://nol-chat-api.proxy.dev.triple.zone/docs/swagger-ui/index.html#/room-external-controller/getRoom


## 변경 내역
- ExpirePolicyBase 필드 추가
- AfterDateOfUsePolicy 삭제된 필드 반영
- type AFTER_CANCEL, AfterCancelPolicy 추가

## 체크리스트

## 스크린샷 & URL
