### PR TITLE
[triple-web] multiple hash 지원

### DIFF
--- a/packages/triple-web/README.md
+++ b/packages/triple-web/README.md
@@ -48,8 +48,10 @@ addUriHash, removeUriHash 메서드에 별도의 type을 전달하지 않는다�
 
 ```jsx
 function ExampleComponent() {
-  const { uriHash } = useHashRouter()
-  const open = uriHash === 'some.unique.hash'
+  const { uriHash, hasUriHash } = useHashRouter()
+  const open = uriHash.includes('some.unique.hash')
+  // 또는
+  const open = hasUriHash('some.unique.hash')
 
   return <Popup open={open} />
 }
@@ -88,15 +90,23 @@ function ExampleComponent() {
 
 ### 사용 예시
 
+`uriHash`는 `&`로 엮인 해시값을 리턴합니다.
+
+ex) `hash.first&hash.second&hash.third`
+
+`hasUriHash`를 통해 특정 값이 해시에 존재하는지 확인합니다.
+
+ex) `hasUriHash('hash.second')`
+
 ```jsx
 function ExampleComponent() {
   const POPUP_HASH = 'popup.hash'
-  const { uriHash, addUriHash, removeUriHash } = useHashRouter()
+  const { hasUriHash, addUriHash, removeUriHash } = useHashRouter()
 
   return (
     <div>
       <button onClick={() => addUriHash(POPUP_HASH)}>팝업 열기</button>
-      <Popup open={uriHash === POPUP_HASH} onClose={() => removeUriHash()} />
+      <Popup open={hasUriHash(POPUP_HASH)} onClose={() => removeUriHash()} />
     </div>
   )
 }
