### PR TITLE
[middleware] next14용 미들웨어에 applySetCookie 적용

### DIFF
--- a/packages/middlewares/src/refresh-session/next-14.ts
+++ b/packages/middlewares/src/refresh-session/next-14.ts
@@ -17,6 +17,7 @@ import { TP_SE, TP_TK } from '@titicaca/constants'
 import { serialize, SerializeOptions } from 'cookie'
 
 import { getDomain } from '../utils/get-domain'
+import { applySetCookie } from '../utils/apply-set-cookie'
 
 /**
  *
@@ -63,7 +64,6 @@ export function refreshSessionMiddleware(next: NextMiddleware) {
     >('/api/users/session/verify', options)
 
     const checkFirstTrialResponse = await handle401Error(firstTrialResponse)
-
     if (checkFirstTrialResponse !== NEED_REFRESH_IDENTIFIER) {
       captureHttpError(firstTrialResponse)
       const setCookieHeader = firstTrialResponse.headers.getSetCookie()
@@ -76,6 +76,7 @@ export function refreshSessionMiddleware(next: NextMiddleware) {
           const { name, value, ...rest } = parseString(cookie)
           response.cookies.set(name, value, { ...(rest as ResponseCookie) })
         })
+        applySetCookie(request, response)
       }
       return response
     }
@@ -98,6 +99,7 @@ export function refreshSessionMiddleware(next: NextMiddleware) {
         response.cookies.set(name, value, { ...(rest as ResponseCookie) })
       })
     }
+    applySetCookie(request, response)
     return response
   }
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
next v14용 미들웨어에도 `applySetCookie`를 적용해 페이지 request에 갱신된 세션이 적용될 수 있도록 합니다. 
<!-- PR의 목적, PR이 구현하는 기획이나 디자인(figma, slack or jira) 등 리뷰어가 참고할 내용을 적어주세요. -->

## 변경 내역

<!-- 실제 변경이 발생한 부분을 위주로 서술해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
<!-- 리뷰어가 변경점에 대해 빠르게 이해를 할 수 있도록 서술해주세요. -->

## 체크리스트

<!-- 프로젝트별로 반드시 확인해야 하는 항목을 나열해주세요. -->
<!-- 각 항목을 읽어 보시고, 해당하는 항목의 주석을 해제해주세요. -->
<!-- 조금이라도 명확하지 않은 부분이 있다면 슬랙 #triple-web-dev 채널로 질문해주세요! -->
<!-- - [x] 주요 동선의 통합 테스트를 진행하셨나요? -->
<!-- - [x] 기획자/디자이너에게 확인을 받았나요? 혹은 확인이 필요없는 이슈인가요? -->

## 스크린샷 & URL

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
<!-- 반드시 필요한 게 아니라면 생략 가능합니다. -->
<!-- 변경 사항을 확인할 수 있는 샘플 URL을 알려주세요. 바로 동작하는 링크일수록 좋습니다. -->
