### PR TITLE
[DMTALK-316] message payload 내 extra 노출

### DIFF
--- a/packages/tds-widget/src/chat/chat/chat-room-messages/messages.tsx
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/messages.tsx
@@ -109,6 +109,7 @@ function convertMessages<T = UserType>(
       blinded: !!message.blindedAt,
       type,
       value,
+      extra: message.payload?.extra,
       ...(showReactions &&
         message.reactions?.thanks && {
           thanks: message.reactions.thanks,

--- a/packages/tds-widget/src/chat/index.ts
+++ b/packages/tds-widget/src/chat/index.ts
@@ -1,6 +1,6 @@
 export * from './types'
 export * from './bubble'
-export * as BubbleContainer from './bubble-container'
+export * from './bubble-container'
 export * from './chat'
 export * from './utils'
 export * from './navbar'

--- a/packages/tds-widget/src/chat/messages/index.tsx
+++ b/packages/tds-widget/src/chat/messages/index.tsx
@@ -59,6 +59,11 @@ interface MessagesProp<
   onParentMessageClick?: (id: MessageInterface<Message, User>['id']) => void
   onUserClick?: (userId: string, unregistered: boolean) => void
   showProfilePhoto?: boolean
+  /**
+   * message.payload의 extra를 렌더하는 컴포넌트
+   * message의 하위에
+   */
+  BubbleExtra?: ComponentType<Required<Pick<MessageBase<User>, 'extra'>>>
 }
 
 export default function Messages<
@@ -87,6 +92,7 @@ export default function Messages<
   bubbleInfoStyle,
   spacing,
   showProfilePhoto = true,
+  BubbleExtra,
   ...bubbleProps
 }: MessagesProp<Message, User> &
   Omit<
@@ -283,6 +289,9 @@ export default function Messages<
             >
               {getBubble({ message, my, hasArrow: showProfile })}
             </BubbleContainer>
+            {message.extra && BubbleExtra && (
+              <BubbleExtra extra={message.extra} />
+            )}
           </IntersectionObserver>
         </Fragment>
       )

--- a/packages/tds-widget/src/chat/messages/index.tsx
+++ b/packages/tds-widget/src/chat/messages/index.tsx
@@ -61,7 +61,7 @@ interface MessagesProp<
   showProfilePhoto?: boolean
   /**
    * message.payload의 extra를 렌더하는 컴포넌트
-   * message의 하위에
+   * 해당 메시지 하단에 렌더링됨
    */
   BubbleExtra?: ComponentType<Required<Pick<MessageBase<User>, 'extra'>>>
 }

--- a/packages/tds-widget/src/chat/messages/type.ts
+++ b/packages/tds-widget/src/chat/messages/type.ts
@@ -13,6 +13,7 @@ export interface MessageBase<User extends UserInterface> {
   blinded?: boolean
   deleted?: boolean
   thanks?: { count: number; haveMine: boolean }
+  extra?: Record<string, unknown>
 }
 
 export type MessageInterface<

--- a/packages/tds-widget/src/chat/types/message.ts
+++ b/packages/tds-widget/src/chat/types/message.ts
@@ -54,6 +54,7 @@ export type RichItem = RichItemText | RichItemImages | RichItemButton
 
 export interface ChatMessagePayloadBase {
   type: ChatMessagePayloadType
+  extra?: Record<string, unknown>
 }
 
 interface ChatTextMessagePayload extends ChatMessagePayloadBase {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

- message payload 내 extra 노출합니다.

### 관련 PR 
  - https://github.com/titicacadev/nol-chat-center/pull/63

## 변경 내역

- message payload 내 extra 노출할 수 있도록 ExtraBubble props를 추가합니다.
  - message.payload 내 extra 필드를 활용하여 버블에 커스텀 UI를 추가합니다.
- BubbleContainer export 오류를 수정합니다.


<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL



<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
