### PR TITLE
[DMTALK-217] welcomeMessage 전송시 UI 오류 수정

### DIFF
--- a/packages/tds-widget/src/chat/chat/chat-room-messages/chat-message-context.tsx
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/chat-message-context.tsx
@@ -47,6 +47,7 @@ export interface ChatMessagesContextValue<T = UserType> {
   >
   welcomeMessages: WelcomeMessageInterface<T>[]
   initMessages: () => Promise<void>
+  useTripleChat: boolean
 }
 
 export const ChatApiServiceContext = createContext<ChatApiService | null>(null)
@@ -124,6 +125,7 @@ export function ChatMessagesProvider<T = UserType>({
     dispatch,
     welcomeMessages,
     initMessages,
+    useTripleChat,
   } as unknown as ChatMessagesContextValue
 
   return (

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
@@ -66,6 +66,7 @@ export function useChatMessages<T = UserType>(
     dispatch,
     initMessages,
     welcomeMessages,
+    useTripleChat,
   } = useChatMessagesContext<T>()
   const api = useChatApiService<T>()
 
@@ -421,28 +422,29 @@ export function useChatMessages<T = UserType>(
       } = {},
     ) => {
       if (message && message.payload) {
-        const messageWithNumberId = ensureMessageWithNumberId(message)
+        const typeEnsuredMessage = useTripleChat
+          ? message
+          : ensureMessageWithNumberId(message)
         /**
             pendingMessage와 messages 간의 부드러운 UI 전환을 위해
             me의 메세지일 경우 handleSendMessageAction 함수 내에서 dispatch합니다.
             coupon 메세지는 서버에서 직접 전송되므로 항상 푸셔 이벤트로 dispatch합니다.
           */
         const myMessage =
-          getUserIdentifier(me) ===
-          getUserIdentifier(messageWithNumberId.sender)
-        if (!myMessage || messageWithNumberId.payload.type === 'coupon') {
+          getUserIdentifier(me) === getUserIdentifier(typeEnsuredMessage.sender)
+        if (!myMessage || typeEnsuredMessage.payload.type === 'coupon') {
           dispatch({
             action: MessagesActions.NEW,
-            messages: [messageWithNumberId],
+            messages: [typeEnsuredMessage],
             filterPendingMessages: isWelcomeMessagePendingRef.current
-              ? filterPendingMessage(messageWithNumberId)
+              ? filterPendingMessage(typeEnsuredMessage)
               : undefined,
           })
         }
-        onComplete?.(messageWithNumberId, myMessage)
+        onComplete?.(typeEnsuredMessage, myMessage)
         if (
           scrollToBottomOnNewMessage ||
-          (myMessage && messageWithNumberId.payload.type === 'coupon')
+          (myMessage && typeEnsuredMessage.payload.type === 'coupon')
         ) {
           triggerScrollToBottom()
         }

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
@@ -290,6 +290,15 @@ export function useChatMessages<T = UserType>(
 
     /** 첫 렌더링 시에만 자동 메세지를 보내도록 합니다. */
     if (isWelcomeMessagePendingRef.current) {
+      dispatch({
+        action: MessagesActions.PENDING,
+        message: tempMessage,
+      })
+      setTimeout(() => {
+        triggerScrollToBottom()
+      }, 100)
+      skipPending = true
+
       await handleSendWelcomeMessage({
         room: currentRoom as ChatRoomDetailInterface,
         me: roomMemberMe,

--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
@@ -412,26 +412,28 @@ export function useChatMessages<T = UserType>(
       } = {},
     ) => {
       if (message && message.payload) {
+        const messageWithNumberId = ensureMessageWithNumberId(message)
         /**
             pendingMessage와 messages 간의 부드러운 UI 전환을 위해
             me의 메세지일 경우 handleSendMessageAction 함수 내에서 dispatch합니다.
             coupon 메세지는 서버에서 직접 전송되므로 항상 푸셔 이벤트로 dispatch합니다.
           */
         const myMessage =
-          getUserIdentifier(me) === getUserIdentifier(message.sender)
-        if (!myMessage || message.payload.type === 'coupon') {
+          getUserIdentifier(me) ===
+          getUserIdentifier(messageWithNumberId.sender)
+        if (!myMessage || messageWithNumberId.payload.type === 'coupon') {
           dispatch({
             action: MessagesActions.NEW,
-            messages: [message],
+            messages: [messageWithNumberId],
             filterPendingMessages: isWelcomeMessagePendingRef.current
-              ? filterPendingMessage(message)
+              ? filterPendingMessage(messageWithNumberId)
               : undefined,
           })
         }
-        onComplete?.(message, myMessage)
+        onComplete?.(messageWithNumberId, myMessage)
         if (
           scrollToBottomOnNewMessage ||
-          (myMessage && message.payload.type === 'coupon')
+          (myMessage && messageWithNumberId.payload.type === 'coupon')
         ) {
           triggerScrollToBottom()
         }
@@ -589,4 +591,11 @@ function compareChatMessagePayloads<T extends ChatMessagePayloadType>(
   }
 
   return false
+}
+
+function ensureMessageWithNumberId<T>(message: ChatMessageInterface<T>) {
+  return {
+    ...message,
+    id: typeof message.id === 'number' ? message.id : Number(message.id),
+  }
 }

--- a/packages/tds-widget/src/chat/chat/messages-reducer.ts
+++ b/packages/tds-widget/src/chat/chat/messages-reducer.ts
@@ -61,6 +61,9 @@ export type MessagesAction<Message extends MessageBase<Id>, Id = string> =
   | {
       action: MessagesActions.NEW
       messages: Message[]
+      filterPendingMessages?: (
+        pendingMessages: UnsentMessage<Message, Id>[],
+      ) => UnsentMessage<Message, Id>[]
     }
   | {
       action: MessagesActions.UPDATE
@@ -118,6 +121,9 @@ function MessagesReducer<Message extends MessageBase<Id>, Id = string>(
     case MessagesActions.NEW:
       return {
         ...state,
+        ...(action.filterPendingMessages && {
+          pendingMessages: action.filterPendingMessages(state.pendingMessages),
+        }),
         messages: deduplicateAndSortMessages<Message, Id>(
           state.messages,
           action.messages,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

- welcomeMessage 전송 시 UI 오류를 수정합니다.
  - `triple-chat`에서는 message의 id가 string로 사용되고, `nol-chat`에서는 number로 사용되고 있으며, pusher의 `onSendMessageEvent`를 통해 전달되는 message의 id는 string 형이라, `nol-chat`에서는 message-context에서 가지고 있는 message id 형이 달라, 메시지 중복이 발생하고 있어 같은 타입으로 변환하는 로직을 추가합니다. 
  - 웰컴 메시지의 경우 `onSendMessageEvent` 이벤트로 부터 `message`에 추가되는 타이밍에 `pendingMessage`에서 제거되지 않아 중복 노출되는 케이스가 있어 filtering 로직을 추가합니다.
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

- as-is
<img width="372" alt="스크린샷 2025-06-25 오전 11 38 36" src="https://github.com/user-attachments/assets/ed6e09f3-4492-496e-9d64-dd149ba88ada" />


https://github.com/user-attachments/assets/b4546244-fee4-4fcc-a605-1332e85bf70b



- to-be

https://github.com/user-attachments/assets/b79669ac-0a1b-4025-a687-444b5bb54b6b




<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->

