### PR TITLE
[DMTALK-265] private 메시지 상태 및 스타일 추가

### DIFF
--- a/packages/tds-widget/src/chat/chat/chat-room-messages/messages.tsx
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/messages.tsx
@@ -96,7 +96,7 @@ function convertMessages<T = UserType>(
         | OriginalMessagesPropTypes<T>['pendingMessages'],
       { displayTarget: messageDisplayTarget, ...message },
     ) => {
-      const payload = getDisplayedPayload({
+      const { payload, privateMessage = false } = getDisplayedPayload({
         payload: message.payload,
         alternativePayload: message.alternative,
         messageDisplayTarget,
@@ -112,6 +112,7 @@ function convertMessages<T = UserType>(
         {
           ...message,
           id: message.id,
+          private: privateMessage,
           sender,
           ...('createdAt' in message && { createdAt: message.createdAt }),
           blinded: !!message.blindedAt,
@@ -140,12 +141,12 @@ function getDisplayedPayload<T = UserType>({
   roomDisplayTarget: T
 }) {
   if (!messageDisplayTarget || messageDisplayTarget === 'all') {
-    return payload
+    return { payload }
   }
   if (messageDisplayTarget.includes(roomDisplayTarget)) {
-    return payload
+    return { payload, privateMessage: true }
   }
-  return alternativePayload
+  return { payload: alternativePayload }
 }
 
 function getMessageTypeAndValue<T = UserType>(

--- a/packages/tds-widget/src/chat/messages/index.tsx
+++ b/packages/tds-widget/src/chat/messages/index.tsx
@@ -14,6 +14,11 @@ import { MessageBase, MessageInterface } from './type'
 import { isBubbleType, compareSender, compareDate } from './utils'
 import { DateDivider } from './date-divider'
 
+interface CustomBubbleStyle {
+  css?: CSSProp
+  alteredTextColor?: CSSProp
+}
+
 interface MessagesProp<
   Message extends MessageBase<User>,
   User extends UserInterface,
@@ -39,11 +44,9 @@ interface MessagesProp<
   bubbleStyle?: {
     borderRadius?: number
     arrowRadius?: number
-    received?: {
-      css?: CSSProp
-      alteredTextColor?: CSSProp
-    }
-    sent?: { css?: CSSProp; alteredTextColor?: CSSProp }
+    received?: CustomBubbleStyle
+    sent?: CustomBubbleStyle
+    private?: CustomBubbleStyle
   }
   spacing?: {
     message?: number
@@ -110,8 +113,21 @@ export default function Messages<
     my: boolean
     hasArrow?: boolean
   }) {
-    const { id, sender, type, value, blinded, deleted, createdAt, ...rest } =
-      message
+    const {
+      id,
+      sender,
+      private: isPrivate,
+      type,
+      value,
+      blinded,
+      deleted,
+      createdAt,
+      ...rest
+    } = message
+
+    const customBubbleStyle =
+      (isPrivate && bubbleStyle?.private) ||
+      (my ? bubbleStyle?.sent : bubbleStyle?.received)
 
     const CustomBubble = customBubble?.[type]
     if (CustomBubble) {
@@ -128,11 +144,7 @@ export default function Messages<
                   ? ALTERNATIVE_TEXT_MESSAGE.blinded
                   : ALTERNATIVE_TEXT_MESSAGE.deleted
             }
-            textColor={
-              my
-                ? bubbleStyle?.sent?.alteredTextColor
-                : bubbleStyle?.received?.alteredTextColor
-            }
+            textColor={customBubbleStyle?.alteredTextColor}
             hasArrow={hasArrow}
           />
         )
@@ -155,16 +167,12 @@ export default function Messages<
         unfriended={sender.unfriended}
         type={type}
         value={value}
-        alteredTextColor={
-          my
-            ? bubbleStyle?.sent?.alteredTextColor
-            : bubbleStyle?.received?.alteredTextColor
-        }
+        alteredTextColor={customBubbleStyle?.alteredTextColor}
         hasArrow={hasArrow}
         onOpenMenu={() => onOpenMenu?.(message)}
         onParentMessageClick={onParentMessageClick}
         fullTextViewAvailable={fullTextViewAvailable}
-        css={my ? bubbleStyle?.sent?.css : bubbleStyle?.received?.css}
+        css={customBubbleStyle?.css}
         arrowRadius={bubbleStyle?.arrowRadius}
         borderRadius={bubbleStyle?.borderRadius}
         {...rest}

--- a/packages/tds-widget/src/chat/messages/type.ts
+++ b/packages/tds-widget/src/chat/messages/type.ts
@@ -13,6 +13,7 @@ export interface MessageBase<User extends UserInterface> {
   blinded?: boolean
   deleted?: boolean
   thanks?: { count: number; haveMine: boolean }
+  private?: boolean
 }
 
 export type MessageInterface<


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

- displayTarget이 all이 아닌 메시지에 대한 스타일 variant가 필요해 message interface에 private 필드를 추가하고, bubble style에서 제어할 수 있도록 합니다.

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<img width="536" alt="스크린샷 2025-05-14 오전 11 13 34" src="https://github.com/user-attachments/assets/ff85c3d9-7167-4734-a153-d6ad1b0a9d95" />


<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
