### PR TITLE
[STAY-1323] ActionSheetItem 이 overflow 속성을 받을 수 있도록 수정(optional)

### DIFF
--- a/packages/action-sheet/src/action-sheet-item.tsx
+++ b/packages/action-sheet/src/action-sheet-item.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren } from 'react'
 import styled from 'styled-components'
+import * as CSS from 'csstype'
 
 import { useActionSheet } from './action-sheet-context'
 
@@ -9,7 +10,10 @@ export const ActionItemContainer = styled.div`
   height: 54px;
 `
 
-const ItemText = styled.div<{ checked?: boolean }>`
+const ItemText = styled.div<{
+  checked?: boolean
+  overflow?: CSS.Property.Overflow
+}>`
   flex: 1;
   height: 54px;
   line-height: 54px;
@@ -18,7 +22,7 @@ const ItemText = styled.div<{ checked?: boolean }>`
   font-weight: ${({ checked }) => (checked ? 'bold' : 'normal')};
   white-space: nowrap;
   text-overflow: ellipsis;
-  overflow: hidden;
+  overflow: ${({ overflow }) => overflow ?? 'hidden'};
 `
 
 const ItemButton = styled.a`
@@ -71,6 +75,7 @@ export interface ActionSheetItemProps extends PropsWithChildren {
   buttonLabel?: string
   icon?: string
   checked?: boolean
+  overflow?: CSS.Property.Overflow
   onClick?: () => unknown
 }
 
@@ -79,6 +84,7 @@ export const ActionSheetItem = ({
   buttonLabel,
   icon,
   checked,
+  overflow,
   onClick,
   ...props
 }: ActionSheetItemProps) => {
@@ -94,7 +100,9 @@ export const ActionSheetItem = ({
       {...props}
     >
       {icon ? <ItemIcon src={URL_BY_NAMES[icon]} /> : null}
-      <ItemText checked={checked}>{children}</ItemText>
+      <ItemText checked={checked} overflow={overflow}>
+        {children}
+      </ItemText>
       {buttonLabel ? (
         <ItemButton onClick={handleClick}>{buttonLabel}</ItemButton>
       ) : null}


### PR DESCRIPTION
## PR 설명
ActionSheetItem 내에서 아이템에 대한 툴팁 요소를 노출할 때, 다른 아이템에 의해서 가려지는 현상을 해결하기 위해 overflow 속성을 주입할 수 있도록 수정
[참고 피그마](https://www.figma.com/design/upwT9BlpaM9K23EJ6wgQsy/%EC%88%99%EC%86%8C_SRP--PDP--%EC%98%88%EC%95%BD%EA%B2%B0%EC%A0%9C--Copy-?node-id=2017-23959&p=f&m=dev)

아래 이미지처럼 노출되도록 하기 위함입니다.
![image](https://github.com/user-attachments/assets/696a2150-3ae2-45f4-a560-743e089b0514)

## 스크린샷 & URL
