### PR TITLE
[DMTALK-183] 링크 두번 열리는 오류 수정

### DIFF
--- a/packages/router/src/links/use-open-native-link.ts
+++ b/packages/router/src/links/use-open-native-link.ts
@@ -20,7 +20,10 @@ export function useOpenNativeLink() {
     }
 
     const href = (window.location.href = `${appUrlScheme}://${path}`)
-    window.open(href)
+
+    if (href !== `${appUrlScheme}://${path}`) {
+      window.open(href)
+    }
   }
 
   return openNativeLink

--- a/packages/router/src/links/use-open-native-link.ts
+++ b/packages/router/src/links/use-open-native-link.ts
@@ -19,11 +19,7 @@ export function useOpenNativeLink() {
       return showAppInstallCtaModal()
     }
 
-    const href = (window.location.href = `${appUrlScheme}://${path}`)
-
-    if (href !== `${appUrlScheme}://${path}`) {
-      window.open(href)
-    }
+    window.location.href = `${appUrlScheme}://${path}`
   }
 
   return openNativeLink

--- a/packages/tds-widget/src/review/components/review-placeholder-with-rating.tsx
+++ b/packages/tds-widget/src/review/components/review-placeholder-with-rating.tsx
@@ -158,7 +158,10 @@ export function ReviewsPlaceholder({
         <FilterPlaceholder
           isMorePage={isMorePage}
           hasReviews={hasReviews}
-          onClick={() => handleClick()}
+          onClick={(e) => {
+            e.stopPropagation()
+            handleClick()
+          }}
         />
       ) : (
         <DefaultPlaceholder placeholderText={placeholderText} />


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
- `navigate`로 인앱 페이지 이동 시 iOS에서 두번 이동되는 오류를 수정합니다.
  - `window.location.href`, `window.open`이 중복 실행됨
- 리뷰 리스트 > '전체 리뷰 보기' 버튼 클릭 시 이벤트 버블링으로 인해 페이지 이동이 중복해서 발생하는 오류를 수정합니다.

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->
- [x] chat-web (https://github.com/titicacadev/triple-chat-web/pull/503) DEV
- [x] mileage-web (https://github.com/titicacadev/triple-mileage-web-v2/pull/170) DEV
- [x] reviews-web (https://github.com/titicacadev/triple-reviews-web/pull/359) DEV

## 스크린샷 & URL
- as-is

|전체보기 페이지|유저 프로필|
|--|--|
|iOS: 3번 이동, Android: 2번 이동|iOS: 2번 이동, Android: 정상|
|https://github.com/user-attachments/assets/2e03e02d-ef62-4d93-a645-578c1df4adf0|https://github.com/user-attachments/assets/55b1dd00-bd4b-45ed-ab5e-b6647c00efa0|

- to-be
https://github.com/user-attachments/assets/2a668dc5-dcd2-425a-87fa-81f88d7f2709

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