@@ -116,3 +126,5 @@ function ExampleComponent() {
   - `type?`
     - `pop` : `window.history.back`을 사용하여 Hash를 제거합니다.
     - `replace` : `window.history.replaceState`를 사용하여 Hash를 제거합니다.
+- `hasUriHash: (hash:string) => boolean` : Hash값이 현재 Hash에 있는지 확인합니다.
+  - `hash`: 값의 존재를 확인할 Hash

--- a/packages/triple-web/src/hash-router/context.tsx
+++ b/packages/triple-web/src/hash-router/context.tsx
@@ -44,9 +44,18 @@ export function HashRouterProvider({ children }: { children: ReactNode }) {
   const addUriHash = useCallback<HashRouterContextValue['addUriHash']>(
     (hash, type) => {
       const url = new URL(window.location.href)
+      const currentHash = window.location.hash.replace('#', '')
 
-      if (window.location.hash) {
-        url.hash = window.location.hash.replace('#', '') + '&' + hash
+      if (currentHash) {
+        const hashArray = currentHash.split('&')
+        if (
+          hashArray.includes(hash) &&
+          process.env.NODE_ENV === 'development'
+        ) {
+          // eslint-disable-next-line no-console
+          console.warn(`❗️${hash} already exists in the hash.`)
+        }
+        url.hash = currentHash.replace('#', '') + '&' + hash
       } else {
         url.hash = hash
       }

--- a/packages/triple-web/src/hash-router/context.tsx
+++ b/packages/triple-web/src/hash-router/context.tsx
@@ -81,7 +81,7 @@ export function HashRouterProvider({ children }: { children: ReactNode }) {
           // eslint-disable-next-line no-console
           console.warn(`❗️${hash} already exists in the hash.`)
         }
-        url.hash = currentHash.replace('#', '') + '&' + hash
+        url.hash = currentHash + '&' + hash
       } else {
         url.hash = hash
       }

--- a/packages/triple-web/src/hash-router/context.tsx
+++ b/packages/triple-web/src/hash-router/context.tsx
@@ -11,10 +11,35 @@ import {
 import { useUserAgent } from '../user-agent/use-user-agent'
 
 export interface HashRouterContextValue {
+  /**
+   * @deprecated 'uriHash는 Multiple hash 값을 지원하지 않습니다. 대신 hasUriHash 메소드를 사용하세요.'
+   */
   uriHash: string
+  /**
+   *
+   * @param hash 추가할 hash 값입니다.
+   * @param type 기기 환경에 의존하지 않고 강제로 hash를 추가하고 싶을 때 지정합니다. removeUriHash와 동일한 값을 설정해야합니다.
+   */
   addUriHash: (hash: string, type?: 'push' | 'replace') => void
+  /**
+   * 현재 hash 값에서 마지막 hash를 제거합니다.
+   * @param type 기기 환경에 의존하지 않고 강제로 hash를 제거하고 싶을 때 지정합니다. addUriHash와 동일한 값을 설정해야합니다.
+   */
   removeUriHash: (type?: 'pop' | 'replace') => void
+  /**
+   *
+   * @param hash 확인할 hash 값입니다.
+   * @returns hash값이 현재 uriHash에 포함되어 있는지 여부를 반환합니다.
+   */
   hasUriHash: (hash: string) => boolean
+  /**
+   *
+   * @param sourceHash 대체될 hash 값입니다.
+   * @param targetHash 대체될 hash 값입니다.
+   *
+   * 하나의 hash가 제거되는 동시에 다른 hash를 추가해야할 때 유용합니다.
+   */
+  replaceUriHash: (sourceHash: string, targetHash: string) => void
 }
 
 export const HashRouterContext = createContext<HashRouterContextValue | null>(
@@ -98,6 +123,27 @@ export function HashRouterProvider({ children }: { children: ReactNode }) {
     [isAndroid],
   )
 
+  const replaceUriHash = useCallback(
+    (sourceHash: string, targetHash: string) => {
+      if (!window.location.hash) {
+        return
+      }
+
+      const url = new URL(window.location.href)
+      const currentHash = window.location.hash.replace('#', '')
+
+      if (currentHash.includes(sourceHash)) {
+        url.hash = currentHash.replace(sourceHash, targetHash)
+        window.history.replaceState(null, '', url)
+        window.dispatchEvent(new Event('hashchange'))
+      } else if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.warn(`❗️${sourceHash} does not exist in the hash.`)
+      }
+    },
+    [],
+  )
+
   const hasUriHash = useCallback(
     (hash: string) => {
       return uriHash.split('&').includes(hash)
@@ -110,6 +156,7 @@ export function HashRouterProvider({ children }: { children: ReactNode }) {
     addUriHash,
     removeUriHash,
     hasUriHash,
+    replaceUriHash,
   }
 
   return (

--- a/packages/triple-web/src/hash-router/context.tsx
+++ b/packages/triple-web/src/hash-router/context.tsx
@@ -14,6 +14,7 @@ export interface HashRouterContextValue {
   uriHash: string
   addUriHash: (hash: string, type?: 'push' | 'replace') => void
   removeUriHash: (type?: 'pop' | 'replace') => void
+  hasUriHash: (hash: string) => boolean
 }
 
 export const HashRouterContext = createContext<HashRouterContextValue | null>(

--- a/packages/triple-web/src/hash-router/context.tsx
+++ b/packages/triple-web/src/hash-router/context.tsx
@@ -44,7 +44,12 @@ export function HashRouterProvider({ children }: { children: ReactNode }) {
   const addUriHash = useCallback<HashRouterContextValue['addUriHash']>(
     (hash, type) => {
       const url = new URL(window.location.href)
-      url.hash = hash
+
+      if (window.location.hash) {
+        url.hash = window.location.hash.replace('#', '') + '&' + hash
+      } else {
+        url.hash = hash
+      }
 
       if (type === 'push' || isAndroid) {
         window.history.pushState(null, '', url)
@@ -67,7 +72,16 @@ export function HashRouterProvider({ children }: { children: ReactNode }) {
       }
 
       const url = new URL(window.location.href)
-      url.hash = ''
+
+      const currentHash = window.location.hash.replace('#', '')
+      if (currentHash.includes('&')) {
+        const hashArray = currentHash.split('&')
+        hashArray.pop()
+        url.hash = hashArray.join('&')
+      } else {
+        url.hash = ''
+      }
+
       window.history.replaceState(null, '', url)
       window.dispatchEvent(new Event('hashchange'))
     },

--- a/packages/triple-web/src/hash-router/context.tsx
+++ b/packages/triple-web/src/hash-router/context.tsx
@@ -88,10 +88,18 @@ export function HashRouterProvider({ children }: { children: ReactNode }) {
     [isAndroid],
   )
 
+  const hasUriHash = useCallback(
+    (hash: string) => {
+      return uriHash.split('&').includes(hash)
+    },
+    [uriHash],
+  )
+
   const value = {
     uriHash,
     addUriHash,
     removeUriHash,
+    hasUriHash,
   }
 
   return (


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
Multiple hash를 지원합니다. 같은 값의 hash가 두 번 이상 추가될 경우 로컬 환경에서 워닝을 띄웁니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역
- `addUriHash`가 여러 hash 값을 지원하도록 수정
  - 현재 hash 뒤에 새로운 hash 값을 `&`로 연결해 덧붙입니다. 
- `removeUriHash`가 여러 hash 값을 지원하도록 수정
  - 일단 hash를 뒤에서부터 제거하는 방식을 선택했습니다.
- `hasUriHash` 메소드 추가
- Readme.md 수정 및 추가
<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 논의사항
기존 프로젝트에서 `hasUriHash`를 사용하는 방식을 적용하지 않으면 정상적으로 동작하지 않기 때문에 minor version update로 마일스톤을 할당했습니다. HashRouter의 동작과 관련해 `uriHash`는 value에서 제외하는 것이 좋을까요? 제거하면 기존 프로젝트에서 오류가 발생할 것이라 빠짐없이 수정이 가능할 것이라.. 🤔
<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL
URL : ~~~~#open.memo-modal&action-sheet.memo-more-actions 이면
<img width="496" alt="스크린샷 2025-05-28 오후 5 15 57" src="https://github.com/user-attachments/assets/c1c9bc94-0862-43d1-b318-cdfe6d9789d9" />

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
