### PR TITLE
moment 라이브러리를 date-fns로 변경합니다. 

### DIFF
--- a/packages/tds-widget/src/review/components/review-element/index.tsx
+++ b/packages/tds-widget/src/review/components/review-element/index.tsx
@@ -420,7 +420,7 @@ export function ReviewElement({
                 margin: '2px 0 0',
               }}
             >
-              <>{formatTimestamp(new Date(reviewedAt))}</>
+              <>{formatTimestamp(reviewedAt)}</>
               <MoreIcon
                 src="https://assets.triple.guide/images/btn-review-more@4x.png"
                 onClick={handleMenuClick}

--- a/packages/tds-widget/src/review/components/review-element/index.tsx
+++ b/packages/tds-widget/src/review/components/review-element/index.tsx
@@ -9,9 +9,9 @@ import {
   useClientAppActions,
 } from '@titicaca/triple-web'
 import { formatTimestamp } from '@titicaca/view-utilities'
-import moment from 'moment'
 import { PropsWithChildren, useCallback, useState } from 'react'
 import { styled, css } from 'styled-components'
+import { getMonth, getYear } from 'date-fns'
 
 import { BaseReviewFragment } from '../../data/graphql'
 import {
@@ -116,7 +116,7 @@ export function ReviewElement({
     blinded,
     comment,
     recentTrip,
-    reviewedAt: originReviewedAt,
+    reviewedAt,
     rating,
     media,
     replyBoard,
@@ -290,7 +290,6 @@ export function ReviewElement({
     { triggeredEventAction: '리뷰_댓글_선택' },
   )
 
-  const reviewedAt = moment(originReviewedAt).format()
   const reviewExposureAction = `${
     isFullList ? '리뷰_전체보기_노출' : '리뷰_노출'
   }`
@@ -421,7 +420,7 @@ export function ReviewElement({
                 margin: '2px 0 0',
               }}
             >
-              <>{formatTimestamp(reviewedAt)}</>
+              <>{formatTimestamp(new Date(reviewedAt))}</>
               <MoreIcon
                 src="https://assets.triple.guide/images/btn-review-more@4x.png"
                 onClick={handleMenuClick}
@@ -481,8 +480,8 @@ function RateDescription({
 function ReviewDayInfo({ visitDate }: { visitDate: Date }) {
   const t = useTranslation()
 
-  const visitYear = moment(visitDate).year()
-  const visitMonth = moment(visitDate).month() + 1
+  const visitYear = getYear(visitDate)
+  const visitMonth = getMonth(visitDate) + 1
 
   return (
     <Text size={13} color="gray700" lineHeight="13px">

--- a/packages/tds-widget/src/review/components/review-element/pinned-message.tsx
+++ b/packages/tds-widget/src/review/components/review-element/pinned-message.tsx
@@ -1,7 +1,7 @@
 import { MouseEventHandler, useEffect, useRef, useState } from 'react'
-import moment from 'moment'
 import { Button, FlexBox, Text } from '@titicaca/tds-ui'
 import { useTranslation } from '@titicaca/triple-web'
+import { format } from 'date-fns'
 
 import { BasePinnedMessageFragment } from '../../data/graphql'
 
@@ -74,7 +74,7 @@ export function PinnedMessage({
             fontWeight: 700,
           }}
         >
-          {moment(updatedAt).format('MM.DD')}
+          {format(new Date(updatedAt), 'M.d')}
         </Text>
       </FlexBox>
       <Text

--- a/packages/tds-widget/src/review/mocks/review-element.duo-images.json
+++ b/packages/tds-widget/src/review/mocks/review-element.duo-images.json
@@ -80,5 +80,19 @@
     "purchaseCount": 2,
     "displayName": "디럭스 트윈룸, 호수 전망 + 조식 성인2 포함 + 워터파크 + 골프장 스페셜 골드 프리미엄 얼리버드 특가 (키즈 라운지 추가금 발생)",
     "purchaseDate": "2023-12-12"
+  },
+  "replyBoard": {
+    "id": "board-id",
+    "resourceId": "resource-id",
+    "resourceType": "hotel",
+    "pinnedMessages": [
+      {
+        "createdAt": "2023-12-15T05:09:41.416Z",
+        "updatedAt": "2023-12-15T05:09:41.416Z",
+        "content": {
+          "text": "리뷰에 대해 파트너가 작성한 답변입니다."
+        }
+      }
+    ]
   }
 }

--- a/packages/triple-document/package.json
+++ b/packages/triple-document/package.json
@@ -52,7 +52,7 @@
     "@titicaca/triple-header": "workspace:*",
     "@titicaca/type-definitions": "workspace:*",
     "@titicaca/view-utilities": "workspace:*",
-    "moment": "^2.30.1",
+    "date-fns": "^3.6.0",
     "qs": "^6.14.0"
   },
   "devDependencies": {

--- a/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
+++ b/packages/triple-document/src/elements/coupon/coupon-download-buttons.tsx
@@ -5,7 +5,7 @@ import { styled } from 'styled-components'
 import { VerificationType, useUserVerification } from '@titicaca/tds-widget'
 import { authGuardedFetchers, captureHttpError } from '@titicaca/fetcher'
 import { useInterval } from '@titicaca/react-hooks'
-import moment from 'moment'
+import { isAfter, isEqual } from 'date-fns'
 
 import { CouponData } from '../../types'
 
@@ -40,9 +40,8 @@ export const DEFAULT_BUTTON_COLOR = {
 
 function useDownloadTimePassed(time: string | undefined) {
   const calculator = useCallback(() => {
-    return (
-      time === undefined || moment(new Date()).isSameOrAfter(new Date(time))
-    )
+    const now = new Date()
+    return time === undefined || isAfter(now, time) || isEqual(now, time)
   }, [time])
 
   const [passed, setPassed] = useState(calculator())

--- a/packages/view-utilities/package.json
+++ b/packages/view-utilities/package.json
@@ -40,9 +40,9 @@
   },
   "dependencies": {
     "@titicaca/type-definitions": "workspace:*",
+    "date-fns": "^3.6.0",
     "haversine": "^1.1.1",
     "humps": "^2.0.1",
-    "moment": "^2.30.1",
     "qs": "^6.14.0"
   },
   "devDependencies": {

--- a/packages/view-utilities/src/timestamp.ts
+++ b/packages/view-utilities/src/timestamp.ts
@@ -1,24 +1,38 @@
-import moment from 'moment'
-import 'moment/locale/ko'
+import {
+  isBefore,
+  subMinutes,
+  formatDistanceToNow,
+  setDefaultOptions,
+  subWeeks,
+  format,
+} from 'date-fns'
+import { ko } from 'date-fns/locale'
 
-moment.updateLocale('ko', {
-  relativeTime: {
-    s: '방금',
+setDefaultOptions({
+  locale: {
+    ...ko,
+    formatDistance: (token, count, options) => {
+      if (token === 'lessThanXMinutes' && count === 1) {
+        return '방금'
+      }
+      if (token === 'xMinutes') {
+        return `${count}분${options?.addSuffix ? ' 전' : ''}`
+      }
+      if (token === 'aboutXHours') {
+        return `${count}시간${options?.addSuffix ? ' 전' : ''}`
+      } else if (token === 'xDays' && count <= 7) {
+        return `${count}일${options?.addSuffix ? ' 전' : ''}`
+      }
+      return ko.formatDistance(token, count, options)
+    },
   },
 })
-moment.relativeTimeRounding(Math.floor)
-moment.relativeTimeThreshold('s', 60)
-moment.relativeTimeThreshold('m', 60)
-moment.relativeTimeThreshold('h', 24)
 
-export function formatTimestamp(date: string) {
-  const createdAt = moment(date)
-
-  if (moment().subtract(1, 'minute').isBefore(createdAt)) {
-    return createdAt.fromNow(true)
-  } else if (moment().subtract(1, 'week').isBefore(createdAt)) {
-    return createdAt.fromNow()
+export function formatTimestamp(date: Date) {
+  if (isBefore(subMinutes(new Date(), 1), date)) {
+    return formatDistanceToNow(date)
+  } else if (isBefore(subWeeks(new Date(), 1), date)) {
+    return formatDistanceToNow(date, { addSuffix: true })
   }
-
-  return createdAt.format('YYYY.M.D')
+  return format(date, 'y.M.d')
 }

--- a/packages/view-utilities/src/timestamp.ts
+++ b/packages/view-utilities/src/timestamp.ts
@@ -28,7 +28,7 @@ setDefaultOptions({
   },
 })
 
-export function formatTimestamp(date: Date) {
+export function formatTimestamp(date: string | Date) {
   if (isBefore(subMinutes(new Date(), 1), date)) {
     return formatDistanceToNow(date)
   } else if (isBefore(subWeeks(new Date(), 1), date)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,9 +719,9 @@ importers:
       '@titicaca/view-utilities':
         specifier: workspace:*
         version: link:../view-utilities
-      moment:
-        specifier: ^2.30.1
-        version: 2.30.1
+      date-fns:
+        specifier: ^3.6.0
+        version: 3.6.0
       qs:
         specifier: ^6.14.0
         version: 6.14.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -955,15 +955,15 @@ importers:
       '@titicaca/type-definitions':
         specifier: workspace:*
         version: link:../type-definitions
+      date-fns:
+        specifier: ^3.6.0
+        version: 3.6.0
       haversine:
         specifier: ^1.1.1
         version: 1.1.1
       humps:
         specifier: ^2.0.1
         version: 2.0.1
-      moment:
-        specifier: ^2.30.1
-        version: 2.30.1
       qs:
         specifier: ^6.14.0
         version: 6.14.0


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
moment 라이브러리를 사용하고 있던 코드를 date-fns를 사용하도록 수정합니다. `date-picker`의 경우 `date-picker` 패키지의 업데이트가 필요하여 @dongoc 이 따로 작업 중이십니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

`formatTimestamp` 함수를 사용할 경우 기존에 `한 시간 전` 이라고 표기되던 것이 `1시간 전`으로 표기됩니다. 
