### PR TITLE
[DMTALK-317] interactionStatusSlot 추가

### DIFF
--- a/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
+++ b/packages/tds-widget/src/chat/chat/chat-room-messages/use-chat-room-messages.ts
@@ -535,6 +535,7 @@ export function useChatMessages<T = UserType>(
     onThanksClick,
     onSendMessageEvent,
     hasPrevMessage,
+    triggerScrollToBottom,
   }
 }
 

--- a/packages/tds-widget/src/chat/messages/index.tsx
+++ b/packages/tds-widget/src/chat/messages/index.tsx
@@ -64,6 +64,10 @@ interface MessagesProp<
    * 해당 메시지 하단에 렌더링됨
    */
   BubbleExtra?: ComponentType<Required<Pick<MessageBase<User>, 'extra'>>>
+  /**
+   * pendingMessages와 failedMessages 사이에 렌더되는 컴포넌트
+   */
+  interactionStatusSlot?: JSX.Element
 }
 
 export default function Messages<
@@ -93,6 +97,7 @@ export default function Messages<
   spacing,
   showProfilePhoto = true,
   BubbleExtra,
+  interactionStatusSlot,
   ...bubbleProps
 }: MessagesProp<Message, User> &
   Omit<
@@ -314,6 +319,7 @@ export default function Messages<
           lastMessageOfPrevList: messages[messages.length - 1],
         })}
       </div>
+      {interactionStatusSlot}
       <div id="failed_messages_list">
         {renderMessages({
           listType: 'failed',


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명

- pendingMessages와 failedMessages 사이에 상태를 보여주는 영역이 필요하여 `interactionStatusSlot`을 추가합니다. 

<img width="416" alt="스크린샷 2025-05-20 오후 4 09 26" src="https://github.com/user-attachments/assets/2477ca38-68f4-4e63-b365-b08200db78d3" />

### 관련 PR
https://github.com/titicacadev/triple-chat-web/pull/519

<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
