### PR TITLE
[tds-widget] focus tracker에 disabled props를 추가합니다.

### DIFF
--- a/packages/tds-widget/src/map/focus-tracker.tsx
+++ b/packages/tds-widget/src/map/focus-tracker.tsx
@@ -4,19 +4,23 @@ import { PointGeoJson } from '@titicaca/type-definitions'
 
 const AUTO_ZOOM_THRESHOLD = 10
 
+interface FocusTrackerProps {
+  focusGeolocation?: PointGeoJson
+  activeAutoZoom?: boolean
+  autoZoomThreshold?: number
+  disabled?: boolean
+}
+
 export function FocusTracker({
   focusGeolocation,
   activeAutoZoom = false,
   autoZoomThreshold = AUTO_ZOOM_THRESHOLD,
-}: {
-  focusGeolocation?: PointGeoJson
-  activeAutoZoom?: boolean
-  autoZoomThreshold?: number
-}) {
+  disabled = false,
+}: FocusTrackerProps) {
   const map = useGoogleMap()
 
   useEffect(() => {
-    if (!focusGeolocation || !map) {
+    if (!focusGeolocation || !map || disabled) {
       return
     }
 
@@ -28,7 +32,7 @@ export function FocusTracker({
     }
 
     map.panTo({ lat, lng })
-  }, [activeAutoZoom, focusGeolocation, map, autoZoomThreshold])
+  }, [activeAutoZoom, focusGeolocation, map, autoZoomThreshold, disabled])
 
   return null
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->

## PR 설명
[tds-widget] focus tracker에 disabled props를 추가합니다.
간혹 mapView와 focusTracker를 동시에 사용할 때, mapView의 map.fitBounds와 focusTracker의 map.panTo가 충돌하는 경우가 있어 disabled props를 통해 외부에서 조절할 수 있도록 수정했습니다.
